### PR TITLE
Use Infinite constants where appropriate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ src/.vs/
 
 # Expanded/resolved project.json files
 project.lock.json
+
+# Build outputs
+build/target/

--- a/build/build.cmd
+++ b/build/build.cmd
@@ -6,13 +6,13 @@ set MSBUILD_HOME=%WINDIR%\Microsoft.NET\Framework\v4.0.30319
 rem MSBuild project file is located in the same directory as the current script
 set MSBUILD_PROJECT=%~dp0\build.proj
 
-set MSBUILD_EXE=%MSBUILD_HOME%\msbuild.exe
+set MSBUILD_EXE="%MSBUILD_HOME%\msbuild.exe"
 
 rem verify whether the version of MSBuild that we need is installed
 if not exist %MSBUILD_EXE% goto msbuild_missing
 
 rem launch the build script
-call %MSBUILD_HOME%\msbuild.exe %MSBUILD_PROJECT% /verbosity:minimal /nologo
+call %MSBUILD_EXE% %MSBUILD_PROJECT% /verbosity:minimal /nologo
 if errorlevel 1 goto msbuild_failure
 goto :EOF
 

--- a/build/build.proj
+++ b/build/build.proj
@@ -39,7 +39,7 @@
 	
 	<Target Name="Build">
 		<ItemGroup>
-			<ProjectToBuild Include="$(MSBuildThisFileDirectory)..\Renci.SshNet.VS2012.sln">
+			<ProjectToBuild Include="$(MSBuildThisFileDirectory)..\src\Renci.SshNet.VS2012.sln">
 				<Properties>Configuration=Release</Properties>
 			</ProjectToBuild>
 		</ItemGroup>

--- a/build/build.proj
+++ b/build/build.proj
@@ -52,8 +52,8 @@
 	<Target Name="CopyBuildOutputToPackage" DependsOnTargets="Build" Outputs="%(TargetFramework.Identity)">
 		<ItemGroup>
 			<BuildOutput Remove="@(BuildOutput)"/>
-			<BuildOutput Include="$(MSBuildThisFileDirectory)..\%(TargetFramework.Project)\bin\$(Configuration)\Renci.SshNet.dll"/>
-			<BuildOutput Include="$(MSBuildThisFileDirectory)..\%(TargetFramework.Project)\bin\$(Configuration)\Renci.SshNet.xml"/>
+			<BuildOutput Include="$(MSBuildThisFileDirectory)..\src\%(TargetFramework.Project)\bin\$(Configuration)\Renci.SshNet.dll"/>
+			<BuildOutput Include="$(MSBuildThisFileDirectory)..\src\%(TargetFramework.Project)\bin\$(Configuration)\Renci.SshNet.xml"/>
 		</ItemGroup>
 		<Copy SourceFiles="@(BuildOutput)" DestinationFolder="$(MSBuildThisFileDirectory)target\package\lib\%(TargetFramework.Moniker)"/>
 	</Target>
@@ -63,8 +63,8 @@
 	
 	<Target Name="GenerateSourceZip">
 		<ItemGroup>
-			<SourceFiles Include="$(MSBuildThisFileDirectory)..\Renci.SshNet\**" Exclude="$(MSBuildThisFileDirectory)..\Renci.SshNet\bin\**;$(MSBuildThisFileDirectory)..\Renci.SshNet\obj\**"/>
-			<SourceFiles Include="$(MSBuildThisFileDirectory)..\Renci.SshNet.snk"/>
+			<SourceFiles Include="$(MSBuildThisFileDirectory)..\src\Renci.SshNet\**" Exclude="$(MSBuildThisFileDirectory)..\src\Renci.SshNet\bin\**;$(MSBuildThisFileDirectory)..\src\Renci.SshNet\obj\**"/>
+			<SourceFiles Include="$(MSBuildThisFileDirectory)..\src\Renci.SshNet.snk"/>
 		</ItemGroup>
 		<Zip
 			Files="@(SourceFiles)"

--- a/build/sandcastle/SSH.NET.shfbproj
+++ b/build/sandcastle/SSH.NET.shfbproj
@@ -32,7 +32,7 @@
     <ComponentConfigurations>
       <ComponentConfig id="Code Block Component" enabled="True" xmlns="">
         <component id="Code Block Component">
-          <basePath value="{@HtmlEncProjectFolder}..\..\Renci.SshNet\bin" />
+          <basePath value="{@HtmlEncProjectFolder}..\..\src\Renci.SshNet\bin" />
           <outputPaths>{@HelpFormatOutputPaths}</outputPaths>
           <allowMissingSource value="false" />
           <removeRegionMarkers value="false" />
@@ -41,8 +41,8 @@
       </ComponentConfig>
     </ComponentConfigurations>
     <DocumentationSources>
-      <DocumentationSource sourceFile="..\..\Renci.SshNet\bin\Release\Renci.SshNet.dll" xmlns="" />
-      <DocumentationSource sourceFile="..\..\Renci.SshNet\bin\Release\Renci.SshNet.xml" xmlns="" />
+      <DocumentationSource sourceFile="..\..\src\Renci.SshNet\bin\Release\Renci.SshNet.dll" xmlns="" />
+      <DocumentationSource sourceFile="..\..\src\Renci.SshNet\bin\Release\Renci.SshNet.xml" xmlns="" />
     </DocumentationSources>
     <MissingTags>Summary, Parameter, Returns, AutoDocumentCtors, TypeParameter, AutoDocumentDispose</MissingTags>
     <BuildAssemblerVerbosity>OnlyWarningsAndErrors</BuildAssemblerVerbosity>

--- a/src/Renci.SshNet.Tests/Classes/Channels/ChannelDirectTcpipTest.cs
+++ b/src/Renci.SshNet.Tests/Classes/Channels/ChannelDirectTcpipTest.cs
@@ -57,7 +57,7 @@ namespace Renci.SshNet.Tests.Classes.Channels
                     new MessageEventArgs<ChannelOpenConfirmationMessage>(
                         new ChannelOpenConfirmationMessage(((ChannelOpenMessage)m).LocalChannelNumber, _remoteWindowSize, _remotePacketSize, _remoteChannelNumber))));
             _sessionMock.Setup(p => p.WaitOnHandle(It.IsAny<EventWaitHandle>()))
-                .Callback<WaitHandle>(p => p.WaitOne(-1));
+                .Callback<WaitHandle>(p => p.WaitOne(Session.Infinite));
 
             var localPortEndPoint = new IPEndPoint(IPAddress.Loopback, 8122);
             using (var localPortListener = new AsyncSocketListener(localPortEndPoint))
@@ -107,7 +107,7 @@ namespace Renci.SshNet.Tests.Classes.Channels
                     new MessageEventArgs<ChannelOpenConfirmationMessage>(
                         new ChannelOpenConfirmationMessage(((ChannelOpenMessage)m).LocalChannelNumber, _remoteWindowSize, _remotePacketSize, _remoteChannelNumber))));
             _sessionMock.Setup(p => p.WaitOnHandle(It.IsAny<EventWaitHandle>()))
-                .Callback<WaitHandle>(p => p.WaitOne(-1));
+                .Callback<WaitHandle>(p => p.WaitOne(Session.Infinite));
 
             var localPortEndPoint = new IPEndPoint(IPAddress.Loopback, 8122);
             using (var localPortListener = new AsyncSocketListener(localPortEndPoint))
@@ -159,7 +159,7 @@ namespace Renci.SshNet.Tests.Classes.Channels
                         new ChannelOpenConfirmationMessage(((ChannelOpenMessage) m).LocalChannelNumber,
                             _remoteWindowSize, _remotePacketSize, _remoteChannelNumber))));
             _sessionMock.Setup(p => p.WaitOnHandle(It.IsAny<EventWaitHandle>()))
-                .Callback<WaitHandle>(p => p.WaitOne(-1));
+                .Callback<WaitHandle>(p => p.WaitOne(Session.Infinite));
             _sessionMock.Setup(p => p.ConnectionInfo).Returns(_connectionInfoMock.Object);
             _connectionInfoMock.Setup(p => p.Timeout).Returns(TimeSpan.FromSeconds(60));
             _sessionMock.Setup(p => p.TrySendMessage(It.IsAny<ChannelEofMessage>()))

--- a/src/Renci.SshNet/NetConfClient.cs
+++ b/src/Renci.SshNet/NetConfClient.cs
@@ -21,8 +21,8 @@ namespace Renci.SshNet
         /// Gets or sets the operation timeout.
         /// </summary>
         /// <value>
-        /// The timeout to wait until an operation completes. The default value is <see cref="SshNet.Session.InfiniteTimeSpan"/>
-        /// , which indicates an infinite time-out period.
+        /// The timeout to wait until an operation completes. The default value is negative
+        /// one (-1) milliseconds, which indicates an infinite time-out period.
         /// </value>
         public TimeSpan OperationTimeout { get; set; }
 

--- a/src/Renci.SshNet/NetConfClient.cs
+++ b/src/Renci.SshNet/NetConfClient.cs
@@ -21,8 +21,8 @@ namespace Renci.SshNet
         /// Gets or sets the operation timeout.
         /// </summary>
         /// <value>
-        /// The timeout to wait until an operation completes. The default value is negative
-        /// one (-1) milliseconds, which indicates an infinite time-out period.
+        /// The timeout to wait until an operation completes. The default value is <see cref="SshNet.Session.InfiniteTimeSpan"/>
+        /// , which indicates an infinite time-out period.
         /// </value>
         public TimeSpan OperationTimeout { get; set; }
 

--- a/src/Renci.SshNet/NetConfClient.cs
+++ b/src/Renci.SshNet/NetConfClient.cs
@@ -126,7 +126,7 @@ namespace Renci.SshNet
         internal NetConfClient(ConnectionInfo connectionInfo, bool ownsConnectionInfo, IServiceFactory serviceFactory)
             : base(connectionInfo, ownsConnectionInfo, serviceFactory)
         {
-            OperationTimeout = new TimeSpan(0, 0, 0, 0, -1);
+            OperationTimeout = SshNet.Session.InfiniteTimeSpan;
             AutomaticMessageIdHandling = true;
         }
 

--- a/src/Renci.SshNet/ScpClient.cs
+++ b/src/Renci.SshNet/ScpClient.cs
@@ -144,7 +144,7 @@ namespace Renci.SshNet
         internal ScpClient(ConnectionInfo connectionInfo, bool ownsConnectionInfo, IServiceFactory serviceFactory)
             : base(connectionInfo, ownsConnectionInfo, serviceFactory)
         {
-            OperationTimeout = new TimeSpan(0, 0, 0, 0, -1);
+            OperationTimeout = SshNet.Session.InfiniteTimeSpan;
             BufferSize = 1024 * 16;
 
             if (_byteToChar == null)

--- a/src/Renci.SshNet/ScpClient.cs
+++ b/src/Renci.SshNet/ScpClient.cs
@@ -21,8 +21,8 @@ namespace Renci.SshNet
         /// Gets or sets the operation timeout.
         /// </summary>
         /// <value>
-        /// The timeout to wait until an operation completes. The default value is <see cref="SshNet.Session.InfiniteTimeSpan"/>
-        /// , which indicates an infinite time-out period.
+        /// The timeout to wait until an operation completes. The default value is negative
+        /// one (-1) milliseconds, which indicates an infinite time-out period.
         /// </value>
         public TimeSpan OperationTimeout { get; set; }
 

--- a/src/Renci.SshNet/ScpClient.cs
+++ b/src/Renci.SshNet/ScpClient.cs
@@ -21,8 +21,8 @@ namespace Renci.SshNet
         /// Gets or sets the operation timeout.
         /// </summary>
         /// <value>
-        /// The timeout to wait until an operation completes. The default value is negative
-        /// one (-1) milliseconds, which indicates an infinite time-out period.
+        /// The timeout to wait until an operation completes. The default value is <see cref="SshNet.Session.InfiniteTimeSpan"/>
+        /// , which indicates an infinite time-out period.
         /// </value>
         public TimeSpan OperationTimeout { get; set; }
 

--- a/src/Renci.SshNet/SftpClient.cs
+++ b/src/Renci.SshNet/SftpClient.cs
@@ -229,7 +229,7 @@ namespace Renci.SshNet
         internal SftpClient(ConnectionInfo connectionInfo, bool ownsConnectionInfo, IServiceFactory serviceFactory)
             : base(connectionInfo, ownsConnectionInfo, serviceFactory)
         {
-            OperationTimeout = new TimeSpan(0, 0, 0, 0, -1);
+            OperationTimeout = SshNet.Session.InfiniteTimeSpan;
             BufferSize = 1024 * 32;
         }
 

--- a/src/Renci.SshNet/SftpClient.cs
+++ b/src/Renci.SshNet/SftpClient.cs
@@ -37,8 +37,8 @@ namespace Renci.SshNet
         /// Gets or sets the operation timeout.
         /// </summary>
         /// <value>
-        /// The timeout to wait until an operation completes. The default value is negative
-        /// one (-1) milliseconds, which indicates an infinite timeout period.
+        /// The timeout to wait until an operation completes. The default value is <see cref="SshNet.Session.InfiniteTimeSpan"/>
+        /// , which indicates an infinite time-out period.
         /// </value>
         /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
         public TimeSpan OperationTimeout

--- a/src/Renci.SshNet/SftpClient.cs
+++ b/src/Renci.SshNet/SftpClient.cs
@@ -37,8 +37,8 @@ namespace Renci.SshNet
         /// Gets or sets the operation timeout.
         /// </summary>
         /// <value>
-        /// The timeout to wait until an operation completes. The default value is <see cref="SshNet.Session.InfiniteTimeSpan"/>
-        /// , which indicates an infinite time-out period.
+        /// The timeout to wait until an operation completes. The default value is negative
+        /// one (-1) milliseconds, which indicates an infinite timeout period.
         /// </value>
         /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
         public TimeSpan OperationTimeout

--- a/src/Renci.SshNet/ShellStream.cs
+++ b/src/Renci.SshNet/ShellStream.cs
@@ -464,7 +464,7 @@ namespace Renci.SshNet
         /// </returns>
         public string Expect(string text)
         {
-            return Expect(new Regex(Regex.Escape(text)), TimeSpan.FromMilliseconds(-1));
+            return Expect(new Regex(Regex.Escape(text)), Session.InfiniteTimeSpan);
         }
 
         /// <summary>

--- a/src/Renci.SshNet/SshCommand.cs
+++ b/src/Renci.SshNet/SshCommand.cs
@@ -143,7 +143,7 @@ namespace Renci.SshNet
             _session = session;
             CommandText = commandText;
             _encoding = encoding;
-            CommandTimeout = SshNet.Session.InfiniteTimeSpan;
+            CommandTimeout = Session.InfiniteTimeSpan;
             _sessionErrorOccuredWaitHandle = new AutoResetEvent(false);
 
             _session.Disconnected += Session_Disconnected;

--- a/src/Renci.SshNet/SshCommand.cs
+++ b/src/Renci.SshNet/SshCommand.cs
@@ -143,7 +143,7 @@ namespace Renci.SshNet
             _session = session;
             CommandText = commandText;
             _encoding = encoding;
-            CommandTimeout = new TimeSpan(0, 0, 0, 0, -1);
+            CommandTimeout = SshNet.Session.InfiniteTimeSpan;
             _sessionErrorOccuredWaitHandle = new AutoResetEvent(false);
 
             _session.Disconnected += Session_Disconnected;


### PR DESCRIPTION
All the places in the code where an infinite call was being made has been changed to use the two constants:
- Session.Infinite; and
- SshNet.Session.InfiniteTimeSpan.

The change also includes changes to the .gitignore file to ignore the build/target outputs
The build.cmd; build.proj; and build/sandcastle/SSH.NET.shfbproj
files has been fixed.
