### PR TITLE
Include a way to filter the ipaddresses resolved for the host with a custom func

### DIFF
--- a/src/Renci.SshNet.NET35/Renci.SshNet.NET35.csproj
+++ b/src/Renci.SshNet.NET35/Renci.SshNet.NET35.csproj
@@ -264,6 +264,12 @@
     <Compile Include="..\Renci.SshNet\Common\TerminalModes.cs">
       <Link>Common\TerminalModes.cs</Link>
     </Compile>
+    <Compile Include="..\Renci.SshNet\Common\AddressTypeFilterClass.cs">
+      <Link>Common\AddressTypeFilterClass.cs</Link>
+    </Compile>
+    <Compile Include="..\Renci.SshNet\Common\AddressTypesFilterClass.cs">
+      <Link>Common\AddressTypesFilterClass.cs</Link>
+    </Compile>
     <Compile Include="..\Renci.SshNet\Compression\CompressionMode.cs">
       <Link>Compression\CompressionMode.cs</Link>
     </Compile>

--- a/src/Renci.SshNet.Silverlight/Renci.SshNet.Silverlight.csproj
+++ b/src/Renci.SshNet.Silverlight/Renci.SshNet.Silverlight.csproj
@@ -250,6 +250,12 @@
     <Compile Include="..\Renci.SshNet\Common\TerminalModes.cs">
       <Link>Common\TerminalModes.cs</Link>
     </Compile>
+    <Compile Include="..\Renci.SshNet\Common\AddressTypeFilterClass.cs">
+      <Link>Common\AddressTypeFilterClass.cs</Link>
+    </Compile>
+    <Compile Include="..\Renci.SshNet\Common\AddressTypesFilterClass.cs">
+      <Link>Common\AddressTypesFilterClass.cs</Link>
+    </Compile>
     <Compile Include="..\Renci.SshNet\Compression\CompressionMode.cs">
       <Link>Compression\CompressionMode.cs</Link>
     </Compile>

--- a/src/Renci.SshNet.Silverlight5/Renci.SshNet.Silverlight5.csproj
+++ b/src/Renci.SshNet.Silverlight5/Renci.SshNet.Silverlight5.csproj
@@ -265,6 +265,12 @@
     <Compile Include="..\Renci.SshNet\Common\TerminalModes.cs">
       <Link>Common\TerminalModes.cs</Link>
     </Compile>
+    <Compile Include="..\Renci.SshNet\Common\AddressTypeFilterClass.cs">
+      <Link>Common\AddressTypeFilterClass.cs</Link>
+    </Compile>
+    <Compile Include="..\Renci.SshNet\Common\AddressTypesFilterClass.cs">
+      <Link>Common\AddressTypesFilterClass.cs</Link>
+    </Compile>
     <Compile Include="..\Renci.SshNet\Compression\CompressionMode.cs">
       <Link>Compression\CompressionMode.cs</Link>
     </Compile>

--- a/src/Renci.SshNet.UAP10/Renci.SshNet.UAP10.csproj
+++ b/src/Renci.SshNet.UAP10/Renci.SshNet.UAP10.csproj
@@ -297,6 +297,12 @@
     <Compile Include="..\Renci.SshNet\Common\TerminalModes.cs">
       <Link>Common\TerminalModes.cs</Link>
     </Compile>
+    <Compile Include="..\Renci.SshNet\Common\AddressTypeFilterClass.cs">
+      <Link>Common\AddressTypeFilterClass.cs</Link>
+    </Compile>
+    <Compile Include="..\Renci.SshNet\Common\AddressTypesFilterClass.cs">
+      <Link>Common\AddressTypesFilterClass.cs</Link>
+    </Compile>
     <Compile Include="..\Renci.SshNet\Compression\CompressionMode.cs">
       <Link>Compression\CompressionMode.cs</Link>
     </Compile>

--- a/src/Renci.SshNet.WindowsPhone/Renci.SshNet.WindowsPhone.csproj
+++ b/src/Renci.SshNet.WindowsPhone/Renci.SshNet.WindowsPhone.csproj
@@ -239,6 +239,12 @@
     <Compile Include="..\Renci.SshNet\Common\TerminalModes.cs">
       <Link>Common\TerminalModes.cs</Link>
     </Compile>
+    <Compile Include="..\Renci.SshNet\Common\AddressTypeFilterClass.cs">
+      <Link>Common\AddressTypeFilterClass.cs</Link>
+    </Compile>
+    <Compile Include="..\Renci.SshNet\Common\AddressTypesFilterClass.cs">
+      <Link>Common\AddressTypesFilterClass.cs</Link>
+    </Compile>
     <Compile Include="..\Renci.SshNet\Compression\CompressionMode.cs">
       <Link>Compression\CompressionMode.cs</Link>
     </Compile>

--- a/src/Renci.SshNet.WindowsPhone8/Renci.SshNet.WindowsPhone8.csproj
+++ b/src/Renci.SshNet.WindowsPhone8/Renci.SshNet.WindowsPhone8.csproj
@@ -283,6 +283,12 @@
     <Compile Include="..\Renci.SshNet\Common\TerminalModes.cs">
       <Link>Common\TerminalModes.cs</Link>
     </Compile>
+    <Compile Include="..\Renci.SshNet\Common\AddressTypeFilterClass.cs">
+      <Link>Common\AddressTypeFilterClass.cs</Link>
+    </Compile>
+    <Compile Include="..\Renci.SshNet\Common\AddressTypesFilterClass.cs">
+      <Link>Common\AddressTypesFilterClass.cs</Link>
+    </Compile>
     <Compile Include="..\Renci.SshNet\Compression\CompressionMode.cs">
       <Link>Compression\CompressionMode.cs</Link>
     </Compile>

--- a/src/Renci.SshNet/Common/AddressTypeFilterClass.cs
+++ b/src/Renci.SshNet/Common/AddressTypeFilterClass.cs
@@ -1,0 +1,75 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace Renci.SshNet.Common
+{
+    /// <summary>
+    /// Defines methods which will filter <see cref="IPAddress" />'s to prefer or require a specific <see cref="System.Net.Sockets.AddressFamily" /> by <see cref="IPAddress.AddressFamily" />
+    /// </summary>
+    public sealed class AddressTypeFilterClass
+    {
+        /// <summary>
+        /// The address family to prefer or require
+        /// </summary>
+        public readonly AddressFamily AddressFamily;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AddressTypeFilterClass"/> class which requires or prefers addresses of type <paramref name="addressFamily"/>
+        /// </summary>
+        /// <param name="addressFamily">The address family to require or prefer.</param>
+        public AddressTypeFilterClass(System.Net.Sockets.AddressFamily addressFamily)
+        {
+            AddressFamily = addressFamily;
+        }
+
+        /// <summary>
+        /// Returns a single address which will be of type <see cref="AddressFamily"/> or the first <paramref name="addresses"/>
+        /// </summary>
+        /// <param name="addresses">The addresses.</param>
+        /// <returns>A single address which will be of type <see cref="AddressFamily"/> or the first <paramref name="addresses"/></returns>
+        public IPAddress PreferAddressOfType(IPAddress[] addresses)
+        {
+            var preferAddressOfType = GetFirstAddressOfType(addresses);
+            if (preferAddressOfType != null)
+            {
+                return preferAddressOfType;
+            }
+            return addresses[0];
+        }
+
+        /// <summary>
+        /// Returns a single address which will be of type <see cref="AddressFamily"/>
+        /// </summary>
+        /// <param name="addresses">The addresses.</param>
+        /// <returns>A single address which will be of type <see cref="AddressFamily"/></returns>
+        /// <exception cref="SocketException">If an address of the required type is not found</exception>
+        public IPAddress RequireAddressOfType(IPAddress[] addresses)
+        {
+            var preferAddressOfType = GetFirstAddressOfType(addresses);
+            if (preferAddressOfType != null)
+            {
+                return preferAddressOfType;
+            }
+
+            // The type of the address was not found so throw an exception
+            throw new SocketException((int)SocketError.TypeNotFound);
+        }
+
+        /// <summary>
+        /// Returns a single address which will be of type <see cref="AddressFamily"/> or null if none are found
+        /// </summary>
+        /// <param name="addresses">The addresses.</param>
+        /// <returns>A single address which will be of type <see cref="AddressFamily"/> or null if none are found</returns>
+        private IPAddress GetFirstAddressOfType(IPAddress[] addresses)
+        {
+            foreach (var address in addresses)
+            {
+                if (address.AddressFamily == AddressFamily)
+                {
+                    return address;
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/src/Renci.SshNet/Common/AddressTypesFilterClass.cs
+++ b/src/Renci.SshNet/Common/AddressTypesFilterClass.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Renci.SshNet.Common
+{
+    /// <summary>
+    /// Defines methods which will filter <see cref="IPAddress"/>'s to prefer or require specific <see cref="AddressFamily"/>'s by <see cref="IPAddress.AddressFamily"/>
+    /// </summary>
+    public sealed class AddressTypesFilterClass
+    {
+        /// <summary>
+        /// The address families to prefer or require
+        /// </summary>
+        public readonly AddressFamily[] AddressFamilies;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AddressTypesFilterClass"/> class which requires or prefers addresses of types <paramref name="addressFamilies"/>
+        /// </summary>
+        /// <param name="addressFamilies">The address families to require or prefer.</param>
+        /// <exception cref="ArgumentException">If no <paramref name="addressFamilies"/> are passed in</exception>
+        public AddressTypesFilterClass(params AddressFamily[] addressFamilies)
+        {
+            if (addressFamilies == null || addressFamilies.Length == 0)
+            {
+                throw new ArgumentException("At least one System.Net.Sockets.AddressFamily must be specified");
+            }
+            AddressFamilies = addressFamilies;
+        }
+
+        /// <summary>
+        /// Returns a single address which will be one of the types specified in <see cref="AddressFamilies"/> or the first <paramref name="addresses"/>
+        /// </summary>
+        /// <param name="addresses">The addresses.</param>
+        /// <returns>A single address which will be one of the types specified in <see cref="AddressFamilies"/> or the first <paramref name="addresses"/></returns>
+        public IPAddress PreferAddressOfTypes(IPAddress[] addresses)
+        {
+            var address = GetFirstAddressOfAnyType(addresses);
+            if (address != null)
+            {
+                return address;
+            }
+
+            return addresses[0];
+        }
+
+        /// <summary>
+        /// Returns a single address which will be one of the types specified in <see cref="AddressFamilies"/>
+        /// </summary>
+        /// <param name="addresses">The addresses.</param>
+        /// <returns>A single address which will be one of the types specified in <see cref="AddressFamilies"/></returns>
+        /// <exception cref="SocketException">If an address of the required type is not found</exception>
+        public IPAddress RequireAddressOfTypes(IPAddress[] addresses)
+        {
+            var address = GetFirstAddressOfAnyType(addresses);
+            if (address != null)
+            {
+                return address;
+            }
+
+            // The type of the addresses was not found so throw an exception
+            throw new SocketException((int)SocketError.TypeNotFound);
+        }
+
+        /// <summary>
+        /// Returns a single address which will be one of the types specified in <see cref="AddressFamilies"/> or the first <paramref name="addresses"/>
+        /// , the preference of <see cref="IPAddress.AddressFamily"/> will be tried in the same order as the <see cref="AddressFamilies"/>
+        /// </summary>
+        /// <param name="addresses">The addresses.</param>
+        /// <returns>A single address which will be one of the types specified in <see cref="AddressFamilies"/> or the first <paramref name="addresses"/>
+        /// , the preference of <see cref="IPAddress.AddressFamily"/> will be tried in the same order as the <see cref="AddressFamilies"/></returns>
+        public IPAddress PreferAddressOfTypesOrdered(IPAddress[] addresses)
+        {
+            var address = GetFirstAddressOfAnyTypeOrdered(addresses);
+            if (address != null)
+            {
+                return address;
+            }
+
+            return addresses[0];
+        }
+
+        /// <summary>
+        /// Returns a single address which will be one of the types specified in <see cref="AddressFamilies"/>
+        /// , the preference of <see cref="IPAddress.AddressFamily"/> will be tried in the same order as the <see cref="AddressFamilies"/>
+        /// </summary>
+        /// <param name="addresses">The addresses.</param>
+        /// <returns>A single address which will be one of the types specified in <see cref="AddressFamilies"/>
+        /// , the preference of <see cref="IPAddress.AddressFamily"/> will be tried in the same order as the <see cref="AddressFamilies"/></returns>
+        /// <exception cref="SocketException">If an address of the required type is not found</exception>
+        public IPAddress RequireAddressOfTypesOrdered(IPAddress[] addresses)
+        {
+            var address = GetFirstAddressOfAnyType(addresses);
+            if (address != null)
+            {
+                return address;
+            }
+
+            // The type of the addresses was not found so throw an exception
+            throw new SocketException((int)SocketError.TypeNotFound);
+        }
+
+        /// <summary>
+        /// Returns a single address which will be of any type in <see cref="AddressFamilies"/> or null if none are found
+        /// </summary>
+        /// <param name="addresses">The addresses.</param>
+        /// <returns>A single address which will be of any type in <see cref="AddressFamilies"/> or null if none are found</returns>
+        private IPAddress GetFirstAddressOfAnyType(IPAddress[] addresses)
+        {
+            foreach (var address in addresses)
+            {
+                if (AddressFamilies.Contains(address.AddressFamily))
+                {
+                    return address;
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Returns a single address which will be of any type in <see cref="AddressFamilies"/> or null if none are found
+        /// , the preference of <see cref="IPAddress.AddressFamily"/> will be tried in the same order as the <see cref="AddressFamilies"/>
+        /// </summary>
+        /// <param name="addresses">The addresses.</param>
+        /// <returns>A single address which will be of any type in <see cref="AddressFamilies"/> or null if none are found
+        /// , the preference of <see cref="IPAddress.AddressFamily"/> will be tried in the same order as the <see cref="AddressFamilies"/></returns>
+        private IPAddress GetFirstAddressOfAnyTypeOrdered(IPAddress[] addresses)
+        {
+            foreach (var addressFamily in AddressFamilies)
+            {
+                foreach (var address in addresses)
+                {
+                    if (address.AddressFamily == addressFamily)
+                    {
+                        return address;
+                    }
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/src/Renci.SshNet/ConnectionInfo.cs
+++ b/src/Renci.SshNet/ConnectionInfo.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
+using System.Net.Sockets;
 using System.Text;
 using Renci.SshNet.Security;
 using Renci.SshNet.Messages.Connection;
@@ -209,6 +211,22 @@ namespace Renci.SshNet
         /// Gets the current client compression algorithm.
         /// </summary>
         public string CurrentClientCompressionAlgorithm { get; internal set; }
+
+        /// <summary>
+        /// Sets a value for the <see cref="FilterHostAddressesFunc"/> so that the addresses of <paramref name="addressFamily"/>are preferred.<para />
+        /// Using this method is shorthand for:<para />
+        /// <see cref="FilterHostAddressesFunc"/> = new <see cref="AddressTypeFilterClass"/>(<paramref name="addressFamily"/>).PreferAddressOfType<para />
+        /// </summary>
+        /// <param name="addressFamily">The address family which should be prefered</param>
+        public void SetPreferAddressFamily(AddressFamily addressFamily)
+        {
+            FilterHostAddressesFunc = new AddressTypeFilterClass(addressFamily).PreferAddressOfType;
+        }
+
+        /// <value>
+        /// A function which can be used to filter the return addresses from resolving the <see cref="Host"/>.
+        /// </value>
+        public Func<IPAddress[], IPAddress> FilterHostAddressesFunc { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConnectionInfo"/> class.

--- a/src/Renci.SshNet/Renci.SshNet.csproj
+++ b/src/Renci.SshNet/Renci.SshNet.csproj
@@ -144,6 +144,8 @@
     <Compile Include="Common\TerminalModes.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Common\AddressTypeFilterClass.cs" />
+    <Compile Include="Common\AddressTypesFilterClass.cs" />
     <Compile Include="Compression\CompressionMode.cs" />
     <Compile Include="Compression\Compressor.cs" />
     <Compile Include="Compression\Zlib.cs" />

--- a/src/Renci.SshNet/Session.cs
+++ b/src/Renci.SshNet/Session.cs
@@ -528,18 +528,18 @@ namespace Renci.SshNet
                     switch (ConnectionInfo.ProxyType)
                     {
                         case ProxyTypes.None:
-                            SocketConnect(ConnectionInfo.Host, ConnectionInfo.Port);
+                            SocketConnect(ConnectionInfo.Host, ConnectionInfo.Port, ConnectionInfo.FilterHostAddressesFunc);
                             break;
                         case ProxyTypes.Socks4:
-                            SocketConnect(ConnectionInfo.ProxyHost, ConnectionInfo.ProxyPort);
+                            SocketConnect(ConnectionInfo.ProxyHost, ConnectionInfo.ProxyPort, ConnectionInfo.FilterHostAddressesFunc);
                             ConnectSocks4();
                             break;
                         case ProxyTypes.Socks5:
-                            SocketConnect(ConnectionInfo.ProxyHost, ConnectionInfo.ProxyPort);
+                            SocketConnect(ConnectionInfo.ProxyHost, ConnectionInfo.ProxyPort, ConnectionInfo.FilterHostAddressesFunc);
                             ConnectSocks5();
                             break;
                         case ProxyTypes.Http:
-                            SocketConnect(ConnectionInfo.ProxyHost, ConnectionInfo.ProxyPort);
+                            SocketConnect(ConnectionInfo.ProxyHost, ConnectionInfo.ProxyPort, ConnectionInfo.FilterHostAddressesFunc);
                             ConnectHttp();
                             break;
                     }
@@ -1661,11 +1661,13 @@ namespace Renci.SshNet
         /// </summary>
         /// <param name="host">The host name of the server to connect to.</param>
         /// <param name="port">The port to connect to.</param>
+        /// <param name="addressFilter">If not <const>null</const>filters the addresses from the GetHostAddresses call, otherwise the first address is used.</param>
         /// <exception cref="SshOperationTimeoutException">The connection failed to establish within the configured <see cref="Renci.SshNet.ConnectionInfo.Timeout"/>.</exception>
         /// <exception cref="SocketException">An error occurred trying to establish the connection.</exception>
-        private void SocketConnect(string host, int port)
+        private void SocketConnect(string host, int port, Func<IPAddress[], IPAddress> addressFilter)
         {
-            var ipAddress = DnsAbstraction.GetHostAddresses(host)[0];
+            var ipAddresses = DnsAbstraction.GetHostAddresses(host);
+            var ipAddress = addressFilter != null ? addressFilter(ipAddresses) : ipAddresses[0];
             var ep = new IPEndPoint(ipAddress, port);
 
             DiagnosticAbstraction.Log(string.Format("Initiating connect to '{0}:{1}'.", host, port));


### PR DESCRIPTION
This relates the the #28 issue.

This includes a way to filter the addresses returned from DnsAbstraction.GetHostAddresses(host) to the actual address that you want.

It also provides some default classes to provide the filter functions.

**NOTE:** Until you have merged in #27 I wouldn't check this branch out.
This is because I used the github instructions (instead of the new git instructions) on how to reset end of lines for existing files, and so the files are still getting changed by the .gitattribute settings.

I just wanted your feedback on this for now, if you want changes done I'll do them, but then wait until #27 has been merged before I push up again, so that it's an easier merge.
