### PR TITLE
Use LastWriteTimeUtc when files have the exact same length

### DIFF
--- a/src/Renci.SshNet/SftpClient.cs
+++ b/src/Renci.SshNet/SftpClient.cs
@@ -1681,10 +1681,11 @@ namespace Renci.SshNet
 
                 if (!isDifferent)
                 {
-                    var temp = destDict[localFile.Name];
+                    var dest = destDict[localFile.Name];
                     //  TODO:   Use md5 to detect a difference
-                    //ltang: File exists at the destination => Using filesize to detect the difference
-                    isDifferent = localFile.Length != temp.Length;
+                    // ltang: File exists at the destination => Using filesize to detect the difference
+                    // and the LastWriteTime (with a window of 60s to avoid clock differences between machines)
+                    isDifferent = (localFile.Length != dest.Length) || (dest.LastWriteTimeUtc.AddSeconds(-60.0)  <= localFile.LastWriteTimeUtc);
                 }
 
                 if (isDifferent)


### PR DESCRIPTION
This is to better see if files are different or not while waiting
for the MD5 implementation. This is not bullet proof but better than
what exists today.

This is to address issue #33 
