### PR TITLE
Add support for host resolution by the proxy itself

### DIFF
--- a/src/Renci.SshNet.NET35/Renci.SshNet.NET35.csproj
+++ b/src/Renci.SshNet.NET35/Renci.SshNet.NET35.csproj
@@ -289,7 +289,7 @@
       <Link>HashInfo.cs</Link>
     </Compile>
     <Compile Include="..\Renci.SshNet\HostResolutionMode.cs">
-      <Link>HashInfo.cs</Link>
+      <Link>HostResolutionMode.cs</Link>
     </Compile>
     <Compile Include="..\Renci.SshNet\IAuthenticationMethod.cs">
       <Link>IAuthenticationMethod.cs</Link>

--- a/src/Renci.SshNet.NET35/Renci.SshNet.NET35.csproj
+++ b/src/Renci.SshNet.NET35/Renci.SshNet.NET35.csproj
@@ -288,6 +288,9 @@
     <Compile Include="..\Renci.SshNet\HashInfo.cs">
       <Link>HashInfo.cs</Link>
     </Compile>
+    <Compile Include="..\Renci.SshNet\HostResolutionMode.cs">
+      <Link>HashInfo.cs</Link>
+    </Compile>
     <Compile Include="..\Renci.SshNet\IAuthenticationMethod.cs">
       <Link>IAuthenticationMethod.cs</Link>
     </Compile>

--- a/src/Renci.SshNet.Silverlight5/Renci.SshNet.Silverlight5.csproj
+++ b/src/Renci.SshNet.Silverlight5/Renci.SshNet.Silverlight5.csproj
@@ -312,6 +312,9 @@
     <Compile Include="..\Renci.SshNet\HashInfo.cs">
       <Link>HashInfo.cs</Link>
     </Compile>
+    <Compile Include="..\Renci.SshNet\HostResolutionMode.cs">
+      <Link>HostResolutionMode.cs</Link>
+    </Compile>
     <Compile Include="..\Renci.SshNet\IAuthenticationMethod.cs">
       <Link>IAuthenticationMethod.cs</Link>
     </Compile>

--- a/src/Renci.SshNet.Tests/Classes/ConnectionInfoTest.cs
+++ b/src/Renci.SshNet.Tests/Classes/ConnectionInfoTest.cs
@@ -343,5 +343,74 @@ namespace Renci.SshNet.Tests.Classes
                 Assert.AreEqual("serviceFactory", ex.ParamName);
             }
         }
-   }
+
+        [TestMethod]
+        [TestCategory("ConnectionInfo")]
+        public void ConstructorShouldThrowArgumentExceptionWhenUsingNoProxyAndNotResolvingHostLocally()
+        {
+            try
+            {
+                new ConnectionInfo(Resources.HOST, int.Parse(Resources.PORT), Resources.USERNAME,
+                    ProxyTypes.None, null, int.Parse(Resources.PORT), Resources.USERNAME, Resources.PASSWORD,
+                    HostResolutionMode.ResolvedByProxy,
+                    new KeyboardInteractiveAuthenticationMethod(Resources.USERNAME));
+                Assert.Fail();
+            }
+            catch (ArgumentException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual("hostResolutionMode", ex.ParamName);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionInfo")]
+        public void ConstructorShouldThrowArgumentExceptionWhenUsingHttproxyAndResolvingHostOnProxy()
+        {
+            try
+            {
+                new ConnectionInfo(Resources.HOST, int.Parse(Resources.PORT), Resources.USERNAME,
+                    ProxyTypes.Http, Resources.HOST, int.Parse(Resources.PORT), Resources.USERNAME, Resources.PASSWORD,
+                    HostResolutionMode.ResolvedByProxy,
+                    new KeyboardInteractiveAuthenticationMethod(Resources.USERNAME));
+                Assert.Fail();
+            }
+            catch (ArgumentException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual("hostResolutionMode", ex.ParamName);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionInfo")]
+        public void ConstructorShouldThrowArgumentExceptionWhenUsingSocks4ProxyAndResolvingHostOnProxy()
+        {
+            try
+            {
+                new ConnectionInfo(Resources.HOST, int.Parse(Resources.PORT), Resources.USERNAME,
+                    ProxyTypes.Socks4, Resources.HOST, int.Parse(Resources.PORT), Resources.USERNAME, Resources.PASSWORD,
+                    HostResolutionMode.ResolvedByProxy,
+                    new KeyboardInteractiveAuthenticationMethod(Resources.USERNAME));
+                Assert.Fail();
+            }
+            catch (ArgumentException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual("hostResolutionMode", ex.ParamName);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("ConnectionInfo")]
+        public void ConstructorShouldNotThrowArgumentExceptionWhenUsingSocks5ProxyAndResolvingHostOnProxy()
+        {
+                var connectionInfo = new ConnectionInfo(Resources.HOST, int.Parse(Resources.PORT), Resources.USERNAME,
+                    ProxyTypes.Socks5, Resources.HOST, int.Parse(Resources.PORT), Resources.USERNAME, Resources.PASSWORD,
+                    HostResolutionMode.ResolvedByProxy,
+                    new KeyboardInteractiveAuthenticationMethod(Resources.USERNAME));
+
+            Assert.AreEqual(HostResolutionMode.ResolvedByProxy, connectionInfo.HostResolutionMode);
+        }
+    }
 }

--- a/src/Renci.SshNet.UAP10/Renci.SshNet.UAP10.csproj
+++ b/src/Renci.SshNet.UAP10/Renci.SshNet.UAP10.csproj
@@ -351,6 +351,9 @@
     <Compile Include="..\Renci.SshNet\HashInfo.cs">
       <Link>HashInfo.cs</Link>
     </Compile>
+    <Compile Include="..\Renci.SshNet\HostResolutionMode.cs">
+      <Link>HostResolutionMode.cs</Link>
+    </Compile>
     <Compile Include="..\Renci.SshNet\IAuthenticationMethod.cs">
       <Link>IAuthenticationMethod.cs</Link>
     </Compile>

--- a/src/Renci.SshNet.WindowsPhone8/Renci.SshNet.WindowsPhone8.csproj
+++ b/src/Renci.SshNet.WindowsPhone8/Renci.SshNet.WindowsPhone8.csproj
@@ -337,6 +337,9 @@
     <Compile Include="..\Renci.SshNet\HashInfo.cs">
       <Link>HashInfo.cs</Link>
     </Compile>
+    <Compile Include="..\Renci.SshNet\HostResolutionMode.cs">
+      <Link>HostResolutionMode.cs</Link>
+    </Compile>
     <Compile Include="..\Renci.SshNet\IAuthenticationMethod.cs">
       <Link>IAuthenticationMethod.cs</Link>
     </Compile>

--- a/src/Renci.SshNet/ConnectionInfo.cs
+++ b/src/Renci.SshNet/ConnectionInfo.cs
@@ -116,6 +116,11 @@ namespace Renci.SshNet
         public string ProxyPassword { get; private set; }
 
         /// <summary>
+        /// Gets the host resolution mode.
+        /// </summary>
+        public HostResolutionMode? HostResolutionMode { get; private set; }
+
+        /// <summary>
         /// Gets or sets connection timeout.
         /// </summary>
         /// <value>
@@ -263,6 +268,32 @@ namespace Renci.SshNet
         /// <exception cref="ArgumentNullException"><paramref name="authenticationMethods"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">No <paramref name="authenticationMethods"/> specified.</exception>
         public ConnectionInfo(string host, int port, string username, ProxyTypes proxyType, string proxyHost, int proxyPort, string proxyUsername, string proxyPassword, params AuthenticationMethod[] authenticationMethods)
+            : this(host, port, username, proxyType, proxyHost, proxyPort, proxyUsername, proxyPassword, SshNet.HostResolutionMode.ResolvedLocally, authenticationMethods)
+        {
+        }
+
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConnectionInfo" /> class.
+        /// </summary>
+        /// <param name="host">Connection host.</param>
+        /// <param name="port">Connection port.</param>
+        /// <param name="username">Connection username.</param>
+        /// <param name="proxyType">Type of the proxy.</param>
+        /// <param name="proxyHost">The proxy host.</param>
+        /// <param name="proxyPort">The proxy port.</param>
+        /// <param name="proxyUsername">The proxy username.</param>
+        /// <param name="proxyPassword">The proxy password.</param>
+        /// <param name="hostResolutionMode">The host name resolution method when using the proxy.</param>
+        /// <param name="authenticationMethods">The authentication methods.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="host"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="username" /> is <c>null</c>, a zero-length string or contains only whitespace characters.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="port" /> is not within <see cref="F:System.Net.IPEndPoint.MinPort" /> and <see cref="F:System.Net.IPEndPoint.MaxPort" />.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="proxyType"/> is not <see cref="ProxyTypes.None"/> and <paramref name="proxyHost" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="proxyType"/> is not <see cref="ProxyTypes.None"/> and <paramref name="proxyPort" /> is not within <see cref="F:System.Net.IPEndPoint.MinPort" /> and <see cref="F:System.Net.IPEndPoint.MaxPort" />.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="authenticationMethods"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">No <paramref name="authenticationMethods"/> specified.</exception>
+        public ConnectionInfo(string host, int port, string username, ProxyTypes proxyType, string proxyHost, int proxyPort, string proxyUsername, string proxyPassword, HostResolutionMode hostResolutionMode, params AuthenticationMethod[] authenticationMethods)
         {
             if (host == null)
                 throw new ArgumentNullException("host");
@@ -278,6 +309,17 @@ namespace Renci.SshNet
                 if (proxyHost == null)
                     throw new ArgumentNullException("proxyHost");
                 proxyPort.ValidatePort("proxyPort");
+            }
+            else
+            {
+                if (hostResolutionMode != SshNet.HostResolutionMode.ResolvedLocally)
+                    throw new ArgumentException("HostResolutionMode.ResolvedLocally is the only supported value when using no proxy", "hostResolutionMode");
+            }
+
+            if (hostResolutionMode == SshNet.HostResolutionMode.ResolvedByProxy)
+            {
+                if (proxyType != ProxyTypes.Socks5)
+                    throw new ArgumentException("HostResolutionMode.ResolvedByProxy is only supported by SOCKS5 proxies", "hostResolutionMode");
             }
 
             if (authenticationMethods == null)
@@ -392,6 +434,8 @@ namespace Renci.SshNet
             ProxyPort = proxyPort;
             ProxyUsername = proxyUsername;
             ProxyPassword = proxyPassword;
+
+            HostResolutionMode = hostResolutionMode;
 
             AuthenticationMethods = authenticationMethods;
         }

--- a/src/Renci.SshNet/HostResolutionMode.cs
+++ b/src/Renci.SshNet/HostResolutionMode.cs
@@ -1,0 +1,14 @@
+﻿namespace Renci.SshNet
+{
+    /// <summary>
+    /// Specifies the way host names will be resolved when conecting through a proxy.
+    /// </summary>
+    public enum HostResolutionMode
+    {
+        /// <summary>The host name is resolved by the client and the host IP is sent to the proxy.</summary>
+        ResolvedLocally,
+
+        /// <summary>The host name is sent to the proxy and resolved later.</summary>
+        ResolvedByProxy
+    }
+}

--- a/src/Renci.SshNet/KeyboardInteractiveConnectionInfo.cs
+++ b/src/Renci.SshNet/KeyboardInteractiveConnectionInfo.cs
@@ -30,7 +30,6 @@ namespace Renci.SshNet
         public KeyboardInteractiveConnectionInfo(string host, string username)
             : this(host, DefaultPort, username, ProxyTypes.None, string.Empty, 0, string.Empty, string.Empty)
         {
-
         }
 
         /// <summary>
@@ -42,7 +41,6 @@ namespace Renci.SshNet
         public KeyboardInteractiveConnectionInfo(string host, int port, string username)
             : this(host, port, username, ProxyTypes.None, string.Empty, 0, string.Empty, string.Empty)
         {
-
         }
 
         /// <summary>
@@ -68,9 +66,40 @@ namespace Renci.SshNet
         /// <param name="proxyType">Type of the proxy.</param>
         /// <param name="proxyHost">The proxy host.</param>
         /// <param name="proxyPort">The proxy port.</param>
+        /// <param name="hostResolutionMode">The host name resolution method when using the proxy.</param>
+        public KeyboardInteractiveConnectionInfo(string host, int port, string username, ProxyTypes proxyType, string proxyHost, int proxyPort, HostResolutionMode hostResolutionMode)
+            : this(host, port, username, proxyType, proxyHost, proxyPort, string.Empty, string.Empty, hostResolutionMode)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeyboardInteractiveConnectionInfo"/> class.
+        /// </summary>
+        /// <param name="host">Connection host.</param>
+        /// <param name="port">Connection port.</param>
+        /// <param name="username">Connection username.</param>
+        /// <param name="proxyType">Type of the proxy.</param>
+        /// <param name="proxyHost">The proxy host.</param>
+        /// <param name="proxyPort">The proxy port.</param>
         /// <param name="proxyUsername">The proxy username.</param>
         public KeyboardInteractiveConnectionInfo(string host, int port, string username, ProxyTypes proxyType, string proxyHost, int proxyPort, string proxyUsername)
             : this(host, port, username, proxyType, proxyHost, proxyPort, proxyUsername, string.Empty)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeyboardInteractiveConnectionInfo"/> class.
+        /// </summary>
+        /// <param name="host">Connection host.</param>
+        /// <param name="port">Connection port.</param>
+        /// <param name="username">Connection username.</param>
+        /// <param name="proxyType">Type of the proxy.</param>
+        /// <param name="proxyHost">The proxy host.</param>
+        /// <param name="proxyPort">The proxy port.</param>
+        /// <param name="proxyUsername">The proxy username.</param>
+        /// <param name="hostResolutionMode">The host name resolution method when using the proxy.</param>
+        public KeyboardInteractiveConnectionInfo(string host, int port, string username, ProxyTypes proxyType, string proxyHost, int proxyPort, string proxyUsername, HostResolutionMode hostResolutionMode)
+            : this(host, port, username, proxyType, proxyHost, proxyPort, proxyUsername, string.Empty, hostResolutionMode)
         {
         }
 
@@ -84,6 +113,20 @@ namespace Renci.SshNet
         /// <param name="proxyPort">The proxy port.</param>
         public KeyboardInteractiveConnectionInfo(string host, string username, ProxyTypes proxyType, string proxyHost, int proxyPort)
             : this(host, DefaultPort, username, proxyType, proxyHost, proxyPort, string.Empty, string.Empty)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeyboardInteractiveConnectionInfo"/> class.
+        /// </summary>
+        /// <param name="host">Connection host.</param>
+        /// <param name="username">Connection username.</param>
+        /// <param name="proxyType">Type of the proxy.</param>
+        /// <param name="proxyHost">The proxy host.</param>
+        /// <param name="proxyPort">The proxy port.</param>
+        /// <param name="hostResolutionMode">The host name resolution method when using the proxy.</param>
+        public KeyboardInteractiveConnectionInfo(string host, string username, ProxyTypes proxyType, string proxyHost, int proxyPort, HostResolutionMode hostResolutionMode)
+            : this(host, DefaultPort, username, proxyType, proxyHost, proxyPort, string.Empty, string.Empty, hostResolutionMode)
         {
         }
 
@@ -110,9 +153,40 @@ namespace Renci.SshNet
         /// <param name="proxyHost">The proxy host.</param>
         /// <param name="proxyPort">The proxy port.</param>
         /// <param name="proxyUsername">The proxy username.</param>
+        /// <param name="hostResolutionMode">The host name resolution method when using the proxy.</param>
+        public KeyboardInteractiveConnectionInfo(string host, string username, ProxyTypes proxyType, string proxyHost, int proxyPort, string proxyUsername, HostResolutionMode hostResolutionMode)
+            : this(host, DefaultPort, username, proxyType, proxyHost, proxyPort, proxyUsername, string.Empty, hostResolutionMode)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeyboardInteractiveConnectionInfo"/> class.
+        /// </summary>
+        /// <param name="host">Connection host.</param>
+        /// <param name="username">Connection username.</param>
+        /// <param name="proxyType">Type of the proxy.</param>
+        /// <param name="proxyHost">The proxy host.</param>
+        /// <param name="proxyPort">The proxy port.</param>
+        /// <param name="proxyUsername">The proxy username.</param>
         /// <param name="proxyPassword">The proxy password.</param>
         public KeyboardInteractiveConnectionInfo(string host, string username, ProxyTypes proxyType, string proxyHost, int proxyPort, string proxyUsername, string proxyPassword)
             : this(host, DefaultPort, username, proxyType, proxyHost, proxyPort, proxyUsername, proxyPassword)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeyboardInteractiveConnectionInfo"/> class.
+        /// </summary>
+        /// <param name="host">Connection host.</param>
+        /// <param name="username">Connection username.</param>
+        /// <param name="proxyType">Type of the proxy.</param>
+        /// <param name="proxyHost">The proxy host.</param>
+        /// <param name="proxyPort">The proxy port.</param>
+        /// <param name="proxyUsername">The proxy username.</param>
+        /// <param name="proxyPassword">The proxy password.</param>
+        /// <param name="hostResolutionMode">The host name resolution method when using the proxy.</param>
+        public KeyboardInteractiveConnectionInfo(string host, string username, ProxyTypes proxyType, string proxyHost, int proxyPort, string proxyUsername, string proxyPassword, HostResolutionMode hostResolutionMode)
+            : this(host, DefaultPort, username, proxyType, proxyHost, proxyPort, proxyUsername, proxyPassword, hostResolutionMode)
         {
         }
 
@@ -129,6 +203,28 @@ namespace Renci.SshNet
         /// <param name="proxyPassword">The proxy password.</param>
         public KeyboardInteractiveConnectionInfo(string host, int port, string username, ProxyTypes proxyType, string proxyHost, int proxyPort, string proxyUsername, string proxyPassword)
             : base(host, port, username, proxyType, proxyHost, proxyPort, proxyUsername, proxyPassword, new KeyboardInteractiveAuthenticationMethod(username))
+        {
+            foreach (var authenticationMethod in AuthenticationMethods.OfType<KeyboardInteractiveAuthenticationMethod>())
+            {
+                authenticationMethod.AuthenticationPrompt += AuthenticationMethod_AuthenticationPrompt;
+            }
+
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeyboardInteractiveConnectionInfo"/> class.
+        /// </summary>
+        /// <param name="host">Connection host.</param>
+        /// <param name="port">Connection port.</param>
+        /// <param name="username">Connection username.</param>
+        /// <param name="proxyType">Type of the proxy.</param>
+        /// <param name="proxyHost">The proxy host.</param>
+        /// <param name="proxyPort">The proxy port.</param>
+        /// <param name="proxyUsername">The proxy username.</param>
+        /// <param name="proxyPassword">The proxy password.</param>
+        /// <param name="hostResolutionMode">The host name resolution method when using the proxy.</param>
+        public KeyboardInteractiveConnectionInfo(string host, int port, string username, ProxyTypes proxyType, string proxyHost, int proxyPort, string proxyUsername, string proxyPassword, HostResolutionMode hostResolutionMode)
+            : base(host, port, username, proxyType, proxyHost, proxyPort, proxyUsername, proxyPassword, hostResolutionMode, new KeyboardInteractiveAuthenticationMethod(username))
         {
             foreach (var authenticationMethod in AuthenticationMethods.OfType<KeyboardInteractiveAuthenticationMethod>())
             {

--- a/src/Renci.SshNet/PasswordConnectionInfo.cs
+++ b/src/Renci.SshNet/PasswordConnectionInfo.cs
@@ -80,9 +80,42 @@ namespace Renci.SshNet
         /// <param name="proxyType">Type of the proxy.</param>
         /// <param name="proxyHost">The proxy host.</param>
         /// <param name="proxyPort">The proxy port.</param>
+        /// <param name="hostResolutionMode">The host name resolution method when using the proxy.</param>
+        public PasswordConnectionInfo(string host, int port, string username, string password, ProxyTypes proxyType, string proxyHost, int proxyPort, HostResolutionMode hostResolutionMode)
+            : this(host, port, username, Encoding.UTF8.GetBytes(password), proxyType, proxyHost, proxyPort, string.Empty, string.Empty, hostResolutionMode)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PasswordConnectionInfo"/> class.
+        /// </summary>
+        /// <param name="host">Connection host.</param>
+        /// <param name="port">The port.</param>
+        /// <param name="username">Connection username.</param>
+        /// <param name="password">Connection password.</param>
+        /// <param name="proxyType">Type of the proxy.</param>
+        /// <param name="proxyHost">The proxy host.</param>
+        /// <param name="proxyPort">The proxy port.</param>
         /// <param name="proxyUsername">The proxy username.</param>
         public PasswordConnectionInfo(string host, int port, string username, string password, ProxyTypes proxyType, string proxyHost, int proxyPort, string proxyUsername)
             : this(host, port, username, Encoding.UTF8.GetBytes(password), proxyType, proxyHost, proxyPort, proxyUsername, string.Empty)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PasswordConnectionInfo"/> class.
+        /// </summary>
+        /// <param name="host">Connection host.</param>
+        /// <param name="port">The port.</param>
+        /// <param name="username">Connection username.</param>
+        /// <param name="password">Connection password.</param>
+        /// <param name="proxyType">Type of the proxy.</param>
+        /// <param name="proxyHost">The proxy host.</param>
+        /// <param name="proxyPort">The proxy port.</param>
+        /// <param name="proxyUsername">The proxy username.</param>
+        /// <param name="hostResolutionMode">The host name resolution method when using the proxy.</param>
+        public PasswordConnectionInfo(string host, int port, string username, string password, ProxyTypes proxyType, string proxyHost, int proxyPort, string proxyUsername, HostResolutionMode hostResolutionMode)
+            : this(host, port, username, Encoding.UTF8.GetBytes(password), proxyType, proxyHost, proxyPort, proxyUsername, string.Empty, hostResolutionMode)
         {
         }
 
@@ -97,6 +130,21 @@ namespace Renci.SshNet
         /// <param name="proxyPort">The proxy port.</param>
         public PasswordConnectionInfo(string host, string username, string password, ProxyTypes proxyType, string proxyHost, int proxyPort)
             : this(host, DefaultPort, username, Encoding.UTF8.GetBytes(password), proxyType, proxyHost, proxyPort, string.Empty, string.Empty)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PasswordConnectionInfo"/> class.
+        /// </summary>
+        /// <param name="host">Connection host.</param>
+        /// <param name="username">Connection username.</param>
+        /// <param name="password">Connection password.</param>
+        /// <param name="proxyType">Type of the proxy.</param>
+        /// <param name="proxyHost">The proxy host.</param>
+        /// <param name="proxyPort">The proxy port.</param>
+        /// <param name="hostResolutionMode">The host name resolution method when using the proxy.</param>
+        public PasswordConnectionInfo(string host, string username, string password, ProxyTypes proxyType, string proxyHost, int proxyPort, HostResolutionMode hostResolutionMode)
+            : this(host, DefaultPort, username, Encoding.UTF8.GetBytes(password), proxyType, proxyHost, proxyPort, string.Empty, string.Empty, hostResolutionMode)
         {
         }
 
@@ -125,9 +173,42 @@ namespace Renci.SshNet
         /// <param name="proxyHost">The proxy host.</param>
         /// <param name="proxyPort">The proxy port.</param>
         /// <param name="proxyUsername">The proxy username.</param>
+        /// <param name="hostResolutionMode">The host name resolution method when using the proxy.</param>
+        public PasswordConnectionInfo(string host, string username, string password, ProxyTypes proxyType, string proxyHost, int proxyPort, string proxyUsername, HostResolutionMode hostResolutionMode)
+            : this(host, DefaultPort, username, Encoding.UTF8.GetBytes(password), proxyType, proxyHost, proxyPort, proxyUsername, string.Empty, hostResolutionMode)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PasswordConnectionInfo"/> class.
+        /// </summary>
+        /// <param name="host">Connection host.</param>
+        /// <param name="username">Connection username.</param>
+        /// <param name="password">Connection password.</param>
+        /// <param name="proxyType">Type of the proxy.</param>
+        /// <param name="proxyHost">The proxy host.</param>
+        /// <param name="proxyPort">The proxy port.</param>
+        /// <param name="proxyUsername">The proxy username.</param>
         /// <param name="proxyPassword">The proxy password.</param>
         public PasswordConnectionInfo(string host, string username, string password, ProxyTypes proxyType, string proxyHost, int proxyPort, string proxyUsername, string proxyPassword)
             : this(host, DefaultPort, username, Encoding.UTF8.GetBytes(password), proxyType, proxyHost, proxyPort, proxyUsername, proxyPassword)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PasswordConnectionInfo"/> class.
+        /// </summary>
+        /// <param name="host">Connection host.</param>
+        /// <param name="username">Connection username.</param>
+        /// <param name="password">Connection password.</param>
+        /// <param name="proxyType">Type of the proxy.</param>
+        /// <param name="proxyHost">The proxy host.</param>
+        /// <param name="proxyPort">The proxy port.</param>
+        /// <param name="proxyUsername">The proxy username.</param>
+        /// <param name="proxyPassword">The proxy password.</param>
+        /// <param name="hostResolutionMode">The host name resolution method when using the proxy.</param>
+        public PasswordConnectionInfo(string host, string username, string password, ProxyTypes proxyType, string proxyHost, int proxyPort, string proxyUsername, string proxyPassword, HostResolutionMode hostResolutionMode)
+            : this(host, DefaultPort, username, Encoding.UTF8.GetBytes(password), proxyType, proxyHost, proxyPort, proxyUsername, proxyPassword, hostResolutionMode)
         {
         }
 
@@ -182,9 +263,42 @@ namespace Renci.SshNet
         /// <param name="proxyType">Type of the proxy.</param>
         /// <param name="proxyHost">The proxy host.</param>
         /// <param name="proxyPort">The proxy port.</param>
+        /// <param name="hostResolutionMode">The host name resolution method when using the proxy.</param>
+        public PasswordConnectionInfo(string host, int port, string username, byte[] password, ProxyTypes proxyType, string proxyHost, int proxyPort, HostResolutionMode hostResolutionMode)
+            : this(host, port, username, password, proxyType, proxyHost, proxyPort, string.Empty, string.Empty, hostResolutionMode)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PasswordConnectionInfo"/> class.
+        /// </summary>
+        /// <param name="host">Connection host.</param>
+        /// <param name="port">The port.</param>
+        /// <param name="username">Connection username.</param>
+        /// <param name="password">Connection password.</param>
+        /// <param name="proxyType">Type of the proxy.</param>
+        /// <param name="proxyHost">The proxy host.</param>
+        /// <param name="proxyPort">The proxy port.</param>
         /// <param name="proxyUsername">The proxy username.</param>
         public PasswordConnectionInfo(string host, int port, string username, byte[] password, ProxyTypes proxyType, string proxyHost, int proxyPort, string proxyUsername)
             : this(host, port, username, password, proxyType, proxyHost, proxyPort, proxyUsername, string.Empty)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PasswordConnectionInfo"/> class.
+        /// </summary>
+        /// <param name="host">Connection host.</param>
+        /// <param name="port">The port.</param>
+        /// <param name="username">Connection username.</param>
+        /// <param name="password">Connection password.</param>
+        /// <param name="proxyType">Type of the proxy.</param>
+        /// <param name="proxyHost">The proxy host.</param>
+        /// <param name="proxyPort">The proxy port.</param>
+        /// <param name="proxyUsername">The proxy username.</param>
+        /// <param name="hostResolutionMode">The host name resolution method when using the proxy.</param>
+        public PasswordConnectionInfo(string host, int port, string username, byte[] password, ProxyTypes proxyType, string proxyHost, int proxyPort, string proxyUsername, HostResolutionMode hostResolutionMode)
+            : this(host, port, username, password, proxyType, proxyHost, proxyPort, proxyUsername, string.Empty, hostResolutionMode)
         {
         }
 
@@ -199,6 +313,21 @@ namespace Renci.SshNet
         /// <param name="proxyPort">The proxy port.</param>
         public PasswordConnectionInfo(string host, string username, byte[] password, ProxyTypes proxyType, string proxyHost, int proxyPort)
             : this(host, DefaultPort, username, password, proxyType, proxyHost, proxyPort, string.Empty, string.Empty)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PasswordConnectionInfo"/> class.
+        /// </summary>
+        /// <param name="host">Connection host.</param>
+        /// <param name="username">Connection username.</param>
+        /// <param name="password">Connection password.</param>
+        /// <param name="proxyType">Type of the proxy.</param>
+        /// <param name="proxyHost">The proxy host.</param>
+        /// <param name="proxyPort">The proxy port.</param>
+        /// <param name="hostResolutionMode">The host name resolution method when using the proxy.</param>
+        public PasswordConnectionInfo(string host, string username, byte[] password, ProxyTypes proxyType, string proxyHost, int proxyPort, HostResolutionMode hostResolutionMode)
+            : this(host, DefaultPort, username, password, proxyType, proxyHost, proxyPort, string.Empty, string.Empty, hostResolutionMode)
         {
         }
 
@@ -227,9 +356,42 @@ namespace Renci.SshNet
         /// <param name="proxyHost">The proxy host.</param>
         /// <param name="proxyPort">The proxy port.</param>
         /// <param name="proxyUsername">The proxy username.</param>
+        /// <param name="hostResolutionMode">The host name resolution method when using the proxy.</param>
+        public PasswordConnectionInfo(string host, string username, byte[] password, ProxyTypes proxyType, string proxyHost, int proxyPort, string proxyUsername, HostResolutionMode hostResolutionMode)
+            : this(host, DefaultPort, username, password, proxyType, proxyHost, proxyPort, proxyUsername, string.Empty, hostResolutionMode)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PasswordConnectionInfo"/> class.
+        /// </summary>
+        /// <param name="host">Connection host.</param>
+        /// <param name="username">Connection username.</param>
+        /// <param name="password">Connection password.</param>
+        /// <param name="proxyType">Type of the proxy.</param>
+        /// <param name="proxyHost">The proxy host.</param>
+        /// <param name="proxyPort">The proxy port.</param>
+        /// <param name="proxyUsername">The proxy username.</param>
         /// <param name="proxyPassword">The proxy password.</param>
         public PasswordConnectionInfo(string host, string username, byte[] password, ProxyTypes proxyType, string proxyHost, int proxyPort, string proxyUsername, string proxyPassword)
             : this(host, DefaultPort, username, password, proxyType, proxyHost, proxyPort, proxyUsername, proxyPassword)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PasswordConnectionInfo"/> class.
+        /// </summary>
+        /// <param name="host">Connection host.</param>
+        /// <param name="username">Connection username.</param>
+        /// <param name="password">Connection password.</param>
+        /// <param name="proxyType">Type of the proxy.</param>
+        /// <param name="proxyHost">The proxy host.</param>
+        /// <param name="proxyPort">The proxy port.</param>
+        /// <param name="proxyUsername">The proxy username.</param>
+        /// <param name="proxyPassword">The proxy password.</param>
+        /// <param name="hostResolutionMode">The host name resolution method when using the proxy.</param>
+        public PasswordConnectionInfo(string host, string username, byte[] password, ProxyTypes proxyType, string proxyHost, int proxyPort, string proxyUsername, string proxyPassword, HostResolutionMode hostResolutionMode)
+            : this(host, DefaultPort, username, password, proxyType, proxyHost, proxyPort, proxyUsername, proxyPassword, hostResolutionMode)
         {
         }
 
@@ -247,6 +409,28 @@ namespace Renci.SshNet
         /// <param name="proxyPassword">The proxy password.</param>
         public PasswordConnectionInfo(string host, int port, string username, byte[] password, ProxyTypes proxyType, string proxyHost, int proxyPort, string proxyUsername, string proxyPassword)
             : base(host, port, username, proxyType, proxyHost, proxyPort, proxyUsername, proxyPassword, new PasswordAuthenticationMethod(username, password))
+        {
+            foreach (var authenticationMethod in AuthenticationMethods.OfType<PasswordAuthenticationMethod>())
+            {
+                authenticationMethod.PasswordExpired += AuthenticationMethod_PasswordExpired;
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PasswordConnectionInfo"/> class.
+        /// </summary>
+        /// <param name="host">Connection host.</param>
+        /// <param name="port">The port.</param>
+        /// <param name="username">Connection username.</param>
+        /// <param name="password">Connection password.</param>
+        /// <param name="proxyType">Type of the proxy.</param>
+        /// <param name="proxyHost">The proxy host.</param>
+        /// <param name="proxyPort">The proxy port.</param>
+        /// <param name="proxyUsername">The proxy username.</param>
+        /// <param name="proxyPassword">The proxy password.</param>
+        /// <param name="hostResolutionMode">The host name resolution method when using the proxy.</param>
+        public PasswordConnectionInfo(string host, int port, string username, byte[] password, ProxyTypes proxyType, string proxyHost, int proxyPort, string proxyUsername, string proxyPassword, HostResolutionMode hostResolutionMode)
+            : base(host, port, username, proxyType, proxyHost, proxyPort, proxyUsername, proxyPassword, hostResolutionMode, new PasswordAuthenticationMethod(username, password))
         {
             foreach (var authenticationMethod in AuthenticationMethods.OfType<PasswordAuthenticationMethod>())
             {

--- a/src/Renci.SshNet/PrivateKeyConnectionInfo.cs
+++ b/src/Renci.SshNet/PrivateKeyConnectionInfo.cs
@@ -70,10 +70,43 @@ namespace Renci.SshNet
         /// <param name="proxyType">Type of the proxy.</param>
         /// <param name="proxyHost">The proxy host.</param>
         /// <param name="proxyPort">The proxy port.</param>
+        /// <param name="hostResolutionMode">The host name resolution method when using the proxy.</param>
+        /// <param name="keyFiles">The key files.</param>
+        public PrivateKeyConnectionInfo(string host, int port, string username, ProxyTypes proxyType, string proxyHost, int proxyPort, HostResolutionMode hostResolutionMode, params PrivateKeyFile[] keyFiles)
+            : this(host, port, username, proxyType, proxyHost, proxyPort, string.Empty, string.Empty, hostResolutionMode, keyFiles)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PasswordConnectionInfo"/> class.
+        /// </summary>
+        /// <param name="host">Connection host.</param>
+        /// <param name="port">The port.</param>
+        /// <param name="username">Connection username.</param>
+        /// <param name="proxyType">Type of the proxy.</param>
+        /// <param name="proxyHost">The proxy host.</param>
+        /// <param name="proxyPort">The proxy port.</param>
         /// <param name="proxyUsername">The proxy username.</param>
         /// <param name="keyFiles">The key files.</param>
         public PrivateKeyConnectionInfo(string host, int port, string username, ProxyTypes proxyType, string proxyHost, int proxyPort, string proxyUsername, params PrivateKeyFile[] keyFiles)
             : this(host, port, username, proxyType, proxyHost, proxyPort, proxyUsername, string.Empty, keyFiles)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PasswordConnectionInfo"/> class.
+        /// </summary>
+        /// <param name="host">Connection host.</param>
+        /// <param name="port">The port.</param>
+        /// <param name="username">Connection username.</param>
+        /// <param name="proxyType">Type of the proxy.</param>
+        /// <param name="proxyHost">The proxy host.</param>
+        /// <param name="proxyPort">The proxy port.</param>
+        /// <param name="proxyUsername">The proxy username.</param>
+        /// <param name="hostResolutionMode">The host name resolution method when using the proxy.</param>
+        /// <param name="keyFiles">The key files.</param>
+        public PrivateKeyConnectionInfo(string host, int port, string username, ProxyTypes proxyType, string proxyHost, int proxyPort, string proxyUsername, HostResolutionMode hostResolutionMode, params PrivateKeyFile[] keyFiles)
+            : this(host, port, username, proxyType, proxyHost, proxyPort, proxyUsername, string.Empty, hostResolutionMode, keyFiles)
         {
         }
 
@@ -88,6 +121,21 @@ namespace Renci.SshNet
         /// <param name="keyFiles">The key files.</param>
         public PrivateKeyConnectionInfo(string host, string username, ProxyTypes proxyType, string proxyHost, int proxyPort, params PrivateKeyFile[] keyFiles)
             : this(host, DefaultPort, username, proxyType, proxyHost, proxyPort, string.Empty, string.Empty, keyFiles)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PasswordConnectionInfo"/> class.
+        /// </summary>
+        /// <param name="host">Connection host.</param>
+        /// <param name="username">Connection username.</param>
+        /// <param name="proxyType">Type of the proxy.</param>
+        /// <param name="proxyHost">The proxy host.</param>
+        /// <param name="proxyPort">The proxy port.</param>
+        /// <param name="hostResolutionMode">The host name resolution method when using the proxy.</param>
+        /// <param name="keyFiles">The key files.</param>
+        public PrivateKeyConnectionInfo(string host, string username, ProxyTypes proxyType, string proxyHost, int proxyPort, HostResolutionMode hostResolutionMode, params PrivateKeyFile[] keyFiles)
+            : this(host, DefaultPort, username, proxyType, proxyHost, proxyPort, string.Empty, string.Empty, hostResolutionMode, keyFiles)
         {
         }
 
@@ -115,10 +163,43 @@ namespace Renci.SshNet
         /// <param name="proxyHost">The proxy host.</param>
         /// <param name="proxyPort">The proxy port.</param>
         /// <param name="proxyUsername">The proxy username.</param>
+        /// <param name="hostResolutionMode">The host name resolution method when using the proxy.</param>
+        /// <param name="keyFiles">The key files.</param>
+        public PrivateKeyConnectionInfo(string host, string username, ProxyTypes proxyType, string proxyHost, int proxyPort, string proxyUsername, HostResolutionMode hostResolutionMode, params PrivateKeyFile[] keyFiles)
+            : this(host, DefaultPort, username, proxyType, proxyHost, proxyPort, proxyUsername, string.Empty, hostResolutionMode, keyFiles)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PasswordConnectionInfo"/> class.
+        /// </summary>
+        /// <param name="host">Connection host.</param>
+        /// <param name="username">Connection username.</param>
+        /// <param name="proxyType">Type of the proxy.</param>
+        /// <param name="proxyHost">The proxy host.</param>
+        /// <param name="proxyPort">The proxy port.</param>
+        /// <param name="proxyUsername">The proxy username.</param>
         /// <param name="proxyPassword">The proxy password.</param>
         /// <param name="keyFiles">The key files.</param>
         public PrivateKeyConnectionInfo(string host, string username, ProxyTypes proxyType, string proxyHost, int proxyPort, string proxyUsername, string proxyPassword, params PrivateKeyFile[] keyFiles)
             : this(host, DefaultPort, username, proxyType, proxyHost, proxyPort, proxyUsername, proxyPassword, keyFiles)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PasswordConnectionInfo"/> class.
+        /// </summary>
+        /// <param name="host">Connection host.</param>
+        /// <param name="username">Connection username.</param>
+        /// <param name="proxyType">Type of the proxy.</param>
+        /// <param name="proxyHost">The proxy host.</param>
+        /// <param name="proxyPort">The proxy port.</param>
+        /// <param name="proxyUsername">The proxy username.</param>
+        /// <param name="proxyPassword">The proxy password.</param>
+        /// <param name="hostResolutionMode">The host name resolution method when using the proxy.</param>
+        /// <param name="keyFiles">The key files.</param>
+        public PrivateKeyConnectionInfo(string host, string username, ProxyTypes proxyType, string proxyHost, int proxyPort, string proxyUsername, string proxyPassword, HostResolutionMode hostResolutionMode, params PrivateKeyFile[] keyFiles)
+            : this(host, DefaultPort, username, proxyType, proxyHost, proxyPort, proxyUsername, proxyPassword, hostResolutionMode, keyFiles)
         {
         }
 
@@ -136,6 +217,25 @@ namespace Renci.SshNet
         /// <param name="keyFiles">The key files.</param>
         public PrivateKeyConnectionInfo(string host, int port, string username, ProxyTypes proxyType, string proxyHost, int proxyPort, string proxyUsername, string proxyPassword, params PrivateKeyFile[] keyFiles)
             : base(host, port, username, proxyType, proxyHost, proxyPort, proxyUsername, proxyPassword, new PrivateKeyAuthenticationMethod(username, keyFiles))
+        {
+            KeyFiles = new Collection<PrivateKeyFile>(keyFiles);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PasswordConnectionInfo"/> class.
+        /// </summary>
+        /// <param name="host">Connection host.</param>
+        /// <param name="port">The port.</param>
+        /// <param name="username">Connection username.</param>
+        /// <param name="proxyType">Type of the proxy.</param>
+        /// <param name="proxyHost">The proxy host.</param>
+        /// <param name="proxyPort">The proxy port.</param>
+        /// <param name="proxyUsername">The proxy username.</param>
+        /// <param name="proxyPassword">The proxy password.</param>
+        /// <param name="hostResolutionMode">The host name resolution method when using the proxy.</param>
+        /// <param name="keyFiles">The key files.</param>
+        public PrivateKeyConnectionInfo(string host, int port, string username, ProxyTypes proxyType, string proxyHost, int proxyPort, string proxyUsername, string proxyPassword, HostResolutionMode hostResolutionMode, params PrivateKeyFile[] keyFiles)
+            : base(host, port, username, proxyType, proxyHost, proxyPort, proxyUsername, proxyPassword, hostResolutionMode, new PrivateKeyAuthenticationMethod(username, keyFiles))
         {
             KeyFiles = new Collection<PrivateKeyFile>(keyFiles);
         }

--- a/src/Renci.SshNet/Renci.SshNet.csproj
+++ b/src/Renci.SshNet/Renci.SshNet.csproj
@@ -147,6 +147,7 @@
     <Compile Include="HashInfo.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="HostResolutionMode.cs" />
     <Compile Include="IAuthenticationMethod.cs" />
     <Compile Include="IClientAuthentication.cs" />
     <Compile Include="IConnectionInfo.cs" />

--- a/src/Renci.SshNet/Session.cs
+++ b/src/Renci.SshNet/Session.cs
@@ -34,7 +34,7 @@ namespace Renci.SshNet
         /// Specifies an infinite waiting period.
         /// </summary>
         /// <remarks>
-        /// The value of this field is <c>-1</c> millisecond. 
+        /// The value of this field is <c>-1</c> millisecond.
         /// </remarks>
         internal static readonly TimeSpan InfiniteTimeSpan = new TimeSpan(0, 0, 0, 0, -1);
 
@@ -1697,7 +1697,7 @@ namespace Renci.SshNet
 
             // 2012-09-11: Kenneth_aa
             // When Disconnect or Dispose is called, this throws SshConnectionException(), which...
-            // 1 - goes up to ReceiveMessage() 
+            // 1 - goes up to ReceiveMessage()
             // 2 - up again to MessageListener()
             // which is where there is a catch-all exception block so it can notify event listeners.
             // 3 - MessageListener then again calls RaiseError().
@@ -1950,7 +1950,7 @@ namespace Renci.SshNet
                 // Send the host name
                 SocketWriteByte(0x03);
 
-                var hostNameBytes = SshData.Ascii.GetBytes(ConnectionInfo.ProxyHost);
+                var hostNameBytes = SshData.Ascii.GetBytes(ConnectionInfo.Host);
                 SocketWriteByte((byte) hostNameBytes.Length);
                 SocketAbstraction.Send(_socket, hostNameBytes);
             }

--- a/src/Renci.SshNet/Session.cs
+++ b/src/Renci.SshNet/Session.cs
@@ -1950,7 +1950,7 @@ namespace Renci.SshNet
                 // Send the host name
                 SocketWriteByte(0x03);
 
-                var hostNameBytes = Encoding.ASCII.GetBytes(ConnectionInfo.ProxyHost);
+                var hostNameBytes = SshData.Ascii.GetBytes(ConnectionInfo.ProxyHost);
                 SocketWriteByte((byte) hostNameBytes.Length);
                 SocketAbstraction.Send(_socket, hostNameBytes);
             }


### PR DESCRIPTION
I have a business case where the proxy I need to use has a set of permissions based on the targetted host name, and rejects connections targetting an IP address.
SOCKS5 allows sending the host name instead of the locally-resolved IP addess, so I've implemented support for that.
