### PR TITLE
Suppressing a not-connected exception on socket shutdown

### DIFF
--- a/src/Renci.SshNet/Channels/ChannelDirectTcpip.cs
+++ b/src/Renci.SshNet/Channels/ChannelDirectTcpip.cs
@@ -132,7 +132,21 @@ namespace Renci.SshNet.Channels
                 if (_socket == null || !_socket.Connected)
                     return;
 
-                _socket.Shutdown(how);
+                try
+                {
+                    _socket.Shutdown(how);
+                }
+                catch (SocketException ex)
+                {
+                    if (ex != null && ex.Message != null &&  ex.Message.Contains("The socket is not connected"))
+                    {
+                        DiagnosticAbstraction.Log("Eating a 'socket is not connected' message, because we're closing this socket anyway.");
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
I'm trying out SshNet on an ARM device with a very old linux kernel (2.6.29) and old version of mono (3.0.11). I'm not sure if this is a function of my ancient environment.

While closing a socket associated with ChannelDirectTcpip, the _socket seems to respond true to `_socket.Connected`; but throws `SocketException: The socket is not connected` when it hits `_socket.Shutdown()`. Since it's a shutdown procedure anyway, I assume this exception is not important so I just send it to the log and escape out.

I ran some limited tests and by suppressing this exception, SshNet no longer bombs out and instead continues to be available and seems to continue humming along without any other apparent issues. I have not checked if there's other sockets which also have an untrustworthy Connected property.
