### PR TITLE
SftpFileStream.BeginRead/BeginWrite implementation

### DIFF
--- a/src/Renci.SshNet/Renci.SshNet.csproj
+++ b/src/Renci.SshNet/Renci.SshNet.csproj
@@ -170,6 +170,7 @@
     <Compile Include="Security\KeyExchangeDiffieHellmanGroupExchangeShaBase.cs" />
     <Compile Include="ServiceFactory.cs" />
     <Compile Include="ServiceFactory.NET.cs" />
+    <Compile Include="Sftp\SftpFileStreamAsyncResult.cs" />
     <Compile Include="Sftp\ISftpSession.cs" />
     <Compile Include="Common\SshDataStream.cs" />
     <Compile Include="ExpectAsyncResult.cs" />

--- a/src/Renci.SshNet/Sftp/ISftpSession.cs
+++ b/src/Renci.SshNet/Sftp/ISftpSession.cs
@@ -96,6 +96,16 @@ namespace Renci.SshNet.Sftp
         byte[] RequestRead(byte[] handle, ulong offset, uint length);
 
         /// <summary>
+        /// Performs SSH_FXP_READ request asynchronously.
+        /// </summary>
+        /// <param name="handle">The handle.</param>
+        /// <param name="offset">The offset.</param>
+        /// <param name="length">The length.</param>
+        /// <param name="responseData">An action that will be executed upon receiving a data response.</param>
+        /// <param name="responseStatus">An action that will be executed upon receiving a status response.</param>
+        void RequestReadAsync(byte[] handle, ulong offset, uint length, Action<SftpDataResponse> responseData, Action<SftpStatusResponse> responseStatus);
+
+        /// <summary>
         /// Performs SSH_FXP_READDIR request
         /// </summary>
         /// <param name="handle">The handle.</param>

--- a/src/Renci.SshNet/Sftp/SftpFileStream.cs
+++ b/src/Renci.SshNet/Sftp/SftpFileStream.cs
@@ -492,48 +492,42 @@ namespace Renci.SshNet.Sftp
                         _session.RequestReadAsync(_handle, (ulong)_position, (uint)thisBytesToRead, 
                             response =>
                                 {
-                                    //ThreadAbstraction.ExecuteThread(() =>
-                                    //{
-                                        try
-                                        {
-                                            data = response.Data;
-                                            if (data.Length > buffer.Length - thisOffset || data.Length > thisBytesToRead)
-                                                throw new IOException("The server returned more data than requested");
+                                    try
+                                    {
+                                        data = response.Data;
+                                        if (data.Length > buffer.Length - thisOffset || data.Length > thisBytesToRead)
+                                            throw new IOException("The server returned more data than requested");
 
-                                            // Copy stream data to the caller's buffer.
-                                            Buffer.BlockCopy(data, 0, buffer, thisOffset, data.Length);
+                                        // Copy stream data to the caller's buffer.
+                                        Buffer.BlockCopy(data, 0, buffer, thisOffset, data.Length);
 
-                                            asyncResult.Update(asyncResult.Bytes + data.Length);
-                                            if (asyncResult.Bytes == count)
-                                                asyncResult.SetAsCompleted(null, false);
-                                        }
-                                        catch (Exception exp)
-                                        {
-                                            asyncResult.SetAsCompleted(exp, false);
-                                        }
-                                    //});
+                                        asyncResult.Update(asyncResult.Bytes + data.Length);
+                                        if (asyncResult.Bytes == count)
+                                            asyncResult.SetAsCompleted(null, false);
+                                    }
+                                    catch (Exception exp)
+                                    {
+                                        asyncResult.SetAsCompleted(exp, false);
+                                    }
                                 },
                             response =>
                                 {
-                                    //ThreadAbstraction.ExecuteThread(() =>
-                                    //{
-                                        try
+                                    try
+                                    {
+                                        if (response.StatusCode != StatusCodes.Eof)
                                         {
-                                            if (response.StatusCode != StatusCodes.Eof)
-                                            {
-                                                exception = SftpSession.GetSftpException(response);
-                                                asyncResult.Update(0);
-                                                buffer = Array<byte>.Empty;
-                                                if (exception != null) throw exception;
-                                            }
+                                            exception = SftpSession.GetSftpException(response);
+                                            asyncResult.Update(0);
+                                            buffer = Array<byte>.Empty;
+                                            if (exception != null) throw exception;
+                                        }
                                             
-                                            asyncResult.SetAsCompleted(null, false);
-                                        }
-                                        catch (Exception exp)
-                                        {
-                                            asyncResult.SetAsCompleted(exp, false);
-                                        }
-                                    //});
+                                        asyncResult.SetAsCompleted(null, false);
+                                    }
+                                    catch (Exception exp)
+                                    {
+                                        asyncResult.SetAsCompleted(exp, false);
+                                    }
                                 });
                         
                         _serverFilePosition = (ulong)_position;

--- a/src/Renci.SshNet/Sftp/SftpFileStreamAsyncResult.cs
+++ b/src/Renci.SshNet/Sftp/SftpFileStreamAsyncResult.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Renci.SshNet.Common;
+
+namespace Renci.SshNet.Sftp
+{
+    /// <summary>
+    /// Encapsulates the results of an asynchronous read or write operation.
+    /// </summary>
+    public class SftpFileStreamAsyncResult :  AsyncResult
+    {
+        /// <summary>
+        /// Gets the number of read or written bytes.
+        /// </summary>
+        public int Bytes { get; private set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SftpFileStreamAsyncResult"/> class.
+        /// </summary>
+        /// <param name="asyncCallback">The async callback.</param>
+        /// <param name="state">The state.</param>
+        public SftpFileStreamAsyncResult(AsyncCallback asyncCallback, object state)
+            : base(asyncCallback, state)
+        {
+        }
+
+        /// <summary>
+        /// Updates asynchronous operation status information.
+        /// </summary>
+        /// <param name="bytes">Number of IO bytes in this operation.</param>
+        internal void Update(int bytes)
+        {
+            Bytes = bytes;
+        }
+    }
+}

--- a/src/Renci.SshNet/Sftp/SftpFileStreamAsyncResult.cs
+++ b/src/Renci.SshNet/Sftp/SftpFileStreamAsyncResult.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Renci.SshNet.Common;
+using System.Threading;
 
 namespace Renci.SshNet.Sftp
 {
@@ -8,10 +9,21 @@ namespace Renci.SshNet.Sftp
     /// </summary>
     public class SftpFileStreamAsyncResult :  AsyncResult
     {
+        private int _bytes;
         /// <summary>
         /// Gets the number of read or written bytes.
         /// </summary>
-        public int Bytes { get; private set; }
+        public int Bytes 
+        {
+            get
+            {
+                return _bytes;
+            }
+            private set
+            {
+                Interlocked.Exchange(ref _bytes, value);
+            }
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SftpFileStreamAsyncResult"/> class.

--- a/src/Renci.SshNet/Sftp/SftpSession.cs
+++ b/src/Renci.SshNet/Sftp/SftpSession.cs
@@ -443,6 +443,20 @@ namespace Renci.SshNet.Sftp
         }
 
         /// <summary>
+        /// Performs SSH_FXP_READ request asynchronously.
+        /// </summary>
+        /// <param name="handle">The handle.</param>
+        /// <param name="offset">The offset.</param>
+        /// <param name="length">The length.</param>
+        /// <param name="responseData">An action that will be executed upon receiving a data response.</param>
+        /// <param name="responseStatus">An action that will be executed upon receiving a status response.</param>
+        public void RequestReadAsync(byte[] handle, ulong offset, uint length, Action<SftpDataResponse> responseData, Action<SftpStatusResponse> responseStatus)
+        {
+            var request = new SftpReadRequest(ProtocolVersion, NextRequestId, handle, offset, length, responseData, responseStatus);
+            SendRequest(request);
+        }
+
+        /// <summary>
         /// Performs SSH_FXP_WRITE request.
         /// </summary>
         /// <param name="handle">The handle.</param>
@@ -1204,7 +1218,7 @@ namespace Renci.SshNet.Sftp
             return Math.Min(bufferSize, maximumPacketSize) - lengthOfNonDataProtocolFields;
         }
 
-        private static SshException GetSftpException(SftpStatusResponse response)
+        public static SshException GetSftpException(SftpStatusResponse response)
         {
             switch (response.StatusCode)
             {

--- a/src/Renci.SshNet/SftpClient.cs
+++ b/src/Renci.SshNet/SftpClient.cs
@@ -1306,7 +1306,7 @@ namespace Renci.SshNet
         /// <param name="path">The file to open.</param>
         /// <param name="mode">A <see cref="FileMode"/> value that specifies whether a file is created if one does not exist, and determines whether the contents of existing files are retained or overwritten.</param>
         /// <param name="access">A <see cref="FileAccess"/> value that specifies the operations that can be performed on the file.</param>
-        /// <param name="isAsync">A boolean value which indicates whether the stream will be opened in asynchronous mode.</param>
+        /// <param name="useAsync">A boolean value which indicates whether the stream will be opened in asynchronous mode.</param>
         /// <returns>
         /// An unshared <see cref="SftpFileStream"/> that provides access to the specified file, with the specified mode and access.
         /// </returns>

--- a/src/Renci.SshNet/SftpClient.cs
+++ b/src/Renci.SshNet/SftpClient.cs
@@ -1306,17 +1306,18 @@ namespace Renci.SshNet
         /// <param name="path">The file to open.</param>
         /// <param name="mode">A <see cref="FileMode"/> value that specifies whether a file is created if one does not exist, and determines whether the contents of existing files are retained or overwritten.</param>
         /// <param name="access">A <see cref="FileAccess"/> value that specifies the operations that can be performed on the file.</param>
+        /// <param name="isAsync">A boolean value which indicates whether the stream will be opened in asynchronous mode.</param>
         /// <returns>
         /// An unshared <see cref="SftpFileStream"/> that provides access to the specified file, with the specified mode and access.
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="path"/> is <b>null</b>.</exception>
         /// <exception cref="SshConnectionException">Client is not connected.</exception>
         /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
-        public SftpFileStream Open(string path, FileMode mode, FileAccess access)
+        public SftpFileStream Open(string path, FileMode mode, FileAccess access, bool useAsync = false)
         {
             CheckDisposed();
 
-            return new SftpFileStream(_sftpSession, path, mode, access, (int) _bufferSize);
+            return new SftpFileStream(_sftpSession, path, mode, access, (int) _bufferSize, useAsync);
         }
 
         /// <summary>


### PR DESCRIPTION
This is an important first step in addressing SFTP performance issues #100 --being able to asynchronously overlap/pipeline IO in the SFTP stream.

My purposes for this are a little unique in that I will be using these methods directly because my SFTP reads/writes will be directly to/from memory instead of disk, so I didn't go so far yet as to make a SftpClient.DownloadFile overload, for instance, which takes advantage of this. Accordingly, I've tested both of these thoroughly and they seem to work. Going further with this shouldn't be terribly difficult, but thought I should share what I have so far.