### PR TITLE
Dispose streams when exec channel is closed instead of flushing

### DIFF
--- a/src/Renci.SshNet/SshCommand.cs
+++ b/src/Renci.SshNet/SshCommand.cs
@@ -398,13 +398,15 @@ namespace Renci.SshNet
             var outputStream = OutputStream;
             if (outputStream != null)
             {
-                outputStream.Flush();
+                outputStream.Dispose();
+                OutputStream = null;
             }
 
             var extendedOutputStream = ExtendedOutputStream;
             if (extendedOutputStream != null)
             {
-                extendedOutputStream.Flush();
+                extendedOutputStream.Dispose();
+                ExtendedOutputStream = null;
             }
 
             _asyncResult.IsCompleted = true;


### PR DESCRIPTION
Flushing PipeStream when the other end has been closed causes a deadlock and it doesn't make much sense given the closed state.

This commit allows streaming execs to successfully end after closing the output stream on client side.

Simple test case that should not fail when streams are closed on client side:
```
var ssh = new SshClient(...);
ssh.Connect();
var cmd = ssh.CreateCommand("cat");
var async = cmd.BeginExecute("test", null, null);
cmd.OutputStream.Close();
cmd.ExtendedOutputStream.Close();
cmd.EndExecute(async); // will hang
ssh.Disconnect();
```