### PR TITLE
RFC: Rewrite PipeStream and SshCommand stream handling

### DIFF
--- a/src/Renci.SshNet/Common/LinkedListQueue.cs
+++ b/src/Renci.SshNet/Common/LinkedListQueue.cs
@@ -6,7 +6,7 @@
     /// <summary>
     /// Fast concurrent generic linked list queue.
     /// </summary>
-    public class LinkedListQueue<T> : IDisposable
+    internal class LinkedListQueue<T> : IDisposable
     {
         sealed class Entry<E>
         {

--- a/src/Renci.SshNet/Common/LinkedListQueue.cs
+++ b/src/Renci.SshNet/Common/LinkedListQueue.cs
@@ -93,10 +93,17 @@
         /// </summary>
         /// <returns><c>true</c>, if an item could be removed; otherwise <c>false</c>.</returns>
         /// <param name="item">The item to be removed from the queue.</param>
-        public bool TryTake(out T item)
+        /// <param name="wait">Wait for data or fail immediately if empty.</param>
+        public bool TryTake(out T item, bool wait)
         {
             lock (_lock)
             {
+                if (_first == null && !wait)
+                {
+                    item = default(T);
+                    return false;
+                }
+
                 while (_first == null && !_isAddingCompleted)
                     Monitor.Wait(_lock);
 

--- a/src/Renci.SshNet/Common/LinkedListQueue.cs
+++ b/src/Renci.SshNet/Common/LinkedListQueue.cs
@@ -1,0 +1,134 @@
+﻿namespace Renci.SshNet.Common
+{
+    using System;
+    using System.Threading;
+
+    /// <summary>
+    /// Fast concurrent generic linked list queue.
+    /// </summary>
+    public class LinkedListQueue<T> : IDisposable
+    {
+        sealed class Entry<E>
+        {
+            public E Item;
+            public Entry<E> Next;
+        }
+
+        private readonly object _lock = new object();
+
+        private Entry<T> _first;
+        private Entry<T> _last;
+
+        private bool _isAddingCompleted;
+
+        /// <summary>
+        /// Gets whether this <see cref="T:Renci.SshNet.Common.LinkedListQueue`1"/> has been marked as complete for adding and is empty.
+        /// </summary>
+        /// <value>Whether this queue has been marked as complete for adding and is empty.</value>
+        public bool IsCompleted
+        {
+            get { return _isAddingCompleted && _first == null && _last == null; }
+        }
+
+        /// <summary>
+        /// Gets whether this <see cref="T:Renci.SshNet.Common.LinkedListQueue`1"/> has been marked as complete for adding.
+        /// </summary>
+        /// <value>Whether this queue has been marked as complete for adding.</value>
+        public bool IsAddingCompleted
+        {
+            get { return _isAddingCompleted; }
+            set
+            {
+                lock (_lock)
+                {
+                    _isAddingCompleted = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Adds the item to <see cref="T:Renci.SshNet.Common.LinkedListQueue`1"/>.
+        /// </summary>
+        /// <param name="item">The item to be added to the queue. The value can be a null reference.</param>
+        public void Add(T item)
+        {
+            lock (_lock)
+            {
+                if (_isAddingCompleted)
+                    return;
+
+                var entry = new Entry<T>();
+                entry.Item = item;
+
+                if (_last != null)
+                {
+                    _last.Next = entry;
+                }
+
+                _last = entry;
+
+                if (_first == null)
+                {
+                    _first = entry;
+                }
+
+                Monitor.PulseAll(_lock);
+            }
+        }
+
+        /// <summary>
+        /// Marks the <see cref="T:Renci.SshNet.Common.LinkedListQueue`1"/> instances as not accepting any more additions.
+        /// </summary>
+        public void CompleteAdding()
+        {
+            lock (_lock)
+            {
+                IsAddingCompleted = true;
+                Monitor.PulseAll(_lock);
+            }
+        }
+
+        /// <summary>
+        /// Tries to remove an item from the <see cref="T:Renci.SshNet.Common.LinkedListQueue`1"/>.
+        /// </summary>
+        /// <returns><c>true</c>, if an item could be removed; otherwise <c>false</c>.</returns>
+        /// <param name="item">The item to be removed from the queue.</param>
+        public bool TryTake(out T item)
+        {
+            lock (_lock)
+            {
+                while (_first == null && !_isAddingCompleted)
+                    Monitor.Wait(_lock);
+
+                if (_first == null && _isAddingCompleted)
+                {
+                    item = default(T);
+                    return false;
+                }
+
+                item = _first.Item;
+                _first = _first.Next;
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Releases all resource used by the <see cref="T:Renci.SshNet.Common.LinkedListQueue`1"/> object.
+        /// </summary>
+        /// <remarks>Call <see cref="Dispose"/> when you are finished using the
+        /// <see cref="T:Renci.SshNet.Common.LinkedListQueue`1"/>. The <see cref="Dispose"/> method leaves the
+        /// <see cref="T:Renci.SshNet.Common.LinkedListQueue`1"/> in an unusable state. After calling
+        /// <see cref="Dispose"/>, you must release all references to the
+        /// <see cref="T:Renci.SshNet.Common.LinkedListQueue`1"/> so the garbage collector can reclaim the memory that
+        /// the <see cref="T:Renci.SshNet.Common.LinkedListQueue`1"/> was occupying.</remarks>
+        public void Dispose()
+        {
+            lock (_lock)
+            {
+                _first = null;
+                _last = null;
+                _isAddingCompleted = true;
+            }
+        }
+    }
+}

--- a/src/Renci.SshNet/Common/Pipe.cs
+++ b/src/Renci.SshNet/Common/Pipe.cs
@@ -1,0 +1,47 @@
+﻿namespace Renci.SshNet.Common
+{
+    using System;
+    using System.IO;
+
+    /// <summary>
+    /// A generic pipe to pass through data.
+    /// </summary>
+    internal class Pipe : IDisposable
+    {
+        private readonly LinkedListQueue<byte[]> _queue;
+
+        /// <summary>
+        /// Gets the input stream.
+        /// </summary>
+        /// <value>The input stream.</value>
+        public Stream InputStream { get; private set; }
+
+        /// <summary>
+        /// Gets the output stream.
+        /// </summary>
+        /// <value>The output stream.</value>
+        public Stream OutputStream { get; private set; }
+
+        public Pipe()
+        {
+            _queue = new LinkedListQueue<byte[]>();
+            InputStream = new PipeInputStream(_queue);
+            OutputStream = new PipeOutputStream(_queue);
+        }
+
+        /// <summary>
+        /// Releases all resource used by the <see cref="T:Renci.SshNet.Common.Pipe"/> object.
+        /// </summary>
+        /// <remarks>Call <see cref="Dispose"/> when you are finished using the <see cref="T:Renci.SshNet.Common.Pipe"/>. The
+        /// <see cref="Dispose"/> method leaves the <see cref="T:Renci.SshNet.Common.Pipe"/> in an unusable state. After
+        /// calling <see cref="Dispose"/>, you must release all references to the
+        /// <see cref="T:Renci.SshNet.Common.Pipe"/> so the garbage collector can reclaim the memory that the
+        /// <see cref="T:Renci.SshNet.Common.Pipe"/> was occupying.</remarks>
+        public void Dispose()
+        {
+            OutputStream.Dispose();
+            InputStream.Dispose();
+            _queue.Dispose();
+        }
+    }
+}

--- a/src/Renci.SshNet/Common/PipeInputStream.cs
+++ b/src/Renci.SshNet/Common/PipeInputStream.cs
@@ -1,0 +1,112 @@
+﻿namespace Renci.SshNet.Common 
+{
+    using System;
+    using System.IO;
+
+    internal class PipeInputStream : Stream
+    {
+        private LinkedListQueue<byte[]> _queue;
+        private byte[] _current;
+        private int _currentPosition;
+        private bool _isDisposed;
+
+        public PipeInputStream(LinkedListQueue<byte[]> queue)
+        {
+            _queue = queue;
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (buffer == null)
+                throw new ArgumentNullException("buffer");
+            if (offset + count > buffer.Length)
+                throw new ArgumentException("The sum of offset and count is greater than the buffer length.");
+            if (offset < 0 || count < 0)
+                throw new ArgumentOutOfRangeException("offset", "offset or count is negative.");
+            if (_isDisposed)
+                throw CreateObjectDisposedException();
+
+            if (_current == null || _currentPosition == _current.Length)
+            {
+                if (_queue.IsCompleted || !_queue.TryTake(out _current))
+                    return 0;
+
+                _currentPosition = 0;
+            }
+
+            var avail = _current.Length - _currentPosition;
+            if (count > avail)
+                count = avail;
+
+            Buffer.BlockCopy(_current, _currentPosition, buffer, offset, count);
+
+            _currentPosition += count;
+            return count;
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override bool CanRead
+        {
+            get { return true; }
+        }
+
+        public override bool CanSeek
+        {
+            get { return false; }
+        }
+
+        public override bool CanWrite
+        {
+            get { return false; }
+        }
+
+        public override long Length
+        {
+            get
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        public override long Position
+        {
+            get
+            {
+                throw new NotSupportedException();
+            }
+            set
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            _isDisposed = true;
+        }
+
+        private ObjectDisposedException CreateObjectDisposedException()
+        {
+            return new ObjectDisposedException(GetType().FullName);
+        }
+    }
+}

--- a/src/Renci.SshNet/Common/PipeInputStream.cs
+++ b/src/Renci.SshNet/Common/PipeInputStream.cs
@@ -65,7 +65,7 @@
 
         public override bool CanRead
         {
-            get { return true; }
+            get { return !_isDisposed; }
         }
 
         public override bool CanSeek

--- a/src/Renci.SshNet/Common/PipeOutputStream.cs
+++ b/src/Renci.SshNet/Common/PipeOutputStream.cs
@@ -40,10 +40,8 @@
                 throw new ArgumentException("The sum of offset and count is greater than the buffer length.");
             if (offset < 0 || count < 0)
                 throw new ArgumentOutOfRangeException("offset", "offset or count is negative.");
-            if (_isDisposed)
+            if (_isDisposed || _queue.IsAddingCompleted)
                 throw CreateObjectDisposedException();
-            if (_queue.IsAddingCompleted)
-                return;
 
             byte[] tmp = new byte[count];
             Buffer.BlockCopy(buffer, offset, tmp, 0, count);
@@ -62,7 +60,7 @@
 
         public override bool CanWrite
         {
-            get { return true; }
+            get { return !_isDisposed; }
         }
 
         public override long Length

--- a/src/Renci.SshNet/Common/PipeOutputStream.cs
+++ b/src/Renci.SshNet/Common/PipeOutputStream.cs
@@ -1,0 +1,111 @@
+﻿namespace Renci.SshNet.Common 
+{
+    using System;
+    using System.IO;
+
+    internal class PipeOutputStream : Stream
+    {
+        private LinkedListQueue<byte[]> _queue;
+        private bool _isDisposed;
+
+        public PipeOutputStream(LinkedListQueue<byte[]> queue)
+        {
+            _queue = queue;
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            if (buffer == null)
+                throw new ArgumentNullException("buffer");
+            if (offset + count > buffer.Length)
+                throw new ArgumentException("The sum of offset and count is greater than the buffer length.");
+            if (offset < 0 || count < 0)
+                throw new ArgumentOutOfRangeException("offset", "offset or count is negative.");
+            if (_isDisposed)
+                throw CreateObjectDisposedException();
+            if (_queue.IsAddingCompleted)
+                return;
+
+            byte[] tmp = new byte[count];
+            Buffer.BlockCopy(buffer, offset, tmp, 0, count);
+            _queue.Add(tmp);
+        }
+
+        public override bool CanRead
+        {
+            get { return false; }
+        }
+
+        public override bool CanSeek
+        {
+            get { return false; }
+        }
+
+        public override bool CanWrite
+        {
+            get { return true; }
+        }
+
+        public override long Length
+        {
+            get
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        public override long Position
+        {
+            get
+            {
+                throw new NotSupportedException();
+            }
+            set
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        public override void Close()
+        {
+            if (!_queue.IsAddingCompleted)
+                _queue.CompleteAdding();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (!_isDisposed)
+            {
+                if (!_queue.IsAddingCompleted)
+                    _queue.CompleteAdding();
+                _isDisposed = true;
+            }
+        }
+
+        private ObjectDisposedException CreateObjectDisposedException()
+        {
+            return new ObjectDisposedException(GetType().FullName);
+        }
+    }
+}

--- a/src/Renci.SshNet/Renci.SshNet.csproj
+++ b/src/Renci.SshNet/Renci.SshNet.csproj
@@ -441,6 +441,10 @@
     <Compile Include="SshCommand.cs" />
     <Compile Include="SshMessageFactory.cs" />
     <Compile Include="SubsystemSession.cs" />
+    <Compile Include="Common\Pipe.cs" />
+    <Compile Include="Common\PipeInputStream.cs" />
+    <Compile Include="Common\PipeOutputStream.cs" />
+    <Compile Include="Common\LinkedListQueue.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\Renci.SshNet.snk">


### PR DESCRIPTION
 + More efficient when moving large amounts of binary data
    * Speedup on Mono: ~1.71x
    * Speedup on Win10: ~1.39x
 + No in-memory buffering of data
    * Except if you use the Execute() method to return a result
      string
    * The result string will be empty if you have read the output
      stream completely
 - Unless you close or have something reading the error stream it
   can completely block the execution as it will hang the event
   handler indefinitely if no one is reading the other end
 - Reading from PipeStream will now always block until EOF
 - Writing to PipeStream will now always block until a reader has
   completely emptied it

This has not been tested with anything else than SshCommand in a very limited way. I'm planning on adding InputStream on top of this if this refactor is in the right direction.