### PR TITLE
Remove unused variables, fixes mcs warnings on Mono

### DIFF
--- a/src/Renci.SshNet/ScpClient.NET.cs
+++ b/src/Renci.SshNet/ScpClient.NET.cs
@@ -202,7 +202,6 @@ namespace Renci.SshNet
                     SendConfirmation(channel); //  Send reply
 
                     //  Read directory
-                    var mode = long.Parse(match.Result("${mode}"));
                     var filename = match.Result("${filename}");
 
                     DirectoryInfo newDirectoryInfo;
@@ -230,7 +229,6 @@ namespace Renci.SshNet
                     //  Read file
                     SendConfirmation(channel); //  Send reply
 
-                    var mode = match.Result("${mode}");
                     var length = long.Parse(match.Result("${length}"));
                     var fileName = match.Result("${filename}");
 

--- a/src/Renci.SshNet/ScpClient.cs
+++ b/src/Renci.SshNet/ScpClient.cs
@@ -231,7 +231,6 @@ namespace Renci.SshNet
                     //  Read file
                     SendConfirmation(channel); //  Send reply
 
-                    var mode = match.Result("${mode}");
                     var length = long.Parse(match.Result("${length}"));
                     var fileName = match.Result("${filename}");
 


### PR DESCRIPTION
Some leftover variables threw errors on Mono C# compiler and the project setting of treating warnings as errors made the project uncompilable with the default setting.