### PR TITLE
Change to Session.cs to address .NET 3.5 compiled version of SSH exce…

### DIFF
--- a/src/Renci.SshNet/Session.cs
+++ b/src/Renci.SshNet/Session.cs
@@ -1817,8 +1817,6 @@ namespace Renci.SshNet
         {
             try
             {
-                var readSockets = new List<Socket> {_socket};
-
                 // remain in message loop until socket is shut down or until we're disconnecting
                 while (_socket.IsConnected())
                 {
@@ -1836,7 +1834,7 @@ namespace Renci.SshNet
                     // perform a blocking select to determine whether there's is data available to be
                     // read; we do not use a blocking read to allow us to use Socket.Poll to determine
                     // if the connection is still available (in IsSocketConnected
-                    Socket.Select(readSockets, null, null, -1);
+                    _socket.Poll(-1, SelectMode.SelectRead);
 
                     // the Select invocation will be interrupted in one of the following conditions:
                     // * data is available to be read


### PR DESCRIPTION
…ption after client connect #113

Addressing the outstanding issue .NET 3.5 compiled version of SSH exception after client connect #113 opened by haimiko. 

Replaced Socket.Select(readSockets, null, null, -1) with _socket.Poll(-1, SelectMode.SelectRead);

When executing the .Net 3.5 code in a Visual Studio 2008 C++ CLR session Socket.Select would return an ArgumentNullException. Upon investigation while reading in data the readSockets list would go from a count of 1 to a count of 0 upon execution of Socket.Select. I'm thinking that Socket.Select was editing the contents of the array.

Looking at the comments it appears that the use of Socket.Select over .Poll is preferred so please feel free to disregard these changes.