### PR TITLE
Fixed SOCKS4 and SOCKS5 proxies sending the incorrect port.

### DIFF
--- a/src/Renci.SshNet/Session.cs
+++ b/src/Renci.SshNet/Session.cs
@@ -1908,8 +1908,9 @@ namespace Renci.SshNet
             SocketWriteByte(0x01);
 
             //  Send port
-            SocketWriteByte((byte)(ConnectionInfo.Port / 0xFF));
-            SocketWriteByte((byte)(ConnectionInfo.Port % 0xFF));
+            var portBytes = BitConverter.GetBytes(IPAddress.HostToNetworkOrder((short)ConnectionInfo.Port));
+            SocketWriteByte(portBytes[0]);
+            SocketWriteByte(portBytes[1]);
 
             //  Send IP
             var ipAddress = DnsAbstraction.GetHostAddresses(ConnectionInfo.Host)[0];
@@ -2039,8 +2040,9 @@ namespace Renci.SshNet
             }
 
             //  Send port
-            SocketWriteByte((byte)(ConnectionInfo.Port / 0xFF));
-            SocketWriteByte((byte)(ConnectionInfo.Port % 0xFF));
+            var portBytes = BitConverter.GetBytes(IPAddress.HostToNetworkOrder((short)ConnectionInfo.Port));
+            SocketWriteByte(portBytes[0]);
+            SocketWriteByte(portBytes[1]);
 
             //  Read Server SOCKS5 version
             if (SocketReadByte() != 5)


### PR DESCRIPTION
When establishing a connection with a SOCKS4 or SOCKS5 proxy, the port was being sent incorrectly. The masking logic was incorrect and it ignored the endianness of the host computer. Both issues are resolved,

Tangentially related to issue #99 as the given advice wouldn't work due to this bug.