### PR TITLE
Fix a hangup when connecting to Windows Phone SFTP

### DIFF
--- a/src/Renci.SshNet/Channels/Channel.cs
+++ b/src/Renci.SshNet/Channels/Channel.cs
@@ -737,6 +737,11 @@ namespace Renci.SshNet.Channels
                 try
                 {
                     OnFailure();
+                    // Close the channel since it failed anyway;
+                    // It will also fire Close events for request failures and channel failures
+                    // this will trigger IChannel close callbacks so that listeners can handle i.e. request failures.
+                    // (this fixes a hangup when connecting to Windows Phones)
+                    OnClose();
                 }
                 catch (Exception ex)
                 {
@@ -773,7 +778,7 @@ namespace Renci.SshNet.Channels
                 lock (_serverWindowSizeLock)
                 {
                     var serverWindowSize = RemoteWindowSize;
-                    if (serverWindowSize == 0U)
+                    if (serverWindowSize == 0)
                     {
                         // allow us to be signal when remote window size is adjusted
                         _channelServerWindowAdjustWaitHandle.Reset();


### PR DESCRIPTION
This fix would allow WinSSHFS to handle request failures, which are now silently dropped since IChannel does not expose all types of failure events. The problem occurs after issuing a shell command (exec request) that returns a negative error code with a subsequent channel failure response from the server. WinSSHFS waits for either success and closed/exception events which never come, since the channel is still open but no exception has been raised.
Technically, SSH.NET treats channel failures as request failures, so this might be a wrong way to fix things (e.g. break everything)