### PR TITLE
Fix for data corruption

### DIFF
--- a/src/Renci.SshNet/Abstractions/ThreadAbstraction.cs
+++ b/src/Renci.SshNet/Abstractions/ThreadAbstraction.cs
@@ -36,6 +36,8 @@ namespace Renci.SshNet.Abstractions
         /// <param name="action">The action to execute.</param>
         public static void ExecuteThread(Action action)
         {
+            if (action == null)
+                throw new ArgumentNullException("action");
 #if FEATURE_THREAD_THREADPOOL
             System.Threading.ThreadPool.QueueUserWorkItem(o => action());
 #elif FEATURE_THREAD_TAP

--- a/src/Renci.SshNet/Sftp/SftpFileStream.cs
+++ b/src/Renci.SshNet/Sftp/SftpFileStream.cs
@@ -362,7 +362,7 @@ namespace Renci.SshNet.Sftp
                         {
                             // copy remaining bytes to read buffer
                             _bufferLen = data.Length - bytesToWriteToCallerBuffer;
-                            Buffer.BlockCopy(data, count, _readBuffer, 0, _bufferLen);
+                            Buffer.BlockCopy(data, bytesToWriteToCallerBuffer, _readBuffer, 0, _bufferLen);
                         }
                     }
                     else


### PR DESCRIPTION
Fix for data corruption when reading to a buffer that is smaller than the internal buffer. This was introduced with the last commit 5 days ago.