### PR TITLE
ShellStream: Write skips a byte when buffer is full

### DIFF
--- a/src/Renci.SshNet/ShellStream.cs
+++ b/src/Renci.SshNet/ShellStream.cs
@@ -226,9 +226,9 @@ namespace Renci.SshNet
         {
             foreach (var b in buffer.Take(offset, count))
             {
+                _outgoing.Enqueue(b);
                 if (_outgoing.Count < BufferSize)
                 {
-                    _outgoing.Enqueue(b);
                     continue;
                 }
 


### PR DESCRIPTION
Fix every 1025th byte being skipped