### PR TITLE
Support forward to unix socket

### DIFF
--- a/src/Renci.SshNet.NET35/Renci.SshNet.NET35.csproj
+++ b/src/Renci.SshNet.NET35/Renci.SshNet.NET35.csproj
@@ -410,6 +410,9 @@
     <Compile Include="..\Renci.SshNet\Messages\Connection\ChannelOpen\DirectTcpipChannelInfo.cs">
       <Link>Messages\Connection\ChannelOpen\DirectTcpipChannelInfo.cs</Link>
     </Compile>
+    <Compile Include="..\Renci.SshNet\Messages\Connection\ChannelOpen\DirectStreamLocalChannelInfo.cs">
+      <Link>Messages\Connection\ChannelOpen\DirectStreamLocalChannelInfo.cs</Link>
+    </Compile>
     <Compile Include="..\Renci.SshNet\Messages\Connection\ChannelOpen\ForwardedTcpipChannelInfo.cs">
       <Link>Messages\Connection\ChannelOpen\ForwardedTcpipChannelInfo.cs</Link>
     </Compile>

--- a/src/Renci.SshNet.NET35/Renci.SshNet.NET35.csproj
+++ b/src/Renci.SshNet.NET35/Renci.SshNet.NET35.csproj
@@ -86,6 +86,18 @@
     <Compile Include="..\Renci.SshNet\Channels\ChannelDirectTcpip.cs">
       <Link>Channels\ChannelDirectTcpip.cs</Link>
     </Compile>
+    <Compile Include="..\Renci.SshNet\Channels\ChannelDirectBase.cs">
+      <Link>Channels\ChannelDirectBase.cs</Link>
+    </Compile>
+    <Compile Include="..\Renci.SshNet\Channels\ChannelDirectStreamLocal.cs">
+      <Link>Channels\ChannelDirectStreamLocal.cs</Link>
+    </Compile>
+    <Compile Include="..\Renci.SshNet\Channels\IChannelDirectBase.cs">
+      <Link>Channels\IChannelDirectBase.cs</Link>
+    </Compile>
+    <Compile Include="..\Renci.SshNet\Channels\IChannelDirectStreamLocal.cs">
+      <Link>Channels\IChannelDirectStreamLocal.cs</Link>
+    </Compile>
     <Compile Include="..\Renci.SshNet\Channels\ChannelForwardedTcpip.cs">
       <Link>Channels\ChannelForwardedTcpip.cs</Link>
     </Compile>

--- a/src/Renci.SshNet.Silverlight/Renci.SshNet.Silverlight.csproj
+++ b/src/Renci.SshNet.Silverlight/Renci.SshNet.Silverlight.csproj
@@ -413,6 +413,9 @@
     <Compile Include="..\Renci.SshNet\Messages\Connection\ChannelOpen\DirectTcpipChannelInfo.cs">
       <Link>Messages\Connection\ChannelOpen\DirectTcpipChannelInfo.cs</Link>
     </Compile>
+    <Compile Include="..\Renci.SshNet\Messages\Connection\ChannelOpen\DirectStreamLocalChannelInfo.cs">
+      <Link>Messages\Connection\ChannelOpen\DirectStreamLocalChannelInfo.cs</Link>
+    </Compile>
     <Compile Include="..\Renci.SshNet\Messages\Connection\ChannelOpen\ForwardedTcpipChannelInfo.cs">
       <Link>Messages\Connection\ChannelOpen\ForwardedTcpipChannelInfo.cs</Link>
     </Compile>

--- a/src/Renci.SshNet.Silverlight/Renci.SshNet.Silverlight.csproj
+++ b/src/Renci.SshNet.Silverlight/Renci.SshNet.Silverlight.csproj
@@ -101,6 +101,18 @@
     <Compile Include="..\Renci.SshNet\Channels\ChannelDirectTcpip.cs">
       <Link>Channels\ChannelDirectTcpip.cs</Link>
     </Compile>
+    <Compile Include="..\Renci.SshNet\Channels\ChannelDirectBase.cs">
+      <Link>Channels\ChannelDirectBase.cs</Link>
+    </Compile>
+    <Compile Include="..\Renci.SshNet\Channels\ChannelDirectStreamLocal.cs">
+      <Link>Channels\ChannelDirectStreamLocal.cs</Link>
+    </Compile>
+    <Compile Include="..\Renci.SshNet\Channels\IChannelDirectBase.cs">
+      <Link>Channels\IChannelDirectBase.cs</Link>
+    </Compile>
+    <Compile Include="..\Renci.SshNet\Channels\IChannelDirectStreamLocal.cs">
+      <Link>Channels\IChannelDirectStreamLocal.cs</Link>
+    </Compile>
     <Compile Include="..\Renci.SshNet\Channels\ChannelForwardedTcpip.cs">
       <Link>Channels\ChannelForwardedTcpip.cs</Link>
     </Compile>

--- a/src/Renci.SshNet.Silverlight5/Renci.SshNet.Silverlight5.csproj
+++ b/src/Renci.SshNet.Silverlight5/Renci.SshNet.Silverlight5.csproj
@@ -107,6 +107,18 @@
     <Compile Include="..\Renci.SshNet\Channels\ChannelDirectTcpip.cs">
       <Link>Channels\ChannelDirectTcpip.cs</Link>
     </Compile>
+    <Compile Include="..\Renci.SshNet\Channels\ChannelDirectBase.cs">
+      <Link>Channels\ChannelDirectBase.cs</Link>
+    </Compile>
+    <Compile Include="..\Renci.SshNet\Channels\ChannelDirectStreamLocal.cs">
+      <Link>Channels\ChannelDirectStreamLocal.cs</Link>
+    </Compile>
+    <Compile Include="..\Renci.SshNet\Channels\IChannelDirectBase.cs">
+      <Link>Channels\IChannelDirectBase.cs</Link>
+    </Compile>
+    <Compile Include="..\Renci.SshNet\Channels\IChannelDirectStreamLocal.cs">
+      <Link>Channels\IChannelDirectStreamLocal.cs</Link>
+    </Compile>
     <Compile Include="..\Renci.SshNet\Channels\ChannelForwardedTcpip.cs">
       <Link>Channels\ChannelForwardedTcpip.cs</Link>
     </Compile>

--- a/src/Renci.SshNet.Silverlight5/Renci.SshNet.Silverlight5.csproj
+++ b/src/Renci.SshNet.Silverlight5/Renci.SshNet.Silverlight5.csproj
@@ -422,6 +422,9 @@
     <Compile Include="..\Renci.SshNet\Messages\Connection\ChannelOpen\DirectTcpipChannelInfo.cs">
       <Link>Messages\Connection\ChannelOpen\DirectTcpipChannelInfo.cs</Link>
     </Compile>
+    <Compile Include="..\Renci.SshNet\Messages\Connection\ChannelOpen\DirectStreamLocalChannelInfo.cs">
+      <Link>Messages\Connection\ChannelOpen\DirectStreamLocalChannelInfo.cs</Link>
+    </Compile>
     <Compile Include="..\Renci.SshNet\Messages\Connection\ChannelOpen\ForwardedTcpipChannelInfo.cs">
       <Link>Messages\Connection\ChannelOpen\ForwardedTcpipChannelInfo.cs</Link>
     </Compile>

--- a/src/Renci.SshNet.Tests/Classes/Messages/Connection/ChannelDataMessageTest.cs
+++ b/src/Renci.SshNet.Tests/Classes/Messages/Connection/ChannelDataMessageTest.cs
@@ -98,7 +98,7 @@ namespace Renci.SshNet.Tests.Classes.Messages.Connection
             var random = new Random();
 
             var localChannelNumber = (uint) random.Next(0, int.MaxValue);
-            var data = new byte[random.Next(10, 20)];
+            var data = new byte[random.Next(11, 20)];
             random.NextBytes(data);
             var offset = random.Next(2, 4);
             var size = random.Next(5, 9);
@@ -133,7 +133,7 @@ namespace Renci.SshNet.Tests.Classes.Messages.Connection
             var random = new Random();
 
             var localChannelNumber = (uint) random.Next(0, int.MaxValue);
-            var data = new byte[random.Next(10, 20)];
+            var data = new byte[random.Next(11, 20)];
             random.NextBytes(data);
 
             var offset = random.Next(2, 4);

--- a/src/Renci.SshNet.UAP10/Renci.SshNet.UAP10.csproj
+++ b/src/Renci.SshNet.UAP10/Renci.SshNet.UAP10.csproj
@@ -471,6 +471,9 @@
     <Compile Include="..\Renci.SshNet\Messages\Connection\ChannelOpen\DirectTcpipChannelInfo.cs">
       <Link>Messages\Connection\ChannelOpen\DirectTcpipChannelInfo.cs</Link>
     </Compile>
+    <Compile Include="..\Renci.SshNet\Messages\Connection\ChannelOpen\DirectStreamLocalChannelInfo.cs">
+      <Link>Messages\Connection\ChannelOpen\DirectStreamLocalChannelInfo.cs</Link>
+    </Compile>
     <Compile Include="..\Renci.SshNet\Messages\Connection\ChannelOpen\ForwardedTcpipChannelInfo.cs">
       <Link>Messages\Connection\ChannelOpen\ForwardedTcpipChannelInfo.cs</Link>
     </Compile>

--- a/src/Renci.SshNet.UAP10/Renci.SshNet.UAP10.csproj
+++ b/src/Renci.SshNet.UAP10/Renci.SshNet.UAP10.csproj
@@ -147,6 +147,18 @@
     <Compile Include="..\Renci.SshNet\Channels\ChannelDirectTcpip.cs">
       <Link>Channels\ChannelDirectTcpip.cs</Link>
     </Compile>
+    <Compile Include="..\Renci.SshNet\Channels\ChannelDirectBase.cs">
+      <Link>Channels\ChannelDirectBase.cs</Link>
+    </Compile>
+    <Compile Include="..\Renci.SshNet\Channels\ChannelDirectStreamLocal.cs">
+      <Link>Channels\ChannelDirectStreamLocal.cs</Link>
+    </Compile>
+    <Compile Include="..\Renci.SshNet\Channels\IChannelDirectBase.cs">
+      <Link>Channels\IChannelDirectBase.cs</Link>
+    </Compile>
+    <Compile Include="..\Renci.SshNet\Channels\IChannelDirectStreamLocal.cs">
+      <Link>Channels\IChannelDirectStreamLocal.cs</Link>
+    </Compile>
     <Compile Include="..\Renci.SshNet\Channels\ChannelForwardedTcpip.cs">
       <Link>Channels\ChannelForwardedTcpip.cs</Link>
     </Compile>

--- a/src/Renci.SshNet.WindowsPhone/Renci.SshNet.WindowsPhone.csproj
+++ b/src/Renci.SshNet.WindowsPhone/Renci.SshNet.WindowsPhone.csproj
@@ -89,6 +89,18 @@
     <Compile Include="..\Renci.SshNet\Channels\ChannelDirectTcpip.cs">
       <Link>Channels\ChannelDirectTcpip.cs</Link>
     </Compile>
+    <Compile Include="..\Renci.SshNet\Channels\ChannelDirectBase.cs">
+      <Link>Channels\ChannelDirectBase.cs</Link>
+    </Compile>
+    <Compile Include="..\Renci.SshNet\Channels\ChannelDirectStreamLocal.cs">
+      <Link>Channels\ChannelDirectStreamLocal.cs</Link>
+    </Compile>
+    <Compile Include="..\Renci.SshNet\Channels\IChannelDirectBase.cs">
+      <Link>Channels\IChannelDirectBase.cs</Link>
+    </Compile>
+    <Compile Include="..\Renci.SshNet\Channels\IChannelDirectStreamLocal.cs">
+      <Link>Channels\IChannelDirectStreamLocal.cs</Link>
+    </Compile>
     <Compile Include="..\Renci.SshNet\Channels\ChannelForwardedTcpip.cs">
       <Link>Channels\ChannelForwardedTcpip.cs</Link>
     </Compile>

--- a/src/Renci.SshNet.WindowsPhone/Renci.SshNet.WindowsPhone.csproj
+++ b/src/Renci.SshNet.WindowsPhone/Renci.SshNet.WindowsPhone.csproj
@@ -404,6 +404,9 @@
     <Compile Include="..\Renci.SshNet\Messages\Connection\ChannelOpen\DirectTcpipChannelInfo.cs">
       <Link>Messages\Connection\ChannelOpen\DirectTcpipChannelInfo.cs</Link>
     </Compile>
+    <Compile Include="..\Renci.SshNet\Messages\Connection\ChannelOpen\DirectStreamLocalChannelInfo.cs">
+      <Link>Messages\Connection\ChannelOpen\DirectStreamLocalChannelInfo.cs</Link>
+    </Compile>
     <Compile Include="..\Renci.SshNet\Messages\Connection\ChannelOpen\ForwardedTcpipChannelInfo.cs">
       <Link>Messages\Connection\ChannelOpen\ForwardedTcpipChannelInfo.cs</Link>
     </Compile>

--- a/src/Renci.SshNet.WindowsPhone8/Renci.SshNet.WindowsPhone8.csproj
+++ b/src/Renci.SshNet.WindowsPhone8/Renci.SshNet.WindowsPhone8.csproj
@@ -451,6 +451,9 @@
     <Compile Include="..\Renci.SshNet\Messages\Connection\ChannelOpen\DirectTcpipChannelInfo.cs">
       <Link>Messages\Connection\ChannelOpen\DirectTcpipChannelInfo.cs</Link>
     </Compile>
+    <Compile Include="..\Renci.SshNet\Messages\Connection\ChannelOpen\DirectStreamLocalChannelInfo.cs">
+      <Link>Messages\Connection\ChannelOpen\DirectStreamLocalChannelInfo.cs</Link>
+    </Compile>
     <Compile Include="..\Renci.SshNet\Messages\Connection\ChannelOpen\ForwardedTcpipChannelInfo.cs">
       <Link>Messages\Connection\ChannelOpen\ForwardedTcpipChannelInfo.cs</Link>
     </Compile>

--- a/src/Renci.SshNet.WindowsPhone8/Renci.SshNet.WindowsPhone8.csproj
+++ b/src/Renci.SshNet.WindowsPhone8/Renci.SshNet.WindowsPhone8.csproj
@@ -130,6 +130,18 @@
     <Compile Include="..\Renci.SshNet\Channels\ChannelDirectTcpip.cs">
       <Link>Channels\ChannelDirectTcpip.cs</Link>
     </Compile>
+    <Compile Include="..\Renci.SshNet\Channels\ChannelDirectBase.cs">
+      <Link>Channels\ChannelDirectBase.cs</Link>
+    </Compile>
+    <Compile Include="..\Renci.SshNet\Channels\ChannelDirectStreamLocal.cs">
+      <Link>Channels\ChannelDirectStreamLocal.cs</Link>
+    </Compile>
+    <Compile Include="..\Renci.SshNet\Channels\IChannelDirectBase.cs">
+      <Link>Channels\IChannelDirectBase.cs</Link>
+    </Compile>
+    <Compile Include="..\Renci.SshNet\Channels\IChannelDirectStreamLocal.cs">
+      <Link>Channels\IChannelDirectStreamLocal.cs</Link>
+    </Compile>
     <Compile Include="..\Renci.SshNet\Channels\ChannelForwardedTcpip.cs">
       <Link>Channels\ChannelForwardedTcpip.cs</Link>
     </Compile>

--- a/src/Renci.SshNet/Channels/ChannelDirectBase.cs
+++ b/src/Renci.SshNet/Channels/ChannelDirectBase.cs
@@ -1,0 +1,285 @@
+﻿using System;
+using System.Net.Sockets;
+using System.Threading;
+using Renci.SshNet.Abstractions;
+using Renci.SshNet.Common;
+using Renci.SshNet.Messages.Connection;
+
+namespace Renci.SshNet.Channels
+{
+    /// <summary>
+    /// Base class for "direct-*" SSH channels.
+    /// </summary>
+    internal abstract class ChannelDirectBase : ClientChannel, IChannelDirectBase
+    {
+        private readonly object _socketLock = new object();
+
+        protected EventWaitHandle _channelOpen = new AutoResetEvent(false);
+        private EventWaitHandle _channelData = new AutoResetEvent(false);
+        protected IForwardedPort _forwardedPort;
+        protected Socket _socket;
+
+        /// <summary>
+        /// Initializes a new <see cref="ChannelDirectBase"/> instance.
+        /// </summary>
+        /// <param name="session">The session.</param>
+        /// <param name="localChannelNumber">The local channel number.</param>
+        /// <param name="localWindowSize">Size of the window.</param>
+        /// <param name="localPacketSize">Size of the packet.</param>
+        public ChannelDirectBase(ISession session, uint localChannelNumber, uint localWindowSize, uint localPacketSize)
+            : base(session, localChannelNumber, localWindowSize, localPacketSize)
+        {
+        }
+
+        /// <summary>
+        /// Occurs as the forwarded port is being stopped.
+        /// </summary>
+        protected void ForwardedPort_Closing(object sender, EventArgs eventArgs)
+        {
+            // signal to the client that we will not send anything anymore; this should also interrupt the
+            // blocking receive in Bind if the client sends FIN/ACK in time
+            ShutdownSocket(SocketShutdown.Send);
+
+            // if the FIN/ACK is not sent in time by the remote client, then interrupt the blocking receive
+            // by closing the socket
+            CloseSocket();
+        }
+
+        /// <summary>
+        /// Binds channel to remote host.
+        /// </summary>
+        public void Bind()
+        {
+            //  Cannot bind if channel is not open
+            if (!IsOpen)
+                return;
+
+            var buffer = new byte[RemotePacketSize];
+
+            SocketAbstraction.ReadContinuous(_socket, buffer, 0, buffer.Length, SendData);
+
+            // even though the client has disconnected, we still want to properly close the
+            // channel
+            //
+            // we'll do this in in Close() - invoked through Dispose(bool) - that way we have
+            // a single place from which we send an SSH_MSG_CHANNEL_EOF message and wait for
+            // the SSH_MSG_CHANNEL_CLOSE message
+        }
+
+        /// <summary>
+        /// Closes the socket, hereby interrupting the blocking receive in <see cref="Bind()"/>.
+        /// </summary>
+        private void CloseSocket()
+        {
+            if (_socket == null)
+                return;
+
+            lock (_socketLock)
+            {
+                if (_socket == null)
+                    return;
+
+                // closing a socket actually disposes the socket, so we can safely dereference
+                // the field to avoid entering the lock again later
+                _socket.Dispose();
+                _socket = null;
+            }
+        }
+
+        /// <summary>
+        /// Shuts down the socket.
+        /// </summary>
+        /// <param name="how">One of the <see cref="SocketShutdown"/> values that specifies the operation that will no longer be allowed.</param>
+        private void ShutdownSocket(SocketShutdown how)
+        {
+            if (_socket == null)
+                return;
+
+            lock (_socketLock)
+            {
+                if (!_socket.IsConnected())
+                    return;
+
+                try
+                {
+                    _socket.Shutdown(how);
+                }
+                catch (SocketException ex)
+                {
+                    // TODO: log as warning
+                    DiagnosticAbstraction.Log("Failure shutting down socket: " + ex);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Closes the channel, waiting for the SSH_MSG_CHANNEL_CLOSE message to be received from the server.
+        /// </summary>
+        protected override void Close()
+        {
+            var forwardedPort = _forwardedPort;
+            if (forwardedPort != null)
+            {
+                forwardedPort.Closing -= ForwardedPort_Closing;
+                _forwardedPort = null;
+            }
+
+            // signal to the client that we will not send anything anymore; this will also interrupt the
+            // blocking receive in Bind if the client sends FIN/ACK in time
+            //
+            // if the FIN/ACK is not sent in time, the socket will be closed after the channel is closed
+            ShutdownSocket(SocketShutdown.Send);
+
+            // close the SSH channel
+            base.Close();
+
+            // close the socket
+            CloseSocket();
+        }
+
+        /// <summary>
+        /// Called when channel data is received.
+        /// </summary>
+        /// <param name="data">The data.</param>
+        protected override void OnData(byte[] data)
+        {
+            base.OnData(data);
+
+            if (_socket != null)
+            {
+                lock (_socketLock)
+                {
+                    if (_socket.IsConnected())
+                    {
+                        SocketAbstraction.Send(_socket, data, 0, data.Length);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Called when channel is opened by the server.
+        /// </summary>
+        /// <param name="remoteChannelNumber">The remote channel number.</param>
+        /// <param name="initialWindowSize">Initial size of the window.</param>
+        /// <param name="maximumPacketSize">Maximum size of the packet.</param>
+        protected override void OnOpenConfirmation(uint remoteChannelNumber, uint initialWindowSize, uint maximumPacketSize)
+        {
+            base.OnOpenConfirmation(remoteChannelNumber, initialWindowSize, maximumPacketSize);
+
+            _channelOpen.Set();
+        }
+
+        protected override void OnOpenFailure(uint reasonCode, string description, string language)
+        {
+            base.OnOpenFailure(reasonCode, description, language);
+
+            _channelOpen.Set();
+        }
+
+        /// <summary>
+        /// Called when channel has no more data to receive.
+        /// </summary>
+        protected override void OnEof()
+        {
+            base.OnEof();
+
+            // the channel will send no more data, and hence it does not make sense to receive
+            // any more data from the client to send to the remote party (and we surely won't
+            // send anything anymore)
+            //
+            // this will also interrupt the blocking receive in Bind()
+            ShutdownSocket(SocketShutdown.Send);
+        }
+
+        /// <summary>
+        /// Called whenever an unhandled <see cref="Exception"/> occurs in <see cref="Session"/> causing
+        /// the message loop to be interrupted, or when an exception occurred processing a channel message.
+        /// </summary>
+        protected override void OnErrorOccured(Exception exp)
+        {
+            base.OnErrorOccured(exp);
+
+            // signal to the client that we will not send anything anymore; this will also interrupt the
+            // blocking receive in Bind if the client sends FIN/ACK in time
+            //
+            // if the FIN/ACK is not sent in time, the socket will be closed in Close(bool)
+            ShutdownSocket(SocketShutdown.Send);
+        }
+
+        /// <summary>
+        /// Called when the server wants to terminate the connection immmediately.
+        /// </summary>
+        /// <remarks>
+        /// The sender MUST NOT send or receive any data after this message, and
+        /// the recipient MUST NOT accept any data after receiving this message.
+        /// </remarks>
+        protected override void OnDisconnected()
+        {
+            base.OnDisconnected();
+
+            // the channel will accept or send no more data, and hence it does not make sense
+            // to accept any more data from the client (and we surely won't send anything
+            // anymore)
+            //
+            // so lets signal to the client that we will not send or receive anything anymore
+            // this will also interrupt the blocking receive in Bind()
+            ShutdownSocket(SocketShutdown.Both);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            // make sure we've unsubscribed from all session events and closed the channel
+            // before we starting disposing
+            base.Dispose(disposing);
+
+            if (disposing)
+            {
+                if (_socket != null)
+                {
+                    lock (_socketLock)
+                    {
+                        var socket = _socket;
+                        if (socket != null)
+                        {
+                            _socket = null;
+                                        socket.Dispose();
+                        }
+                    }
+                }
+
+                var channelOpen = _channelOpen;
+                if (channelOpen != null)
+                {
+                    _channelOpen = null;
+                    channelOpen.Dispose();
+                }
+
+                var channelData = _channelData;
+                if (channelData != null)
+                {
+                    _channelData = null;
+                    channelData.Dispose();
+                }
+            }
+        }
+
+        protected void Open(ChannelOpenInfo openInfo, IForwardedPort forwardedPort, Socket socket)
+        {
+            if (IsOpen)
+                throw new SshException("Channel is already open.");
+            if (!IsConnected)
+                throw new SshException("Session is not connected.");
+
+            _socket = socket;
+            _forwardedPort = forwardedPort;
+            _forwardedPort.Closing += ForwardedPort_Closing;
+
+            // open channel
+            SendMessage(new ChannelOpenMessage(LocalChannelNumber, LocalWindowSize, LocalPacketSize, openInfo));
+
+            //  Wait for channel to open
+            WaitOnHandle(_channelOpen);
+        }
+    }
+}

--- a/src/Renci.SshNet/Channels/ChannelDirectStreamLocal.cs
+++ b/src/Renci.SshNet/Channels/ChannelDirectStreamLocal.cs
@@ -1,22 +1,21 @@
-﻿using System.Net;
-using System.Net.Sockets;
+﻿using System.Net.Sockets;
 using Renci.SshNet.Messages.Connection;
 
 namespace Renci.SshNet.Channels
 {
     /// <summary>
-    /// Implements "direct-tcpip" SSH channel.
+    /// Implements "direct-streamlocal@openssh.com" SSH channel.
     /// </summary>
-    internal class ChannelDirectTcpip : ChannelDirectBase, IChannelDirectTcpip
+    internal class ChannelDirectStreamLocal : ChannelDirectBase, IChannelDirectStreamLocal
     {
         /// <summary>
-        /// Initializes a new <see cref="ChannelDirectTcpip"/> instance.
+        /// Initializes a new <see cref="ChannelDirectStreamLocal"/> instance.
         /// </summary>
         /// <param name="session">The session.</param>
         /// <param name="localChannelNumber">The local channel number.</param>
         /// <param name="localWindowSize">Size of the window.</param>
         /// <param name="localPacketSize">Size of the packet.</param>
-        public ChannelDirectTcpip(ISession session, uint localChannelNumber, uint localWindowSize, uint localPacketSize)
+        public ChannelDirectStreamLocal(ISession session, uint localChannelNumber, uint localWindowSize, uint localPacketSize)
             : base(session, localChannelNumber, localWindowSize, localPacketSize)
         {
         }
@@ -29,13 +28,12 @@ namespace Renci.SshNet.Channels
         /// </value>
         public override ChannelTypes ChannelType
         {
-            get { return ChannelTypes.DirectTcpip; }
+            get { return ChannelTypes.DirectStreamLocal; }
         }
 
-        public void Open(string remoteHost, uint port, IForwardedPort forwardedPort, Socket socket)
+        public void Open(string socketPath, IForwardedPort forwardedPort, Socket socket)
         {
-            var ep = (IPEndPoint) socket.RemoteEndPoint;
-            base.Open(new DirectTcpipChannelInfo(remoteHost, port, ep.Address.ToString(), (uint) ep.Port), forwardedPort, socket);
+            base.Open(new DirectStreamLocalChannelInfo(socketPath), forwardedPort, socket);
         }
     }
 }

--- a/src/Renci.SshNet/Channels/ChannelDirectTcpip.cs
+++ b/src/Renci.SshNet/Channels/ChannelDirectTcpip.cs
@@ -57,8 +57,16 @@ namespace Renci.SshNet.Channels
             var ep = (IPEndPoint) socket.RemoteEndPoint;
 
             // open channel
-            SendMessage(new ChannelOpenMessage(LocalChannelNumber, LocalWindowSize, LocalPacketSize,
-                new DirectTcpipChannelInfo(remoteHost, port, ep.Address.ToString(), (uint) ep.Port)));
+            if (remoteHost.IsUnixSocketAddress())
+            {
+                SendMessage(new ChannelOpenMessage(LocalChannelNumber, LocalWindowSize, LocalPacketSize,
+                    new DirectStreamLocalChannelInfo(remoteHost)));
+            }
+            else
+            {
+                SendMessage(new ChannelOpenMessage(LocalChannelNumber, LocalWindowSize, LocalPacketSize,
+                    new DirectTcpipChannelInfo(remoteHost, port, ep.Address.ToString(), (uint) ep.Port)));
+            }
             //  Wait for channel to open
             WaitOnHandle(_channelOpen);
         }

--- a/src/Renci.SshNet/Channels/ChannelTypes.cs
+++ b/src/Renci.SshNet/Channels/ChannelTypes.cs
@@ -21,6 +21,10 @@ namespace Renci.SshNet.Channels
         /// <summary>
         /// direct-tcpip
         /// </summary>
-        DirectTcpip
+        DirectTcpip,
+        /// <summary>
+        /// direct-streamlocal@openssh.com
+        /// </summary>
+        DirectStreamLocal
     }
 }

--- a/src/Renci.SshNet/Channels/IChannelDirectBase.cs
+++ b/src/Renci.SshNet/Channels/IChannelDirectBase.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Renci.SshNet.Common;
+
+namespace Renci.SshNet.Channels
+{
+    /// <summary>
+    /// A "direct-*" SSH channel.
+    /// </summary>
+    internal interface IChannelDirectBase : IDisposable
+    {
+        /// <summary>
+        /// Occurs when an exception is thrown while processing channel messages.
+        /// </summary>
+        event EventHandler<ExceptionEventArgs> Exception;
+
+        /// <summary>
+        /// Gets a value indicating whether this channel is open.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this channel is open; otherwise, <c>false</c>.
+        /// </value>
+        bool IsOpen { get; }
+
+        /// <summary>
+        /// Gets the local channel number.
+        /// </summary>
+        /// <value>
+        /// The local channel number.
+        /// </value>
+        uint LocalChannelNumber { get; }
+
+        /// <summary>
+        /// Binds the channel to the remote host.
+        /// </summary>
+        void Bind();
+    }
+}

--- a/src/Renci.SshNet/Channels/IChannelDirectStreamLocal.cs
+++ b/src/Renci.SshNet/Channels/IChannelDirectStreamLocal.cs
@@ -1,0 +1,18 @@
+﻿using System.Net.Sockets;
+
+namespace Renci.SshNet.Channels
+{
+    /// <summary>
+    /// A "direct-streamlocal@openssh.com" SSH channel.
+    /// </summary>
+    internal interface IChannelDirectStreamLocal : IChannelDirectBase
+    {
+        /// <summary>
+        /// Opens a channel for a locally forwarded Unix socket.
+        /// </summary>
+        /// <param name="socketPath">Path to the socket.</param>
+        /// <param name="forwardedPort">The forwarded port for which the channel is opened.</param>
+        /// <param name="socket">The socket to receive requests from, and send responses from the remote host to.</param>
+        void Open(string socketPath, IForwardedPort forwardedPort, Socket socket);
+    }
+}

--- a/src/Renci.SshNet/Channels/IChannelDirectTcpip.cs
+++ b/src/Renci.SshNet/Channels/IChannelDirectTcpip.cs
@@ -1,35 +1,12 @@
-﻿using System;
-using System.Net.Sockets;
-using Renci.SshNet.Common;
+﻿using System.Net.Sockets;
 
 namespace Renci.SshNet.Channels
 {
     /// <summary>
     /// A "direct-tcpip" SSH channel.
     /// </summary>
-    internal interface IChannelDirectTcpip : IDisposable
+    internal interface IChannelDirectTcpip : IChannelDirectBase
     {
-        /// <summary>
-        /// Occurs when an exception is thrown while processing channel messages.
-        /// </summary>
-        event EventHandler<ExceptionEventArgs> Exception;
-
-        /// <summary>
-        /// Gets a value indicating whether this channel is open.
-        /// </summary>
-        /// <value>
-        /// <c>true</c> if this channel is open; otherwise, <c>false</c>.
-        /// </value>
-        bool IsOpen { get; }
-
-        /// <summary>
-        /// Gets the local channel number.
-        /// </summary>
-        /// <value>
-        /// The local channel number.
-        /// </value>
-        uint LocalChannelNumber { get; }
-
         /// <summary>
         /// Opens a channel for a locally forwarded TCP/IP port.
         /// </summary>
@@ -38,10 +15,5 @@ namespace Renci.SshNet.Channels
         /// <param name="forwardedPort">The forwarded port for which the channel is opened.</param>
         /// <param name="socket">The socket to receive requests from, and send responses from the remote host to.</param>
         void Open(string remoteHost, uint port, IForwardedPort forwardedPort, Socket socket);
-
-        /// <summary>
-        /// Binds the channel to the remote host.
-        /// </summary>
-        void Bind();
     }
 }

--- a/src/Renci.SshNet/Common/Extensions.cs
+++ b/src/Renci.SshNet/Common/Extensions.cs
@@ -134,6 +134,11 @@ namespace Renci.SshNet.Common
                         IPEndPoint.MaxPort));
         }
 
+        internal static bool IsUnixSocketAddress(this string address)
+        {
+            return address.StartsWith("/");
+        }
+
         /// <summary>
         /// Returns a specified number of contiguous bytes from a given offset.
         /// </summary>

--- a/src/Renci.SshNet/ForwardedPortLocal.NET.cs
+++ b/src/Renci.SshNet/ForwardedPortLocal.NET.cs
@@ -120,11 +120,23 @@ namespace Renci.SshNet
                 RaiseRequestReceived(originatorEndPoint.Address.ToString(),
                     (uint)originatorEndPoint.Port);
 
-                using (var channel = Session.CreateChannelDirectTcpip())
+                if (RemoteAddress.IsUnixSocketAddress())
                 {
-                    channel.Exception += Channel_Exception;
-                    channel.Open(Host, Port, this, clientSocket);
-                    channel.Bind();
+                    using (var channel = Session.CreateChannelDirectStreamLocal())
+                    {
+                        channel.Exception += Channel_Exception;
+                        channel.Open(RemoteAddress, this, clientSocket);
+                        channel.Bind();
+                    }
+                }
+                else
+                {
+                    using (var channel = Session.CreateChannelDirectTcpip())
+                    {
+                        channel.Exception += Channel_Exception;
+                        channel.Open(Host, Port, this, clientSocket);
+                        channel.Bind();
+                    }
                 }
             }
             catch (Exception exp)

--- a/src/Renci.SshNet/ForwardedPortLocal.cs
+++ b/src/Renci.SshNet/ForwardedPortLocal.cs
@@ -102,6 +102,37 @@ namespace Renci.SshNet
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="ForwardedPortLocal"/> class.
+        /// </summary>
+        /// <param name="boundHost">The bound host.</param>
+        /// <param name="boundPort">The bound port.</param>
+        /// <param name="socketAddress">Unix socket address.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="boundHost"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="socketAddress"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="boundPort" /> is greater than <see cref="F:System.Net.IPEndPoint.MaxPort" />.</exception>
+        /// <exception cref="ArgumentException"><paramref name="socketAddress"/> does not start with <c>/</c>.</exception>
+        public ForwardedPortLocal(string boundHost, uint boundPort, string socketAddress)
+        {
+            if (boundHost == null)
+                throw new ArgumentNullException("boundHost");
+
+            if (socketAddress == null)
+                throw new ArgumentNullException("socketAddress");
+
+            boundPort.ValidatePort("boundPort");
+            if (!socketAddress.IsUnixSocketAddress())
+            {
+                throw new ArgumentException("socketAddress must be a socket address", "socketAddress");
+            }
+
+            BoundHost = boundHost;
+            BoundPort = boundPort;
+            Host = socketAddress;
+            Port = 0;
+            _status = ForwardedPortStatus.Stopped;
+        }
+
+        /// <summary>
         /// Starts local port forwarding.
         /// </summary>
         protected override void StartPort()

--- a/src/Renci.SshNet/ForwardedPortLocal.cs
+++ b/src/Renci.SshNet/ForwardedPortLocal.cs
@@ -306,9 +306,9 @@ namespace Renci.SshNet
         {
             if (address.Contains(":"))
             {
-                var split = address.Split(new [] { ':' }, 2);
+                var split = address.Split(new [] { ':' });
                 host = split[0];
-                if (!uint.TryParse(split[1], out port))
+                if (split.Length > 2 || !uint.TryParse(split[1], out port))
                 {
                     throw new FormatException("Cannot parse port number.");
                 }

--- a/src/Renci.SshNet/ISession.cs
+++ b/src/Renci.SshNet/ISession.cs
@@ -71,6 +71,14 @@ namespace Renci.SshNet
         IChannelDirectTcpip CreateChannelDirectTcpip();
 
         /// <summary>
+        /// Create a new channel for a locally forwarded TCP/IP port.
+        /// </summary>
+        /// <returns>
+        /// A new channel for a locally forwarded TCP/IP port.
+        /// </returns>
+        IChannelDirectStreamLocal CreateChannelDirectStreamLocal();
+
+        /// <summary>
         /// Creates a "forwarded-tcpip" SSH channel.
         /// </summary>
         /// <returns>

--- a/src/Renci.SshNet/Messages/Connection/ChannelOpen/DirectStreamLocalChannelInfo.cs
+++ b/src/Renci.SshNet/Messages/Connection/ChannelOpen/DirectStreamLocalChannelInfo.cs
@@ -1,0 +1,100 @@
+﻿using System;
+
+namespace Renci.SshNet.Messages.Connection
+{
+    /// <summary>
+    /// Used to open "direct-tcpip" channel type
+    /// </summary>
+    internal class DirectStreamLocalChannelInfo : ChannelOpenInfo
+    {
+        private byte[] _socketPath;
+
+        /// <summary>
+        /// Specifies channel open type
+        /// </summary>
+        public const string NAME = "direct-streamlocal@openssh.com";
+
+        /// <summary>
+        /// Gets the type of the channel to open.
+        /// </summary>
+        /// <value>
+        /// The type of the channel to open.
+        /// </value>
+        public override string ChannelType
+        {
+            get { return NAME; }
+        }
+
+        /// <summary>
+        /// Gets the path to connect.
+        /// </summary>
+        public string SocketPath
+        {
+            get { return Utf8.GetString(_socketPath, 0, _socketPath.Length); }
+            private set { _socketPath = Utf8.GetBytes(value); }
+        }
+
+        /// <summary>
+        /// Gets the size of the message in bytes.
+        /// </summary>
+        /// <value>
+        /// The size of the messages in bytes.
+        /// </value>
+        protected override int BufferCapacity
+        {
+            get
+            {
+                var capacity = base.BufferCapacity;
+                capacity += 4; // SocketPath length
+                capacity += SocketPath.Length; // SocketPath
+                capacity += 4; // Reserved1 length
+                capacity += 0; // Reserved1
+                capacity += 4; // Reserved2
+                return capacity;
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DirectStreamLocalChannelInfo"/> class from the
+        /// specified data.
+        /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="data"/> is <c>null</c>.</exception>
+        public DirectStreamLocalChannelInfo(byte[] data)
+        {
+            Load(data);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DirectStreamLocalChannelInfo"/> class.
+        /// </summary>
+        /// <param name="socketPath">The path to connect.</param>
+        public DirectStreamLocalChannelInfo(string socketPath)
+        {
+            SocketPath = socketPath;
+        }
+
+        /// <summary>
+        /// Called when type specific data need to be loaded.
+        /// </summary>
+        protected override void LoadData()
+        {
+            base.LoadData();
+
+            _socketPath = ReadBinary();
+            ReadBinary(); // Reserved1
+            ReadUInt32(); // Reserved2
+        }
+
+        /// <summary>
+        /// Called when type specific data need to be saved.
+        /// </summary>
+        protected override void SaveData()
+        {
+            base.SaveData();
+
+            WriteBinaryString(_socketPath);
+            Write(string.Empty); // Reserved1
+            Write((uint)0);      // Reserved2
+        }
+    }
+}

--- a/src/Renci.SshNet/Messages/Connection/ChannelOpen/DirectStreamLocalChannelInfo.cs
+++ b/src/Renci.SshNet/Messages/Connection/ChannelOpen/DirectStreamLocalChannelInfo.cs
@@ -3,7 +3,7 @@
 namespace Renci.SshNet.Messages.Connection
 {
     /// <summary>
-    /// Used to open "direct-tcpip" channel type
+    /// Used to open "direct-streamlocal@openssh.com" channel type
     /// </summary>
     internal class DirectStreamLocalChannelInfo : ChannelOpenInfo
     {

--- a/src/Renci.SshNet/Renci.SshNet.csproj
+++ b/src/Renci.SshNet/Renci.SshNet.csproj
@@ -248,6 +248,7 @@
     <Compile Include="Messages\Connection\ChannelOpen\ChannelOpenInfo.cs" />
     <Compile Include="Messages\Connection\ChannelOpen\ChannelOpenMessage.cs" />
     <Compile Include="Messages\Connection\ChannelOpen\DirectTcpipChannelInfo.cs" />
+    <Compile Include="Messages\Connection\ChannelOpen\DirectStreamLocalChannelInfo.cs" />
     <Compile Include="Messages\Connection\ChannelOpen\ForwardedTcpipChannelInfo.cs" />
     <Compile Include="Messages\Connection\ChannelOpen\SessionChannelOpenInfo.cs" />
     <Compile Include="Messages\Connection\ChannelOpen\X11ChannelOpenInfo.cs" />

--- a/src/Renci.SshNet/Renci.SshNet.csproj
+++ b/src/Renci.SshNet/Renci.SshNet.csproj
@@ -72,6 +72,10 @@
     <Compile Include="CommandAsyncResult.cs" />
     <Compile Include="Channels\Channel.cs" />
     <Compile Include="Channels\ChannelDirectTcpip.cs" />
+    <Compile Include="Channels\ChannelDirectBase.cs" />
+    <Compile Include="Channels\ChannelDirectStreamLocal.cs" />
+    <Compile Include="Channels\IChannelDirectBase.cs" />
+    <Compile Include="Channels\IChannelDirectStreamLocal.cs" />
     <Compile Include="Channels\ChannelForwardedTcpip.cs" />
     <Compile Include="Channels\ChannelSession.cs" />
     <Compile Include="Channels\ChannelTypes.cs" />

--- a/src/Renci.SshNet/Session.cs
+++ b/src/Renci.SshNet/Session.cs
@@ -2407,6 +2407,17 @@ namespace Renci.SshNet
         }
 
         /// <summary>
+        /// Create a new channel for a locally forwarded TCP/IP port.
+        /// </summary>
+        /// <returns>
+        /// A new channel for a locally forwarded TCP/IP port.
+        /// </returns>
+        IChannelDirectStreamLocal ISession.CreateChannelDirectStreamLocal()
+        {
+            return new ChannelDirectStreamLocal(this, NextChannelNumber, InitialLocalWindowSize, LocalChannelDataPacketSize);
+        }
+
+        /// <summary>
         /// Creates a "forwarded-tcpip" SSH channel.
         /// </summary>
         /// <returns>


### PR DESCRIPTION
This is a minimal implementation to support forwarding to a unix socket (https://github.com/sshnet/SSH.NET/issues/238).
```
new ForwardedPortLocal("localhost", 5000, "/var/lib/mysql/mysql.sock");
```
makes the unix socket `/var/lib/mysql/mysql.sock` on the remote host available at `localhost:5000`.

Please provide feedback on the implementation and what tests should be implemented.