### PR TITLE
Added new Method - EnsureDirectory

### DIFF
--- a/src/Renci.SshNet/SftpClient.cs
+++ b/src/Renci.SshNet/SftpClient.cs
@@ -629,7 +629,7 @@ namespace Renci.SshNet
 
 			List<string> rollupDirectories = new List<string>();
 			for (int i = 2; i <= splitDirNames.Length; i++)
-				rollupDirectories.Add(string.Join("/", splitDirNames.Where(sdir => !sdir.IsNullOrWhiteSpace()).Take(i)));
+				rollupDirectories.Add(string.Join("/", splitDirNames.Where(sdir => !sdir.IsNullOrWhiteSpace()).Take(i).ToArray()));
 
 			foreach (string dir in rollupDirectories)
 				if (!this.Exists(dir))


### PR DESCRIPTION
## EnsureDirectory("")
Added new method that extends current Existing Folder check to allow for a path to be passed and for SSH.Net to automagically create the missing file structure for a path. It is smart enough to build out the directory hierarchy to maintain the same structure and prevent errors in cases where the same directory hierarchy is required. Use case is when Syncronizing directories with Sub Folders.

### Use Case
You have a local file structure that you are trying to duplicate on another server. It is imperative that these files maintain the same relative paths.

#### Local File Structure
./Folder1
|- SubFolder1
|- SubFolder2
        |- SubSubFolder1

#### Pre-`EnsureDirectory` of Server File Structure
Folder1
|- SubFolder1

#### After executing: `EnsureDirectory("./Folder1/SubFolder2/SubSubFolder1")`
./Folder1
|- SubFolder1
|- SubFolder2
        |- SubSubFolder1