### PR TITLE
Update the verify host identify example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,21 +90,7 @@ using (var client = new SshClient("sftp.foo.com", "guest", "pwd"))
 {
     client.HostKeyReceived += (sender, e) =>
         {
-            if (expectedFingerPrint.Length == e.FingerPrint.Length)
-            {
-                for (var i = 0; i < expectedFingerPrint.Length; i++)
-                {
-                    if (expectedFingerPrint[i] != e.FingerPrint[i])
-                    {
-                        e.CanTrust = false;
-                        break;
-                    }
-                }
-            }
-            else
-            {
-                e.CanTrust = false;
-            }
+            e.CanTrust = expectedFingerPrint.SequenceEqual(e.FingerPrint);
         };
     client.Connect();
 }


### PR DESCRIPTION
Update the verify host identify example to use Enumerable.SequenceEqual from System.Linq.