### PR TITLE
Make SemaphoreLight AuthenticationConnection in Session.cs not static

### DIFF
--- a/src/Renci.SshNet/Session.cs
+++ b/src/Renci.SshNet/Session.cs
@@ -94,7 +94,7 @@ namespace Renci.SshNet
         /// <remarks>
         /// Some server may restrict number to prevent authentication attacks
         /// </remarks>
-        private static readonly SemaphoreLight AuthenticationConnection = new SemaphoreLight(3);
+        private readonly SemaphoreLight AuthenticationConnection = new SemaphoreLight(3);
 
         /// <summary>
         /// Holds metada about session messages


### PR DESCRIPTION
In doing so we avoid needless waiting on a semaphore to signal if you
have more than 3 simultaneous SSH clients in your application.