### PR TITLE
Added subsystem property to netconfclient fixes #473 

### DIFF
--- a/src/Renci.SshNet.NET35/Renci.SshNet.NET35.csproj
+++ b/src/Renci.SshNet.NET35/Renci.SshNet.NET35.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,8 +10,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Renci.SshNet</RootNamespace>
     <AssemblyName>Renci.SshNet</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -24,6 +25,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DocumentationFile>bin\Debug\Renci.SshNet.xml</DocumentationFile>
     <LangVersion>5</LangVersion>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
@@ -37,6 +39,7 @@
     </NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>5</LangVersion>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
@@ -971,7 +974,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties ProjectLinkerExcludeFilter="\\?desktop(\\.*)?$;\\?silverlight(\\.*)?$;\.desktop;\.silverlight;\.xaml;^service references(\\.*)?$;\.clientconfig;^web references(\\.*)?$" ProjectLinkReference="2f5f8c90-0bd1-424f-997c-7bc6280919d1" />
+      <UserProperties ProjectLinkReference="2f5f8c90-0bd1-424f-997c-7bc6280919d1" ProjectLinkerExcludeFilter="\\?desktop(\\.*)?$;\\?silverlight(\\.*)?$;\.desktop;\.silverlight;\.xaml;^service references(\\.*)?$;\.clientconfig;^web references(\\.*)?$" />
     </VisualStudio>
   </ProjectExtensions>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Renci.SshNet.Tests/Classes/NetConfClientTest_Connect_NetConfSessionConnectFailure.cs
+++ b/src/Renci.SshNet.Tests/Classes/NetConfClientTest_Connect_NetConfSessionConnectFailure.cs
@@ -59,7 +59,7 @@ namespace Renci.SshNet.Tests.Classes
             _sessionMock.InSequence(sequence)
                         .Setup(p => p.Connect());
             _serviceFactoryMock.InSequence(sequence)
-                               .Setup(p => p.CreateNetConfSession(_sessionMock.Object, -1))
+                               .Setup(p => p.CreateNetConfSession(_sessionMock.Object, _subSystem, -1))
                                .Returns(_netConfSessionMock.Object);
             _netConfSessionMock.InSequence(sequence)
                             .Setup(p => p.Connect())

--- a/src/Renci.SshNet.Tests/Classes/NetConfClientTest_Dispose_Connected.cs
+++ b/src/Renci.SshNet.Tests/Classes/NetConfClientTest_Dispose_Connected.cs
@@ -14,6 +14,7 @@ namespace Renci.SshNet.Tests.Classes
         private NetConfClient _netConfClient;
         private ConnectionInfo _connectionInfo;
         private int _operationTimeout;
+        private string _sysSystem;
 
         [TestInitialize]
         public void Setup()
@@ -35,6 +36,7 @@ namespace Renci.SshNet.Tests.Classes
 
             _connectionInfo = new ConnectionInfo("host", "user", new NoneAuthenticationMethod("userauth"));
             _operationTimeout = new Random().Next(1000, 10000);
+            _subSystem = "netconf";
             _netConfClient = new NetConfClient(_connectionInfo, false, _serviceFactoryMock.Object);
             _netConfClient.OperationTimeout = TimeSpan.FromMilliseconds(_operationTimeout);
 
@@ -63,7 +65,7 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void CreateNetConfSessionOnServiceFactoryShouldBeInvokedOnce()
         {
-            _serviceFactoryMock.Verify(p => p.CreateNetConfSession(_sessionMock.Object, _operationTimeout), Times.Once);
+            _serviceFactoryMock.Verify(p => p.CreateNetConfSession(_sessionMock.Object, _subSystem, _operationTimeout), Times.Once);
         }
 
         [TestMethod]

--- a/src/Renci.SshNet.Tests/Classes/NetConfClientTest_Dispose_Disconnected.cs
+++ b/src/Renci.SshNet.Tests/Classes/NetConfClientTest_Dispose_Disconnected.cs
@@ -14,6 +14,7 @@ namespace Renci.SshNet.Tests.Classes
         private NetConfClient _netConfClient;
         private ConnectionInfo _connectionInfo;
         private int _operationTimeout;
+        private string _subSystem;
 
         [TestInitialize]
         public void Setup()
@@ -35,6 +36,7 @@ namespace Renci.SshNet.Tests.Classes
 
             _connectionInfo = new ConnectionInfo("host", "user", new NoneAuthenticationMethod("userauth"));
             _operationTimeout = new Random().Next(1000, 10000);
+            _subSystem = "netconf";
             _netConfClient = new NetConfClient(_connectionInfo, false, _serviceFactoryMock.Object);
             _netConfClient.OperationTimeout = TimeSpan.FromMilliseconds(_operationTimeout);
 
@@ -44,7 +46,7 @@ namespace Renci.SshNet.Tests.Classes
                 .Returns(_sessionMock.Object);
             _sessionMock.InSequence(sequence).Setup(p => p.Connect());
             _serviceFactoryMock.InSequence(sequence)
-                .Setup(p => p.CreateNetConfSession(_sessionMock.Object, _operationTimeout))
+                .Setup(p => p.CreateNetConfSession(_sessionMock.Object, _subSystem, _operationTimeout))
                 .Returns(_netConfSessionMock.Object);
             _netConfSessionMock.InSequence(sequence).Setup(p => p.Connect());
             _sessionMock.InSequence(sequence).Setup(p => p.OnDisconnecting());

--- a/src/Renci.SshNet.Tests/Classes/NetConfClientTest_Dispose_Disposed.cs
+++ b/src/Renci.SshNet.Tests/Classes/NetConfClientTest_Dispose_Disposed.cs
@@ -35,6 +35,7 @@ namespace Renci.SshNet.Tests.Classes
 
             _connectionInfo = new ConnectionInfo("host", "user", new NoneAuthenticationMethod("userauth"));
             _operationTimeout = new Random().Next(1000, 10000);
+            _subSystem = "netconf";
             _netConfClient = new NetConfClient(_connectionInfo, false, _serviceFactoryMock.Object);
             _netConfClient.OperationTimeout = TimeSpan.FromMilliseconds(_operationTimeout);
 
@@ -44,7 +45,7 @@ namespace Renci.SshNet.Tests.Classes
                 .Returns(_sessionMock.Object);
             _sessionMock.InSequence(sequence).Setup(p => p.Connect());
             _serviceFactoryMock.InSequence(sequence)
-                .Setup(p => p.CreateNetConfSession(_sessionMock.Object, _operationTimeout))
+                .Setup(p => p.CreateNetConfSession(_sessionMock.Object, _subSystem, _operationTimeout))
                 .Returns(_netConfSessionMock.Object);
             _netConfSessionMock.InSequence(sequence).Setup(p => p.Connect());
             _sessionMock.InSequence(sequence).Setup(p => p.OnDisconnecting());

--- a/src/Renci.SshNet.Tests/Classes/NetConfClientTest_Finalize_Connected.cs
+++ b/src/Renci.SshNet.Tests/Classes/NetConfClientTest_Finalize_Connected.cs
@@ -14,6 +14,7 @@ namespace Renci.SshNet.Tests.Classes
         private NetConfClient _netConfClient;
         private ConnectionInfo _connectionInfo;
         private int _operationTimeout;
+        private string _subSystem;
 
         [TestInitialize]
         public void Setup()
@@ -30,6 +31,7 @@ namespace Renci.SshNet.Tests.Classes
 
             _connectionInfo = new ConnectionInfo("host", "user", new NoneAuthenticationMethod("userauth"));
             _operationTimeout = new Random().Next(1000, 10000);
+            _subSystem = "netconf";
             _netConfClient = new NetConfClient(_connectionInfo, false, _serviceFactoryMock.Object);
             _netConfClient.OperationTimeout = TimeSpan.FromMilliseconds(_operationTimeout);
 
@@ -39,7 +41,7 @@ namespace Renci.SshNet.Tests.Classes
                 .Returns(_sessionMock.Object);
             _sessionMock.InSequence(sequence).Setup(p => p.Connect());
             _serviceFactoryMock.InSequence(sequence)
-                .Setup(p => p.CreateNetConfSession(_sessionMock.Object, _operationTimeout))
+                .Setup(p => p.CreateNetConfSession(_sessionMock.Object, _subSystem, _operationTimeout))
                 .Returns(_netConfSessionMock.Object);
             _netConfSessionMock.InSequence(sequence).Setup(p => p.Connect());
 

--- a/src/Renci.SshNet/IServiceFactory.NET.cs
+++ b/src/Renci.SshNet/IServiceFactory.NET.cs
@@ -9,10 +9,11 @@ namespace Renci.SshNet
         /// and with the specified operation timeout.
         /// </summary>
         /// <param name="session">The <see cref="ISession"/> to create the <see cref="INetConfSession"/> in.</param>
+        /// <param name="subSystem">SSH subsystem for netconf session</param>
         /// <param name="operationTimeout">The number of milliseconds to wait for an operation to complete, or -1 to wait indefinitely.</param>
         /// <returns>
         /// An <see cref="INetConfSession"/>.
         /// </returns>
-        INetConfSession CreateNetConfSession(ISession session, int operationTimeout);
+        INetConfSession CreateNetConfSession(ISession session, string subSystem, int operationTimeout);
     }
 }

--- a/src/Renci.SshNet/NetConfClient.cs
+++ b/src/Renci.SshNet/NetConfClient.cs
@@ -20,6 +20,16 @@ namespace Renci.SshNet
         /// </summary>
         private INetConfSession _netConfSession;
 
+        private string _subSystem = "netconf";
+        /// <summary>
+        /// Changes the used SSH subsystem from netconf to another value
+        /// </summary>
+        public String SubSystem
+        {
+            get { return _subSystem; }
+            set { _subSystem = value; }
+        }
+
         /// <summary>
         /// Gets or sets the operation timeout.
         /// </summary>
@@ -264,7 +274,7 @@ namespace Renci.SshNet
 
         private INetConfSession CreateAndConnectNetConfSession()
         {
-            var netConfSession = ServiceFactory.CreateNetConfSession(Session, _operationTimeout);
+            var netConfSession = ServiceFactory.CreateNetConfSession(Session, _subSystem, _operationTimeout);
             try
             {
                 netConfSession.Connect();

--- a/src/Renci.SshNet/Netconf/NetConfSession.cs
+++ b/src/Renci.SshNet/Netconf/NetConfSession.cs
@@ -33,9 +33,11 @@ namespace Renci.SshNet.NetConf
         /// Initializes a new instance of the <see cref="NetConfSession"/> class.
         /// </summary>
         /// <param name="session">The session.</param>
+        /// <param name="subSystem">SSH subsystem for netconf session.</param>
         /// <param name="operationTimeout">The number of milliseconds to wait for an operation to complete, or -1 to wait indefinitely.</param>
-        public NetConfSession(ISession session, int operationTimeout)
-            : base(session, "netconf", operationTimeout)
+        /// 
+        public NetConfSession(ISession session, string subSystem, int operationTimeout)
+            : base(session, subSystem, operationTimeout)
         {
             ClientCapabilities = new XmlDocument();
             ClientCapabilities.LoadXml("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +

--- a/src/Renci.SshNet/ServiceFactory.NET.cs
+++ b/src/Renci.SshNet/ServiceFactory.NET.cs
@@ -9,13 +9,14 @@ namespace Renci.SshNet
         /// and with the specified operation timeout.
         /// </summary>
         /// <param name="session">The <see cref="ISession"/> to create the <see cref="INetConfSession"/> in.</param>
+        /// <param name="subSystem">SSH subsystem of netconf session. 'netconf' is default.</param>
         /// <param name="operationTimeout">The number of milliseconds to wait for an operation to complete, or -1 to wait indefinitely.</param>
         /// <returns>
         /// An <see cref="INetConfSession"/>.
         /// </returns>
-        public INetConfSession CreateNetConfSession(ISession session, int operationTimeout)
+        public INetConfSession CreateNetConfSession(ISession session, string subSystem, int operationTimeout)
         {
-            return new NetConfSession(session, operationTimeout);
+            return new NetConfSession(session, subSystem, operationTimeout);
         }
     }
 }


### PR DESCRIPTION
Added subsystem property to netconfclient class.
The default is "netconf", so no existing code needs any changes.