### PR TITLE
Sending identification string before waiting for server's

### DIFF
--- a/src/Renci.SshNet/Session.cs
+++ b/src/Renci.SshNet/Session.cs
@@ -601,6 +601,9 @@ namespace Renci.SshNet
                             break;
                     }
 
+                    // Send our identification string before waiting for server's, as mandated by RFC 4253.
+                    SocketAbstraction.Send(_socket, Encoding.UTF8.GetBytes(string.Format(CultureInfo.InvariantCulture, "{0}\x0D\x0A", ClientVersion)));
+
                     Match versionMatch;
 
                     //  Get server version from the server,
@@ -633,8 +636,6 @@ namespace Renci.SshNet
                     {
                         throw new SshConnectionException(string.Format(CultureInfo.CurrentCulture, "Server version '{0}' is not supported.", version), DisconnectReason.ProtocolVersionNotSupported);
                     }
-
-                    SocketAbstraction.Send(_socket, Encoding.UTF8.GetBytes(string.Format(CultureInfo.InvariantCulture, "{0}\x0D\x0A", ClientVersion)));
 
                     //  Register Transport response messages
                     RegisterMessage("SSH_MSG_DISCONNECT");


### PR DESCRIPTION
According to RFC 4253 Section 4.2. Protocol Version Exchange:

> When the connection has been established, both sides MUST send an identification string.

SSH.NET sends its identification string only after waiting for server's identification string. Amazon Managed SFTP server has the same issue. So you cannot connect to that SFTP server with SSH.NET. Both sides first wait for the other side to send the identification string before sending its own.

https://github.com/sshnet/SSH.NET/issues/505