### PR TITLE
Bugfix for "scp: error: unexpected filename "

### DIFF
--- a/src/Renci.SshNet/ScpClient.NET.cs
+++ b/src/Renci.SshNet/ScpClient.NET.cs
@@ -45,7 +45,7 @@ namespace Renci.SshNet
                 using (var source = fileInfo.OpenRead())
                 {
                     UploadTimes(channel, input, fileInfo);
-                    UploadFileModeAndName(channel, input, source.Length, string.Empty);
+                    UploadFileModeAndName(channel, input, source.Length, fileInfo.Name);
                     UploadFileContent(channel, input, source, fileInfo.Name);
                 }
             }

--- a/src/Renci.SshNet/ScpClient.cs
+++ b/src/Renci.SshNet/ScpClient.cs
@@ -222,7 +222,7 @@ namespace Renci.SshNet
 
                 // specify a zero-length file name to avoid creating a file with absolute
                 // path '<path>/<filename part of path>' if directory '<path>' already exists
-                UploadFileModeAndName(channel, input, source.Length, string.Empty);
+                UploadFileModeAndName(channel, input, source.Length, PosixPath.GetFileName(path));
                 UploadFileContent(channel, input, source, PosixPath.GetFileName(path));
             }
         }


### PR DESCRIPTION
Replace string.Empty with file name for UploadFileModeAndName serverFileName parameter.