### PR TITLE
Added SCPClient.Download overload that returns a stream.

### DIFF
--- a/src/Renci.SshNet.NET35/Renci.SshNet.NET35.csproj
+++ b/src/Renci.SshNet.NET35/Renci.SshNet.NET35.csproj
@@ -206,6 +206,9 @@
     <Compile Include="..\Renci.SshNet\Common\ScpDownloadEventArgs.cs">
       <Link>Common\ScpDownloadEventArgs.cs</Link>
     </Compile>
+    <Compile Include="..\Renci.SshNet\Common\ScpDownloadStream.cs">
+      <Link>Common\ScpDownloadStream.cs</Link>
+    </Compile>
     <Compile Include="..\Renci.SshNet\Common\ScpException.cs">
       <Link>Common\ScpException.cs</Link>
     </Compile>
@@ -971,7 +974,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties ProjectLinkerExcludeFilter="\\?desktop(\\.*)?$;\\?silverlight(\\.*)?$;\.desktop;\.silverlight;\.xaml;^service references(\\.*)?$;\.clientconfig;^web references(\\.*)?$" ProjectLinkReference="2f5f8c90-0bd1-424f-997c-7bc6280919d1" />
+      <UserProperties ProjectLinkReference="2f5f8c90-0bd1-424f-997c-7bc6280919d1" ProjectLinkerExcludeFilter="\\?desktop(\\.*)?$;\\?silverlight(\\.*)?$;\.desktop;\.silverlight;\.xaml;^service references(\\.*)?$;\.clientconfig;^web references(\\.*)?$" />
     </VisualStudio>
   </ProjectExtensions>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Renci.SshNet.Silverlight/Renci.SshNet.Silverlight.csproj
+++ b/src/Renci.SshNet.Silverlight/Renci.SshNet.Silverlight.csproj
@@ -218,6 +218,9 @@
     <Compile Include="..\Renci.SshNet\Common\ScpDownloadEventArgs.cs">
       <Link>Common\ScpDownloadEventArgs.cs</Link>
     </Compile>
+	<Compile Include="..\Renci.SshNet\Common\ScpDownloadStream.cs">
+      <Link>Common\ScpDownloadStream.cs</Link>
+    </Compile>
     <Compile Include="..\Renci.SshNet\Common\ScpException.cs">
       <Link>Common\ScpException.cs</Link>
     </Compile>

--- a/src/Renci.SshNet.Silverlight5/Renci.SshNet.Silverlight5.csproj
+++ b/src/Renci.SshNet.Silverlight5/Renci.SshNet.Silverlight5.csproj
@@ -227,6 +227,9 @@
     <Compile Include="..\Renci.SshNet\Common\ScpDownloadEventArgs.cs">
       <Link>Common\ScpDownloadEventArgs.cs</Link>
     </Compile>
+    <Compile Include="..\Renci.SshNet\Common\ScpDownloadStream.cs">
+      <Link>Common\ScpDownloadStream.cs</Link>
+    </Compile>
     <Compile Include="..\Renci.SshNet\Common\ScpException.cs">
       <Link>Common\ScpException.cs</Link>
     </Compile>

--- a/src/Renci.SshNet.Tests/Classes/ScpClientTest.cs
+++ b/src/Renci.SshNet.Tests/Classes/ScpClientTest.cs
@@ -387,7 +387,10 @@ namespace Renci.SshNet.Tests.Classes
                 using (var outputStream = File.OpenWrite(downloadedFileName))
                 using (var downloadStream = scp.Download(Path.GetFileName(uploadedFileName)))
                 {
-                    downloadStream.CopyTo(outputStream);
+                    byte[] buffer = new byte[81920];
+                    int count;
+                    while ((count = downloadStream.Read(buffer, 0, buffer.Length)) != 0)
+                        outputStream.Write(buffer, 0, count);
                 }
 
                 //  Calculate MD5 value
@@ -437,12 +440,12 @@ namespace Renci.SshNet.Tests.Classes
                 var downloadFiles = downloadDirectory.GetFiles("*.*", System.IO.SearchOption.AllDirectories);
 
                 var result = from f1 in uploadedFiles
-                             from f2 in downloadFiles
-                             where
-                             f1.FullName.Substring(uploadDirectory.FullName.Length) ==
-                             f2.FullName.Substring(downloadDirectory.FullName.Length)
-                             && CalculateMD5(f1.FullName) == CalculateMD5(f2.FullName)
-                             select f1;
+                    from f2 in downloadFiles
+                    where
+                        f1.FullName.Substring(uploadDirectory.FullName.Length) ==
+                        f2.FullName.Substring(downloadDirectory.FullName.Length)
+                        && CalculateMD5(f1.FullName) == CalculateMD5(f2.FullName)
+                    select f1;
 
                 var counter = result.Count();
 

--- a/src/Renci.SshNet.UAP10/Renci.SshNet.UAP10.csproj
+++ b/src/Renci.SshNet.UAP10/Renci.SshNet.UAP10.csproj
@@ -267,6 +267,9 @@
     <Compile Include="..\Renci.SshNet\Common\ScpDownloadEventArgs.cs">
       <Link>Common\ScpDownloadEventArgs.cs</Link>
     </Compile>
+    <Compile Include="..\Renci.SshNet\Common\ScpDownloadStream.cs">
+      <Link>Common\ScpDownloadStream.cs</Link>
+    </Compile>
     <Compile Include="..\Renci.SshNet\Common\ScpException.cs">
       <Link>Common\ScpException.cs</Link>
     </Compile>

--- a/src/Renci.SshNet.WindowsPhone/Renci.SshNet.WindowsPhone.csproj
+++ b/src/Renci.SshNet.WindowsPhone/Renci.SshNet.WindowsPhone.csproj
@@ -209,6 +209,9 @@
     <Compile Include="..\Renci.SshNet\Common\ScpDownloadEventArgs.cs">
       <Link>Common\ScpDownloadEventArgs.cs</Link>
     </Compile>
+	<Compile Include="..\Renci.SshNet\Common\ScpDownloadStream.cs">
+      <Link>Common\ScpDownloadStream.cs</Link>
+    </Compile>
     <Compile Include="..\Renci.SshNet\Common\ScpException.cs">
       <Link>Common\ScpException.cs</Link>
     </Compile>

--- a/src/Renci.SshNet.WindowsPhone8/Renci.SshNet.WindowsPhone8.csproj
+++ b/src/Renci.SshNet.WindowsPhone8/Renci.SshNet.WindowsPhone8.csproj
@@ -250,6 +250,9 @@
     <Compile Include="..\Renci.SshNet\Common\ScpDownloadEventArgs.cs">
       <Link>Common\ScpDownloadEventArgs.cs</Link>
     </Compile>
+	<Compile Include="..\Renci.SshNet\Common\ScpDownloadStream.cs">
+      <Link>Common\ScpDownloadStream.cs</Link>
+    </Compile>
     <Compile Include="..\Renci.SshNet\Common\ScpException.cs">
       <Link>Common\ScpException.cs</Link>
     </Compile>

--- a/src/Renci.SshNet/Common/ScpDownloadStream.cs
+++ b/src/Renci.SshNet/Common/ScpDownloadStream.cs
@@ -1,0 +1,105 @@
+﻿using Renci.SshNet.Channels;
+using System;
+using System.IO;
+
+namespace Renci.SshNet.Common
+{
+    /// <summary>
+    /// Forward, read-only stream used to download a file via SCP. 
+    /// </summary>
+    public class ScpDownloadStream : Stream
+    {
+        private readonly ScpClient _client;
+        private readonly IChannelSession _channelSession;
+        private readonly Stream _scpStream;
+        private readonly string _fileName;
+        private readonly long _length;
+        private long _needToRead;
+
+        internal ScpDownloadStream(ScpClient client, IChannelSession channelSession, Stream scpStream, string fileName, long length)
+        {
+            _client = client;
+            _channelSession = channelSession;
+            _scpStream = scpStream;
+            _fileName = fileName;
+            _length = length;
+            _needToRead = length;
+        }
+
+        /// <inheritdoc />
+        public override bool CanRead
+        {
+            get { return true; }
+        }
+        /// <inheritdoc />
+        public override bool CanSeek
+        {
+            get { return false; }
+        }
+        /// <inheritdoc />
+        public override bool CanWrite
+        {
+            get { return false; }
+        }
+        /// <inheritdoc />
+        public override long Length
+        {
+            get { return _length; }
+        }
+
+        /// <inheritdoc />
+        public override long Position
+        {
+            get { return _scpStream.Position; }
+            set { }
+        }
+
+        /// <inheritdoc />
+        protected override void Dispose(bool disposing)
+        {
+            _scpStream.Dispose();
+            _channelSession.Dispose();
+            base.Dispose(disposing);
+        }
+
+        /// <inheritdoc />
+        public override void Flush()
+        {
+            throw new NotSupportedException("Flush is not supported. Forward, read-only stream");
+        }
+        /// <inheritdoc />
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException("Seek is not supported. Forward, read-only stream");
+        }
+        /// <inheritdoc />
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException("SetLength is not supported. Forward, read-only stream");
+        }
+        /// <inheritdoc />
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var read = _scpStream.Read(buffer, offset, (int)Math.Min(_needToRead, count));
+            _needToRead -= read;
+
+            _client.RaiseDownloadingEvent(_fileName, _length, _length - _needToRead);
+
+            if (_needToRead == 0)
+            {
+                //  Send confirmation byte after last data byte was read
+                ScpClient.SendSuccessConfirmation(_channelSession);
+
+                _client.CheckReturnCode(_scpStream);
+            }
+
+            return read;
+        }
+
+        /// <inheritdoc />
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException("Write is not supported. Forward, read-only stream");
+        }
+    }
+}

--- a/src/Renci.SshNet/Renci.SshNet.csproj
+++ b/src/Renci.SshNet/Renci.SshNet.csproj
@@ -117,7 +117,9 @@
     <Compile Include="Common\ScpDownloadEventArgs.cs">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="Common\ScpDownloadStream.cs" />
+    <Compile Include="Common\ScpDownloadStream.cs">
+	  <SubType>Code</SubType>
+    </Compile>
     <Compile Include="Common\ScpException.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/src/Renci.SshNet/Renci.SshNet.csproj
+++ b/src/Renci.SshNet/Renci.SshNet.csproj
@@ -117,6 +117,7 @@
     <Compile Include="Common\ScpDownloadEventArgs.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Common\ScpDownloadStream.cs" />
     <Compile Include="Common\ScpException.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/src/Renci.SshNet/ScpClient.cs
+++ b/src/Renci.SshNet/ScpClient.cs
@@ -284,7 +284,7 @@ namespace Renci.SshNet
         /// <exception cref="ArgumentException"><paramref name="filename"/> is <c>null</c> or contains only whitespace characters.</exception>
         /// <exception cref="ScpException"><paramref name="filename"/> exists on the remote host, and is not a regular file.</exception>
         /// <exception cref="SshException">The secure copy execution request was rejected by the server.</exception>
-        /// <returns cref="Stream">Returns a forward read-only stream. Does not support Seeking or Write.</returns>
+        /// <returns cref="Stream">Returns a forward read-only stream. Does not support Seeking or Write</returns>
         public Stream Download(string filename)
         {
             if (filename.IsNullOrWhiteSpace())

--- a/src/Renci.SshNet/ScpClient.cs
+++ b/src/Renci.SshNet/ScpClient.cs
@@ -30,7 +30,7 @@ namespace Renci.SshNet
     public partial class ScpClient : BaseClient
     {
         private static readonly Regex FileInfoRe = new Regex(@"C(?<mode>\d{4}) (?<length>\d+) (?<filename>.+)");
-        private static readonly byte[] SuccessConfirmationCode = { 0 };
+        private static readonly byte[] SuccessConfirmationCode = {0};
         private static readonly byte[] ErrorConfirmationCode = { 1 };
 
         private IRemotePathTransformation _remotePathTransformation;
@@ -383,7 +383,7 @@ namespace Renci.SshNet
 
             do
             {
-                var read = input.Read(buffer, 0, (int)Math.Min(needToRead, BufferSize));
+                var read = input.Read(buffer, 0, (int) Math.Min(needToRead, BufferSize));
 
                 output.Write(buffer, 0, read);
 
@@ -492,7 +492,7 @@ namespace Renci.SshNet
 
             while (b != SshNet.Session.LineFeed)
             {
-                buffer.Add((byte)b);
+                buffer.Add((byte) b);
                 b = ReadByte(stream);
             }
 


### PR DESCRIPTION
SCP is significantly quicker when dealing with a straight forward read as opposed to Sftp. The Download method on the SCPClient didn't return a stream.

For this scenario, I'm reading a large file, I then need to pass the stream to downward processes to handle, decryption, filtering and write to our end data store. For this to be possible I need to be obtain the read stream first and then I can pass through to each onward process.

This allows for a 17Gb file to be read, decrypted, filtered and saved to a data store all without the file touching the disk at any time.

To ensure notifications are still issued and the channel is cleaned up I've created an ScpDownloadStream, which handles reading and giving notifications back to the client. 

In my testing I found the SCPClient to be twice the speed of the SftpClient when comparing my new method with the SFTPClient.OpenRead.

I'm happy to take on any feedback to get this in. Whilst I can work off a fork I'd prefer to have this in the codebase as I think beneficial and it would align the SCPClient and SFTPClient, both being able to obtain a stream rather than provide one.

I've added an integration test to ensure everything works correctly.