### PR TITLE
Fixed Deadlock when disposing in .NET Core 3.0

### DIFF
--- a/src/Renci.SshNet.NETCore/Renci.SshNet.NETCore.csproj
+++ b/src/Renci.SshNet.NETCore/Renci.SshNet.NETCore.csproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>Renci.SshNet</AssemblyName>
     <AssemblyOriginatorKeyFile>../Renci.SshNet.snk</AssemblyOriginatorKeyFile>
-    <LangVersion>5</LangVersion>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
@@ -25,13 +24,13 @@
     <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
     <PackageReference Include="System.Xml.XPath.XmlDocument" Version="4.3.0" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1' ">
     <PackageReference Include="SshNet.Security.Cryptography" Version="[1.3.0]" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <DefineConstants>FEATURE_ENCODING_ASCII;FEATURE_DIAGNOSTICS_TRACESOURCE;FEATURE_DIRECTORYINFO_ENUMERATEFILES;FEATURE_MEMORYSTREAM_TRYGETBUFFER;FEATURE_REFLECTION_TYPEINFO;FEATURE_RNG_CREATE;FEATURE_SOCKET_TAP;FEATURE_SOCKET_EAP;FEATURE_SOCKET_SYNC;FEATURE_SOCKET_SETSOCKETOPTION;FEATURE_SOCKET_SELECT;FEATURE_SOCKET_POLL;FEATURE_SOCKET_DISPOSE;FEATURE_DNS_TAP;FEATURE_STREAM_TAP;FEATURE_THREAD_COUNTDOWNEVENT;FEATURE_THREAD_TAP;FEATURE_THREAD_THREADPOOL;FEATURE_THREAD_SLEEP;FEATURE_WAITHANDLE_DISPOSE;FEATURE_HASH_MD5;FEATURE_HASH_SHA1_CREATE;FEATURE_HASH_SHA256_CREATE;FEATURE_HASH_SHA384_CREATE;FEATURE_HASH_SHA512_CREATE;FEATURE_HMAC_MD5;FEATURE_HMAC_SHA1;FEATURE_HMAC_SHA256;FEATURE_HMAC_SHA384;FEATURE_HMAC_SHA512</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1' ">
     <DefineConstants>FEATURE_ENCODING_ASCII;FEATURE_DIAGNOSTICS_TRACESOURCE;FEATURE_DIRECTORYINFO_ENUMERATEFILES;FEATURE_MEMORYSTREAM_GETBUFFER;FEATURE_MEMORYSTREAM_TRYGETBUFFER;FEATURE_RNG_CREATE;FEATURE_SOCKET_TAP;FEATURE_SOCKET_APM;FEATURE_SOCKET_EAP;FEATURE_SOCKET_SYNC;FEATURE_SOCKET_SETSOCKETOPTION;FEATURE_SOCKET_SELECT;FEATURE_SOCKET_POLL;FEATURE_SOCKET_DISPOSE;FEATURE_DNS_SYNC;FEATURE_DNS_APM;FEATURE_DNS_TAP;FEATURE_STREAM_APM;FEATURE_STREAM_TAP;FEATURE_THREAD_COUNTDOWNEVENT;FEATURE_THREAD_TAP;FEATURE_THREAD_THREADPOOL;FEATURE_THREAD_SLEEP;FEATURE_WAITHANDLE_DISPOSE;FEATURE_HASH_MD5;FEATURE_HASH_SHA1_CREATE;FEATURE_HASH_SHA256_CREATE;FEATURE_HASH_SHA384_CREATE;FEATURE_HASH_SHA512_CREATE;FEATURE_HMAC_MD5;FEATURE_HMAC_SHA1;FEATURE_HMAC_SHA256;FEATURE_HMAC_SHA384;FEATURE_HMAC_SHA512</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/src/Renci.SshNet/Channels/ChannelDirectTcpip.cs
+++ b/src/Renci.SshNet/Channels/ChannelDirectTcpip.cs
@@ -70,7 +70,7 @@ namespace Renci.SshNet.Channels
         {
             // signal to the client that we will not send anything anymore; this should also interrupt the
             // blocking receive in Bind if the client sends FIN/ACK in time
-            ShutdownSocket(SocketShutdown.Send);
+            ShutdownSocket(SocketShutdown.Both);
 
             // if the FIN/ACK is not sent in time by the remote client, then interrupt the blocking receive
             // by closing the socket
@@ -160,7 +160,7 @@ namespace Renci.SshNet.Channels
             // blocking receive in Bind if the client sends FIN/ACK in time
             //
             // if the FIN/ACK is not sent in time, the socket will be closed after the channel is closed
-            ShutdownSocket(SocketShutdown.Send);
+            ShutdownSocket(SocketShutdown.Both);
 
             // close the SSH channel
             base.Close();
@@ -221,7 +221,7 @@ namespace Renci.SshNet.Channels
             // send anything anymore)
             //
             // this will also interrupt the blocking receive in Bind()
-            ShutdownSocket(SocketShutdown.Send);
+            ShutdownSocket(SocketShutdown.Both);
         }
 
         /// <summary>
@@ -236,7 +236,7 @@ namespace Renci.SshNet.Channels
             // blocking receive in Bind if the client sends FIN/ACK in time
             //
             // if the FIN/ACK is not sent in time, the socket will be closed in Close(bool)
-            ShutdownSocket(SocketShutdown.Send);
+            ShutdownSocket(SocketShutdown.Both);
         }
 
         /// <summary>

--- a/src/Renci.SshNet/Channels/ChannelForwardedTcpip.cs
+++ b/src/Renci.SshNet/Channels/ChannelForwardedTcpip.cs
@@ -98,7 +98,7 @@ namespace Renci.SshNet.Channels
             // blocking receive in Bind if the server sends FIN/ACK in time
             //
             // if the FIN/ACK is not sent in time, the socket will be closed in Close(bool)
-            ShutdownSocket(SocketShutdown.Send);
+            ShutdownSocket(SocketShutdown.Both);
         }
 
         /// <summary>
@@ -110,7 +110,7 @@ namespace Renci.SshNet.Channels
             // blocking receive in Bind if the server sends FIN/ACK in time
             //
             // if the FIN/ACK is not sent in time, the socket will be closed in Close(bool)
-            ShutdownSocket(SocketShutdown.Send);
+            ShutdownSocket(SocketShutdown.Both);
         }
 
         /// <summary>
@@ -175,7 +175,7 @@ namespace Renci.SshNet.Channels
             // blocking receive in Bind if the server sends FIN/ACK in time
             //
             // if the FIN/ACK is not sent in time, the socket will be closed after the channel is closed
-            ShutdownSocket(SocketShutdown.Send);
+            ShutdownSocket(SocketShutdown.Both);
 
             // close the SSH channel, and mark the channel closed
             base.Close();

--- a/src/Renci.SshNet/ForwardedPortDynamic.NET.cs
+++ b/src/Renci.SshNet/ForwardedPortDynamic.NET.cs
@@ -225,7 +225,7 @@ namespace Renci.SshNet
             {
                 try
                 {
-                    clientSocket.Shutdown(SocketShutdown.Send);
+                    clientSocket.Shutdown(SocketShutdown.Both);
                 }
                 catch (Exception)
                 {

--- a/src/Renci.SshNet/ForwardedPortLocal.NET.cs
+++ b/src/Renci.SshNet/ForwardedPortLocal.NET.cs
@@ -175,7 +175,7 @@ namespace Renci.SshNet
             {
                 try
                 {
-                    clientSocket.Shutdown(SocketShutdown.Send);
+                    clientSocket.Shutdown(SocketShutdown.Both);
                 }
                 catch (Exception)
                 {

--- a/src/Renci.SshNet/Session.cs
+++ b/src/Renci.SshNet/Session.cs
@@ -1908,10 +1908,6 @@ namespace Renci.SshNet
         /// </summary>
         private void MessageListener()
         {
-#if FEATURE_SOCKET_SELECT
-            var readSockets = new List<Socket> { _socket };
-#endif // FEATURE_SOCKET_SELECT
-
             try
             {
                 // remain in message loop until socket is shut down or until we're disconnecting


### PR DESCRIPTION
When trying to Dispose SSHClient in .NET Core 3.0 (macOS Mojave), It will not end forever.
I solved the problem with a few modifications:

- Added support for .NET Standard 2.1
- Use SocketShutdown.Both for Session Shutdown
- Use Socket.Poll instead of Socket.Select (otherwise randomly deadlock)

Thanks!