### PR TITLE
Support on sftp local changedir mimmicking

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ SSH.NET is a Secure Shell (SSH-2) library for .NET, optimized for parallelism.
 ## Introduction
 This project was inspired by **Sharp.SSH** library which was ported from java and it seems like was not supported for quite some time. This library is a complete rewrite, without any third party dependencies, using parallelism to achieve the best performance possible.
 
+This specific branch has an additional feature which is for  sftp client to always use absolute paths on the server (i.e. changedirectory will keep track of the absolute path and all file actions will provide absolute paths to the server). This gives support for  buggy server implementations where changedirectory will use the grown permissions. 
+
 ## Features
 * Execution of SSH command using both synchronous and asynchronous methods
 * Return command execution exit status and other information 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ SSH.NET is a Secure Shell (SSH-2) library for .NET, optimized for parallelism.
 ## Introduction
 This project was inspired by **Sharp.SSH** library which was ported from java and it seems like was not supported for quite some time. This library is a complete rewrite, without any third party dependencies, using parallelism to achieve the best performance possible.
 
-This specific branch has an additional feature which is for  sftp client to always use absolute paths on the server (i.e. changedirectory will keep track of the absolute path and all file actions will provide absolute paths to the server). This gives support for  buggy server implementations where changedirectory will use the grown permissions. 
+This specific fork has an additional feature which is for  sftp client to always use absolute paths on the server (i.e. changedirectory will keep track of the absolute path and all file actions will provide absolute paths to the server). This gives support for  buggy server implementations where changedirectory will use the grown permissions. 
 
 ## Features
 * Execution of SSH command using both synchronous and asynchronous methods

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This specific branch has an additional feature which is for  sftp client to alwa
 * Supports DES-EDE3-CBC, DES-EDE3-CFB, DES-CBC, AES-128-CBC, AES-192-CBC and AES-256-CBC algorithms for private key encryption
 * Supports two-factor or higher authentication
 * Supports SOCKS4, SOCKS5 and HTTP Proxy
+* Sample of sftp client exe
 
 ## Key Exchange Method
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ SSH.NET is a Secure Shell (SSH-2) library for .NET, optimized for parallelism.
 ## Introduction
 This project was inspired by **Sharp.SSH** library which was ported from java and it seems like was not supported for quite some time. This library is a complete rewrite, without any third party dependencies, using parallelism to achieve the best performance possible.
 
-This specific fork has an additional feature which is for  sftp client to always use absolute paths on the server (i.e. changedirectory will keep track of the absolute path and all file actions will provide absolute paths to the server). This gives support for  buggy server implementations where changedirectory will use the grown permissions. 
-
 ## Features
 * Execution of SSH command using both synchronous and asynchronous methods
 * Return command execution exit status and other information 
@@ -28,6 +26,7 @@ This specific fork has an additional feature which is for  sftp client to always
 * Supports two-factor or higher authentication
 * Supports SOCKS4, SOCKS5 and HTTP Proxy
 * Sample of sftp client exe
+* sftp client can now be configured to always use absolute paths on the server (i.e. changedirectory will keep track of the absolute path and all file actions will provide absolute paths to the server). This gives support for  buggy server implementations where changedirectory will use the grown permissions
 
 ## Key Exchange Method
 

--- a/build/nuget/SSH.NET.nuspec
+++ b/build/nuget/SSH.NET.nuspec
@@ -32,7 +32,7 @@
           <group targetFramework="netstandard2.0">
             <dependency id="SshNet.Security.Cryptography" version="[1.3.0]" />
           </group>
-          <!-- group targetFramework="sl4">
+          <group targetFramework="sl4">
             <dependency id="SshNet.Security.Cryptography" version="[1.3.0]" />
           </group>
           <group targetFramework="sl5">
@@ -47,7 +47,7 @@
           <group targetFramework="uap10.0">
             <dependency id="SshNet.Security.Cryptography" version="[1.3.0]" />
             <dependency id="System.Xml.XPath.XmlDocument" version="4.3.0" />
-          </group -->
+          </group>
         </dependencies>
     </metadata>
 </package>

--- a/build/nuget/SSH.NET.nuspec
+++ b/build/nuget/SSH.NET.nuspec
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
-        <id>SSH.NET</id>
-        <version>2017.0.0-beta1</version>
-        <title>SSH.NET</title>
+        <id>SSH.NET.SftpAlwaysAbsolute</id>
+        <version>2017.0.0-aa1</version>
+        <title>SSH.NET.SftpAlwaysAbsolute</title>
         <authors>Renci</authors>
         <owners>olegkap,drieseng</owners>
         <licenseUrl>https://github.com/sshnet/SSH.NET/blob/master/LICENSE</licenseUrl>
         <projectUrl>https://github.com/sshnet/SSH.NET/</projectUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>SSH.NET is a Secure Shell (SSH) library for .NET, optimized for parallelism and with broad framework support.</description>
+        <description>SSH.NET is a Secure Shell (SSH) library for .NET, optimized for parallelism and with broad framework support. This fork allows for sftp client to always use absolute paths on the server.</description>
         <releaseNotes>https://github.com/sshnet/SSH.NET/releases/tag/2017.0.0-beta1</releaseNotes>
         <summary>A Secure Shell (SSH) library for .NET, optimized for parallelism.</summary>
         <copyright>2012-2017, RENCI</copyright>

--- a/build/nuget/SSH.NET.nuspec
+++ b/build/nuget/SSH.NET.nuspec
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
-        <id>SSH.NET.SftpAlwaysAbsolute</id>
-        <version>2017.0.0-aa1</version>
-        <title>SSH.NET.SftpAlwaysAbsolute</title>
+        <id>SSH.NET</id>
+        <version>2017.0.0-beta1</version>
+        <title>SSH.NET</title>
         <authors>Renci</authors>
         <owners>olegkap,drieseng</owners>
         <licenseUrl>https://github.com/sshnet/SSH.NET/blob/master/LICENSE</licenseUrl>
         <projectUrl>https://github.com/sshnet/SSH.NET/</projectUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>SSH.NET is a Secure Shell (SSH) library for .NET, optimized for parallelism and with broad framework support. This fork allows for sftp client to always use absolute paths on the server.</description>
+        <description>SSH.NET is a Secure Shell (SSH) library for .NET, optimized for parallelism and with broad framework support.</description>
         <releaseNotes>https://github.com/sshnet/SSH.NET/releases/tag/2017.0.0-beta1</releaseNotes>
         <summary>A Secure Shell (SSH) library for .NET, optimized for parallelism.</summary>
         <copyright>2012-2017, RENCI</copyright>
@@ -32,7 +32,7 @@
           <group targetFramework="netstandard2.0">
             <dependency id="SshNet.Security.Cryptography" version="[1.3.0]" />
           </group>
-          <group targetFramework="sl4">
+          <!-- group targetFramework="sl4">
             <dependency id="SshNet.Security.Cryptography" version="[1.3.0]" />
           </group>
           <group targetFramework="sl5">
@@ -47,7 +47,7 @@
           <group targetFramework="uap10.0">
             <dependency id="SshNet.Security.Cryptography" version="[1.3.0]" />
             <dependency id="System.Xml.XPath.XmlDocument" version="4.3.0" />
-          </group>
+          </group -->
         </dependencies>
     </metadata>
 </package>

--- a/src/Renci.SshNet.Tests/Classes/SftpClientTest_Connect_SftpSessionConnectFailure.cs
+++ b/src/Renci.SshNet.Tests/Classes/SftpClientTest_Connect_SftpSessionConnectFailure.cs
@@ -64,7 +64,7 @@ namespace Renci.SshNet.Tests.Classes
                                .Setup(p => p.CreateSftpResponseFactory())
                                .Returns(_sftpResponseFactoryMock.Object);
             _serviceFactoryMock.InSequence(sequence)
-                               .Setup(p => p.CreateSftpSession(_sessionMock.Object, -1, _connectionInfo.Encoding, _sftpResponseFactoryMock.Object))
+                               .Setup(p => p.CreateSftpSession(_sessionMock.Object, -1, _connectionInfo.Encoding, _sftpResponseFactoryMock.Object, false))
                                .Returns(_sftpSessionMock.Object);
             _sftpSessionMock.InSequence(sequence)
                             .Setup(p => p.Connect())

--- a/src/Renci.SshNet.Tests/Classes/SftpClientTest_Dispose_Connected.cs
+++ b/src/Renci.SshNet.Tests/Classes/SftpClientTest_Dispose_Connected.cs
@@ -49,7 +49,7 @@ namespace Renci.SshNet.Tests.Classes
                                .Setup(p => p.CreateSftpResponseFactory())
                                .Returns(_sftpResponseFactoryMock.Object);
             _serviceFactoryMock.InSequence(sequence)
-                               .Setup(p => p.CreateSftpSession(_sessionMock.Object, _operationTimeout, _connectionInfo.Encoding, _sftpResponseFactoryMock.Object))
+                               .Setup(p => p.CreateSftpSession(_sessionMock.Object, _operationTimeout, _connectionInfo.Encoding, _sftpResponseFactoryMock.Object, false))
                                .Returns(_sftpSessionMock.Object);
             _sftpSessionMock.InSequence(sequence).Setup(p => p.Connect());
             _sessionMock.InSequence(sequence).Setup(p => p.OnDisconnecting());
@@ -74,7 +74,7 @@ namespace Renci.SshNet.Tests.Classes
         public void CreateSftpSessionOnServiceFactoryShouldBeInvokedOnce()
         {
             _serviceFactoryMock.Verify(
-                p => p.CreateSftpSession(_sessionMock.Object, _operationTimeout, _connectionInfo.Encoding, _sftpResponseFactoryMock.Object),
+                p => p.CreateSftpSession(_sessionMock.Object, _operationTimeout, _connectionInfo.Encoding, _sftpResponseFactoryMock.Object, false),
                 Times.Once);
         }
 

--- a/src/Renci.SshNet.Tests/Classes/SftpClientTest_Dispose_Disconnected.cs
+++ b/src/Renci.SshNet.Tests/Classes/SftpClientTest_Dispose_Disconnected.cs
@@ -45,7 +45,7 @@ namespace Renci.SshNet.Tests.Classes
                                .Setup(p => p.CreateSftpResponseFactory())
                                .Returns(_sftpResponseFactoryMock.Object);
             _serviceFactoryMock.InSequence(sequence)
-                .Setup(p => p.CreateSftpSession(_sessionMock.Object, _operationTimeout, _connectionInfo.Encoding, _sftpResponseFactoryMock.Object))
+                .Setup(p => p.CreateSftpSession(_sessionMock.Object, _operationTimeout, _connectionInfo.Encoding, _sftpResponseFactoryMock.Object, false))
                 .Returns(_sftpSessionMock.Object);
             _sftpSessionMock.InSequence(sequence).Setup(p => p.Connect());
             _sessionMock.InSequence(sequence).Setup(p => p.OnDisconnecting());
@@ -71,7 +71,7 @@ namespace Renci.SshNet.Tests.Classes
         public void CreateSftpSessionOnServiceFactoryShouldBeInvokedOnce()
         {
             _serviceFactoryMock.Verify(
-                p => p.CreateSftpSession(_sessionMock.Object, _operationTimeout, _connectionInfo.Encoding, _sftpResponseFactoryMock.Object),
+                p => p.CreateSftpSession(_sessionMock.Object, _operationTimeout, _connectionInfo.Encoding, _sftpResponseFactoryMock.Object, false),
                 Times.Once);
         }
 

--- a/src/Renci.SshNet.Tests/Classes/SftpClientTest_Dispose_Disposed.cs
+++ b/src/Renci.SshNet.Tests/Classes/SftpClientTest_Dispose_Disposed.cs
@@ -49,7 +49,7 @@ namespace Renci.SshNet.Tests.Classes
                                .Setup(p => p.CreateSftpResponseFactory())
                                .Returns(_sftpResponseFactoryMock.Object);
             _serviceFactoryMock.InSequence(sequence)
-                .Setup(p => p.CreateSftpSession(_sessionMock.Object, _operationTimeout, _connectionInfo.Encoding, _sftpResponseFactoryMock.Object))
+                .Setup(p => p.CreateSftpSession(_sessionMock.Object, _operationTimeout, _connectionInfo.Encoding, _sftpResponseFactoryMock.Object, false))
                 .Returns(_sftpSessionMock.Object);
             _sftpSessionMock.InSequence(sequence).Setup(p => p.Connect());
             _sessionMock.InSequence(sequence).Setup(p => p.OnDisconnecting());
@@ -75,7 +75,7 @@ namespace Renci.SshNet.Tests.Classes
         public void CreateSftpSessionOnServiceFactoryShouldBeInvokedOnce()
         {
             _serviceFactoryMock.Verify(
-                p => p.CreateSftpSession(_sessionMock.Object, _operationTimeout, _connectionInfo.Encoding, _sftpResponseFactoryMock.Object),
+                p => p.CreateSftpSession(_sessionMock.Object, _operationTimeout, _connectionInfo.Encoding, _sftpResponseFactoryMock.Object, false),
                 Times.Once);
         }
 

--- a/src/Renci.SshNet.Tests/Classes/SftpClientTest_Finalize_Connected.cs
+++ b/src/Renci.SshNet.Tests/Classes/SftpClientTest_Finalize_Connected.cs
@@ -40,7 +40,7 @@ namespace Renci.SshNet.Tests.Classes
             _sessionMock.Setup(p => p.Connect());
             _serviceFactoryMock.Setup(p => p.CreateSftpResponseFactory())
                                .Returns(_sftpResponseFactoryMock.Object);
-            _serviceFactoryMock.Setup(p => p.CreateSftpSession(_sessionMock.Object, _operationTimeout, _connectionInfo.Encoding, _sftpResponseFactoryMock.Object))
+            _serviceFactoryMock.Setup(p => p.CreateSftpSession(_sessionMock.Object, _operationTimeout, _connectionInfo.Encoding, _sftpResponseFactoryMock.Object, false))
                                .Returns(_sftpSessionMock.Object);
             _sftpSessionMock.Setup(p => p.Connect());
 

--- a/src/Renci.SshNet.VS2017.sln
+++ b/src/Renci.SshNet.VS2017.sln
@@ -27,6 +27,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Renci.SshNet.NET35", "Renci
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Renci.SshNet.NETCore", "Renci.SshNet.NETCore\Renci.SshNet.NETCore.csproj", "{8E8229EB-6780-4A8A-B470-E2023FA55AB5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Renci.sftp", "renci.sftp\Renci.sftp.csproj", "{C0B7112C-064E-4A9A-A22C-7DCBD77FC48B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -103,6 +105,26 @@ Global
 		{8E8229EB-6780-4A8A-B470-E2023FA55AB5}.Release|x64.Build.0 = Release|Any CPU
 		{8E8229EB-6780-4A8A-B470-E2023FA55AB5}.Release|x86.ActiveCfg = Release|Any CPU
 		{8E8229EB-6780-4A8A-B470-E2023FA55AB5}.Release|x86.Build.0 = Release|Any CPU
+		{C0B7112C-064E-4A9A-A22C-7DCBD77FC48B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C0B7112C-064E-4A9A-A22C-7DCBD77FC48B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C0B7112C-064E-4A9A-A22C-7DCBD77FC48B}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{C0B7112C-064E-4A9A-A22C-7DCBD77FC48B}.Debug|ARM.Build.0 = Debug|Any CPU
+		{C0B7112C-064E-4A9A-A22C-7DCBD77FC48B}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{C0B7112C-064E-4A9A-A22C-7DCBD77FC48B}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{C0B7112C-064E-4A9A-A22C-7DCBD77FC48B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C0B7112C-064E-4A9A-A22C-7DCBD77FC48B}.Debug|x64.Build.0 = Debug|Any CPU
+		{C0B7112C-064E-4A9A-A22C-7DCBD77FC48B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C0B7112C-064E-4A9A-A22C-7DCBD77FC48B}.Debug|x86.Build.0 = Debug|Any CPU
+		{C0B7112C-064E-4A9A-A22C-7DCBD77FC48B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C0B7112C-064E-4A9A-A22C-7DCBD77FC48B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C0B7112C-064E-4A9A-A22C-7DCBD77FC48B}.Release|ARM.ActiveCfg = Release|Any CPU
+		{C0B7112C-064E-4A9A-A22C-7DCBD77FC48B}.Release|ARM.Build.0 = Release|Any CPU
+		{C0B7112C-064E-4A9A-A22C-7DCBD77FC48B}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{C0B7112C-064E-4A9A-A22C-7DCBD77FC48B}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{C0B7112C-064E-4A9A-A22C-7DCBD77FC48B}.Release|x64.ActiveCfg = Release|Any CPU
+		{C0B7112C-064E-4A9A-A22C-7DCBD77FC48B}.Release|x64.Build.0 = Release|Any CPU
+		{C0B7112C-064E-4A9A-A22C-7DCBD77FC48B}.Release|x86.ActiveCfg = Release|Any CPU
+		{C0B7112C-064E-4A9A-A22C-7DCBD77FC48B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -110,6 +132,9 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{94EE3919-19FA-4D9B-8DA9-249050B15232} = {2D6CAE62-D053-476F-9BDD-2B1F27FA9C5D}
 		{A6C3FFD3-16A5-44D3-8C1F-3613D6DD17D1} = {2D6CAE62-D053-476F-9BDD-2B1F27FA9C5D}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {BE1E1CE2-57C9-4766-858E-1DE90D2F51FD}
 	EndGlobalSection
 	GlobalSection(TestCaseManagementSettings) = postSolution
 		CategoryFile = Renci.SshNet1.vsmdi

--- a/src/Renci.SshNet/IServiceFactory.cs
+++ b/src/Renci.SshNet/IServiceFactory.cs
@@ -32,10 +32,11 @@ namespace Renci.SshNet
         /// <param name="operationTimeout">The number of milliseconds to wait for an operation to complete, or -1 to wait indefinitely.</param>
         /// <param name="encoding">The encoding.</param>
         /// <param name="sftpMessageFactory">The factory to use for creating SFTP messages.</param>
+        /// <param name="changeDirIsLocal">If true, the sftp client will always pass absolute paths to serve, and will locally mimmick 'changedir' operations</param>
         /// <returns>
         /// An <see cref="ISftpSession"/>.
         /// </returns>
-        ISftpSession CreateSftpSession(ISession session, int operationTimeout, Encoding encoding, ISftpResponseFactory sftpMessageFactory);
+        ISftpSession CreateSftpSession(ISession session, int operationTimeout, Encoding encoding, ISftpResponseFactory sftpMessageFactory, bool changeDirIsLocal);
 
         /// <summary>
         /// Create a new <see cref="PipeStream"/>.

--- a/src/Renci.SshNet/ServiceFactory.cs
+++ b/src/Renci.SshNet/ServiceFactory.cs
@@ -53,12 +53,13 @@ namespace Renci.SshNet
         /// <param name="operationTimeout">The number of milliseconds to wait for an operation to complete, or -1 to wait indefinitely.</param>
         /// <param name="encoding">The encoding.</param>
         /// <param name="sftpMessageFactory">The factory to use for creating SFTP messages.</param>
+        /// <param name="changeDirIsLocal">If true, the sftp client will always pass absolute paths to serve, and will locally mimmick 'changedir' operations</param>
         /// <returns>
         /// An <see cref="ISftpSession"/>.
         /// </returns>
-        public ISftpSession CreateSftpSession(ISession session, int operationTimeout, Encoding encoding, ISftpResponseFactory sftpMessageFactory)
+        public ISftpSession CreateSftpSession(ISession session, int operationTimeout, Encoding encoding, ISftpResponseFactory sftpMessageFactory, bool changeDirIsLocal)
         {
-            return new SftpSession(session, operationTimeout, encoding, sftpMessageFactory);
+            return new SftpSession(session, operationTimeout, encoding, sftpMessageFactory, changeDirIsLocal);
         }
 
         /// <summary>

--- a/src/Renci.SshNet/Sftp/SftpSession.cs
+++ b/src/Renci.SshNet/Sftp/SftpSession.cs
@@ -70,7 +70,7 @@ namespace Renci.SshNet.Sftp
         /// <param name="encoding"></param>
         /// <param name="sftpResponseFactory"></param>
         /// <param name="changeDirIsLocal">If true, the sftp client will always pass absolute paths to serve, and will locally mimmick 'changedir' operations</param>
-        public SftpSession(ISession session, int operationTimeout, Encoding encoding, ISftpResponseFactory sftpResponseFactory, bool changeDirIsLocal)
+        public SftpSession(ISession session, int operationTimeout, Encoding encoding, ISftpResponseFactory sftpResponseFactory, bool changeDirIsLocal=false)
             : base(session, "sftp", operationTimeout)
         {
             Encoding = encoding;

--- a/src/Renci.SshNet/Sftp/SftpSession.cs
+++ b/src/Renci.SshNet/Sftp/SftpSession.cs
@@ -24,6 +24,11 @@ namespace Renci.SshNet.Sftp
         private string localWorkingDirectory;
 
         /// <summary>
+        /// If true, the sftp client will always pass absolute paths to serve, and will locally mimmick 'changedir' operations
+        /// </summary>
+        private bool changeDirIsLocal;
+
+        /// <summary>
         /// Gets the character encoding to use.
         /// </summary>
         protected Encoding Encoding { get; private set; }
@@ -57,11 +62,20 @@ namespace Renci.SshNet.Sftp
             }
         }
 
-        public SftpSession(ISession session, int operationTimeout, Encoding encoding, ISftpResponseFactory sftpResponseFactory)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="session"></param>
+        /// <param name="operationTimeout"></param>
+        /// <param name="encoding"></param>
+        /// <param name="sftpResponseFactory"></param>
+        /// <param name="changeDirIsLocal">If true, the sftp client will always pass absolute paths to serve, and will locally mimmick 'changedir' operations</param>
+        public SftpSession(ISession session, int operationTimeout, Encoding encoding, ISftpResponseFactory sftpResponseFactory, bool changeDirIsLocal)
             : base(session, "sftp", operationTimeout)
         {
             Encoding = encoding;
             _sftpResponseFactory = sftpResponseFactory;
+            this.changeDirIsLocal = changeDirIsLocal;
         }
 
         /// <summary>
@@ -70,7 +84,7 @@ namespace Renci.SshNet.Sftp
         /// <param name="path">The new working directory.</param>
         public void ChangeDirectory(string path)
         {
-            if (!SftpClient.ChangeDirIsLocal)
+            if (!this.changeDirIsLocal)
             {
                 var fullPath = GetCanonicalPath(path);
                 var handle = RequestOpenDir(fullPath);
@@ -95,7 +109,7 @@ namespace Renci.SshNet.Sftp
         /// <returns></returns>
         private string GetRelativePathIfNeeded(string path)
         {
-            if (!path.StartsWith("/") && SftpClient.ChangeDirIsLocal)
+            if (!path.StartsWith("/") && this.changeDirIsLocal)
             {
                 path = Compact(localWorkingDirectory + "/" + path);
             }

--- a/src/Renci.SshNet/SftpClient.cs
+++ b/src/Renci.SshNet/SftpClient.cs
@@ -40,7 +40,7 @@ namespace Renci.SshNet
         /// Gets or sets a value indicating if ChangeDir must be kept local to the client. 
         /// By default, this is false.
         /// </summary>
-        public static bool ChangeDirIsLocal { get; set; }
+        public bool ChangeDirIsLocal { get; set; }
 
         /// <summary>
         /// Gets or sets the operation timeout.
@@ -2213,7 +2213,8 @@ namespace Renci.SshNet
             var sftpSession = ServiceFactory.CreateSftpSession(Session,
                                                                _operationTimeout,
                                                                ConnectionInfo.Encoding,
-                                                               ServiceFactory.CreateSftpResponseFactory());
+                                                               ServiceFactory.CreateSftpResponseFactory(), 
+                                                               this.ChangeDirIsLocal);
             try
             {
                 sftpSession.Connect();

--- a/src/Renci.SshNet/SftpClient.cs
+++ b/src/Renci.SshNet/SftpClient.cs
@@ -35,6 +35,12 @@ namespace Renci.SshNet
         /// Holds the size of the buffer.
         /// </summary>
         private uint _bufferSize;
+        
+        /// <summary>
+        /// Gets or sets a value indicating if ChangeDir must be kept local to the client. 
+        /// By default, this is false.
+        /// </summary>
+        public static bool ChangeDirIsLocal { get; set; }
 
         /// <summary>
         /// Gets or sets the operation timeout.

--- a/src/Renci.sftp/Program.cs
+++ b/src/Renci.sftp/Program.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 
-namespace renci.sftp
+namespace Renci.sftp
 {
     class Program
     {
@@ -18,15 +18,25 @@ namespace renci.sftp
 
             int port = 22;
             string destination = "127.0.0.1";
+            bool localChangeDir = false;
+
             for (int i = 0; i < args.Length; i++)
             {
-                if (args[i] == "P")
+                if (args[i] == "-P")
                 {
                     if (i + 1 < args.Length)
                     {
                         port = int.Parse(args[i + 1]);
                         i++;
                     }
+
+                    continue;
+                }
+
+                if (args[i] == "-LCHD")
+                {
+                    localChangeDir = true;
+                    continue;
                 }
 
                 destination = args[i];
@@ -37,10 +47,11 @@ namespace renci.sftp
             Console.Write("pwd: ");
             string password = ReadPassword();
             Console.WriteLine("connecting...");
-            Renci.SshNet.SftpClient.ChangeDirIsLocal = true;
-            using (var client = new Renci.SshNet.SftpClient(destination, port, username, password))
+            using (var client = new SshNet.SftpClient(destination, port, username, password))
             {
+                client.ChangeDirIsLocal = localChangeDir;
                 client.Connect();
+
                 while (true)
                 {
                     Console.WriteLine();

--- a/src/Renci.sftp/Program.cs
+++ b/src/Renci.sftp/Program.cs
@@ -1,0 +1,182 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace renci.sftp
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            if (args.Length == 0)
+            {
+                Usage();
+                return;
+            }
+
+            int port = 22;
+            string destination = "127.0.0.1";
+            for (int i = 0; i < args.Length; i++)
+            {
+                if (args[i] == "P")
+                {
+                    if (i + 1 < args.Length)
+                    {
+                        port = int.Parse(args[i + 1]);
+                        i++;
+                    }
+                }
+
+                destination = args[i];
+            }
+
+            Console.Write("user: ");
+            string username = Console.ReadLine();
+            Console.Write("pwd: ");
+            string password = ReadPassword();
+            Console.WriteLine("connecting...");
+            Renci.SshNet.SftpClient.ChangeDirIsLocal = true;
+            using (var client = new Renci.SshNet.SftpClient(destination, port, username, password))
+            {
+                client.Connect();
+                while (true)
+                {
+                    Console.WriteLine();
+                    string current = client.WorkingDirectory;
+                    Console.Write(current);
+                    Console.Write(">>");Console.Out.Flush();
+                    string line = Console.ReadLine();
+                    try
+                    {
+                        if (!Process(client, line.Split(' ')))
+                        {
+                            break;
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine(e);
+                    }
+                }
+            }
+        }
+
+        private static bool Process(Renci.SshNet.SftpClient client, string[] line)
+        {
+            switch (line[0])
+            {
+                case "cd":
+                    if (line.Length == 1)
+                    {
+                        Console.WriteLine(client.WorkingDirectory);
+                    }
+                    else
+                    {
+                        client.ChangeDirectory(line[1]);
+                    }
+                    break;
+                case "pwd":
+                    Console.WriteLine(Environment.CurrentDirectory);
+                    break;
+                case "rm":
+                    client.DeleteFile(line[1]);
+                    break;
+                case "put":
+                    using (var l = File.OpenRead(line[1]))
+                    {
+                        string dest = (line.Length > 2 ? line[2] : line[1]);
+                        using (var f = client.OpenWrite(dest))
+                        {
+                            byte[] buffer = new byte[1024 * 16];
+                            int r;
+                            while ((r = l.Read(buffer, 0, buffer.Length)) > 0)
+                            {
+                                f.Write(buffer, 0, r);
+                            }
+                            f.Flush();
+                        }
+                    }
+                    break;
+                case "cat":
+                    Console.WriteLine(client.ReadAllText(line[1]));
+                    break;
+                case "get":
+                    using (var l = client.OpenRead(line[1]))
+                    {
+                        string dest = (line.Length > 2 ? line[2] : line[1]);
+                        using (var f = File.OpenWrite(dest))
+                        {
+                            byte[] buffer = new byte[1024 * 16];
+                            int r;
+                            while ((r = l.Read(buffer, 0, buffer.Length)) > 0)
+                            {
+                                f.Write(buffer, 0, r);
+                            }
+                            f.Flush();
+                        }
+                    }
+                    break;
+                case "dir":
+                    {
+                        string path = (line.Length > 1 ? line[1] : ".");
+                        foreach (var el in Directory.GetFileSystemEntries(path))
+                        {
+                            Console.WriteLine(el);
+                        }
+                        break;
+                    }
+                case "ls":
+                    {
+                        string path = (line.Length > 1 ? line[1] : ".");
+
+                        foreach (var el in client.ListDirectory(path))
+                        {
+                            Console.WriteLine(el.FullName);
+                        }
+                        break;
+                    }
+                case "exit":
+                case "quit":
+                    return false;
+                default:
+                    throw new ArgumentException("unsupported command " + line[0]);
+            }
+
+            return true;
+        }
+
+        private static string ReadPassword()
+        {
+            string pass = String.Empty;
+            do
+            {
+                var key = Console.ReadKey(true);
+
+                if (key.Key == ConsoleKey.Enter)
+                {
+                    Console.WriteLine();
+                    break;
+                }
+
+                if (key.Key == ConsoleKey.Backspace && pass.Length > 0)
+                {
+                    pass = pass.Substring(0, (pass.Length - 1));
+                    Console.Write("\b \b");
+                }
+                else
+                {
+                    pass = pass + key.KeyChar;
+                }
+            } while (true);
+
+            return pass;
+        }
+
+        private static void Usage()
+        {
+            Console.WriteLine(@"usage: Renci.sftp [-P port] destination");
+        }
+    }
+}

--- a/src/Renci.sftp/Properties/AssemblyInfo.cs
+++ b/src/Renci.sftp/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Renci.sftp")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Renci.sftp")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("c0b7112c-064e-4a9a-a22c-7dcbd77fc48b")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Renci.sftp/Renci.sftp.csproj
+++ b/src/Renci.sftp/Renci.sftp.csproj
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C0B7112C-064E-4A9A-A22C-7DCBD77FC48B}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Renci.sftp</RootNamespace>
+    <AssemblyName>Renci.sftp</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Renci.SshNet.NET35\Renci.SshNet.NET35.csproj">
+      <Project>{dd1c552f-7f48-4269-abb3-2e4c89b7e43a}</Project>
+      <Name>Renci.SshNet.NET35</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>


### PR DESCRIPTION
There are some implementations of sftp servers where "ChangeDir" will cause the server to go to a different physical path (due to soft links on the server) where the permissions are different from those permissions if the client-perceived paths are used.
The current sftp client implementation makes use of GetCanonicalPath which causes for those servers to potentially cause a permissions error where the path provided by the client has the right permissions.

This change allows the sftpclient to be configured so the client will always use the paths provided by the application and will not try to changedirs on the server, thus avoiding this issue.

For reference, this problem is present in some Sftp implementation for certain Cisco routers, for example.