### PR TITLE
Correction for issue #562

### DIFF
--- a/src/Renci.SshNet/SshCommand.cs
+++ b/src/Renci.SshNet/SshCommand.cs
@@ -246,13 +246,13 @@ namespace Renci.SshNet
             //  Initialize output streams
             OutputStream = new PipeStream();
             ExtendedOutputStream = new PipeStream();
+            _result = null;
+            _error = null;
+            _callback = callback;
             if (CommandTimeout != Session.InfiniteTimeSpan)
             {
                 _timeoutTimer = new Timer(new TimerCallback(TimeoutCallback), null, CommandTimeout, TimeSpan.FromMilliseconds(-1));
             };
-            _result = null;
-            _error = null;
-            _callback = callback;
 
             _channel = CreateChannel();
             _channel.Open();


### PR DESCRIPTION
To correct issue #562, use only one ManualResetEvent is SshCommand , which is signaled when the command complete, either on success or on error.
Add also a dispose of this ManualResetEvent.