### PR TITLE
Send keys proactively

### DIFF
--- a/src/Renci.SshNet/ConnectionInfo.cs
+++ b/src/Renci.SshNet/ConnectionInfo.cs
@@ -181,6 +181,11 @@ namespace Renci.SshNet
         public int MaxSessions { get; set; }
 
         /// <summary>
+        /// Flag whether the keys should be transferred proactively
+        /// </summary>
+        public bool SendKeysProactively { get; set; }
+
+        /// <summary>
         /// Occurs when authentication banner is sent by the server.
         /// </summary>
         /// <example>

--- a/src/Renci.SshNet/Security/KeyExchange.cs
+++ b/src/Renci.SshNet/Security/KeyExchange.cs
@@ -70,9 +70,10 @@ namespace Renci.SshNet.Security
         public virtual void Start(Session session, KeyExchangeInitMessage message)
         {
             Session = session;
-
-            SendMessage(session.ClientInitMessage);
-
+             
+            if (!Session.ConnectionInfo.SendKeysProactively) {
+                SendMessage(session.ClientInitMessage);
+            }
             //  Determine encryption algorithm
             var clientEncryptionAlgorithmName = (from b in session.ConnectionInfo.Encryptions.Keys
                                                  from a in message.EncryptionAlgorithmsClientToServer

--- a/src/Renci.SshNet/Session.cs
+++ b/src/Renci.SshNet/Session.cs
@@ -638,7 +638,7 @@ namespace Renci.SshNet
                     {
                         throw new SshConnectionException(string.Format(CultureInfo.CurrentCulture, "Server version '{0}' is not supported.", version), DisconnectReason.ProtocolVersionNotSupported);
                     }
-19
+
                     SocketAbstraction.Send(_socket, Encoding.UTF8.GetBytes(string.Format(CultureInfo.InvariantCulture, "{0}\x0D\x0A", ClientVersion)));
 
                     //  Register Transport response messages

--- a/src/Renci.SshNet/Session.cs
+++ b/src/Renci.SshNet/Session.cs
@@ -659,6 +659,9 @@ namespace Renci.SshNet
                     //  Start incoming request listener
                     ThreadAbstraction.ExecuteThread(() => MessageListener());
 
+                    if (this.ConnectionInfo.SendKeysProactively) {
+                        SendMessage(this.ClientInitMessage);
+                    }
                     //  Wait for key exchange to be completed
                     WaitOnHandle(_keyExchangeCompletedWaitHandle);
 
@@ -1935,10 +1938,9 @@ namespace Renci.SshNet
                         break;
                     }
 
-#if FEATURE_SOCKET_POLL || FEATURE_SOCKET_SELECT
                     try
                     {
-#if FEATURE_SOCKET_POLL
+    #if FEATURE_SOCKET_POLL
                         // Block until either data is available or the socket is closed
                         var connectionClosedOrDataAvailable = socket.Poll(-1, SelectMode.SelectRead);
                         if (connectionClosedOrDataAvailable && socket.Available == 0)
@@ -1946,7 +1948,7 @@ namespace Renci.SshNet
                             // connection with SSH server was closed or connection was reset
                             break;
                         }
-#elif FEATURE_SOCKET_SELECT
+    #elif FEATURE_SOCKET_SELECT
                         var readSockets = new List<Socket> { socket };
 
                         // if the socket is already disposed when Select is invoked, then a SocketException
@@ -1982,7 +1984,10 @@ namespace Renci.SshNet
                             // break out of the message loop
                             break;
                         }
-#endif // FEATURE_SOCKET_SELECT
+    #else
+                        #error Blocking wait on either socket data to become available or connection to be 
+                        #error closed is not implemented.
+    #endif // FEATURE_SOCKET_SELECT
                     }
                     catch (ObjectDisposedException)
                     {
@@ -1992,7 +1997,6 @@ namespace Renci.SshNet
                         // * a SSH_MSG_DISCONNECT received from server
                         break;
                     }
-#endif // FEATURE_SOCKET_POLL || FEATURE_SOCKET_SELECT
 
                     var message = ReceiveMessage(socket);
                     if (message == null)


### PR DESCRIPTION
Added flag to send keys proactively. Some devices wait for the keys (like SSH.Net does) so it will timeout because both parties are waiting for a message from the other.