### PR TITLE
PrivateKeyFile constructor xml documentation update

### DIFF
--- a/src/Renci.SshNet/PrivateKeyFile.cs
+++ b/src/Renci.SshNet/PrivateKeyFile.cs
@@ -104,7 +104,8 @@ namespace Renci.SshNet
         /// </summary>
         /// <param name="fileName">Name of the file.</param>
         /// <param name="passPhrase">The pass phrase.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="fileName"/> is <c>null</c> or empty, or <paramref name="passPhrase"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="fileName"/> is <c>null</c>.</exception>
+        /// <exception cref="SshPassPhraseNullOrEmptyException"><paramref name="passPhrase"/> is null when the private key requires a valid pass phrase.</exception>
         /// <remarks>This method calls <see cref="System.IO.File.Open(string, System.IO.FileMode)"/> internally, this method does not catch exceptions from <see cref="System.IO.File.Open(string, System.IO.FileMode)"/>.</remarks>
         public PrivateKeyFile(string fileName, string passPhrase)
         {
@@ -122,7 +123,8 @@ namespace Renci.SshNet
         /// </summary>
         /// <param name="privateKey">The private key.</param>
         /// <param name="passPhrase">The pass phrase.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="privateKey"/> or <paramref name="passPhrase"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="privateKey"/> is <c>null</c>.</exception>
+        /// <exception cref="SshPassPhraseNullOrEmptyException"><paramref name="passPhrase"/> is null when the private key requires a valid pass phrase.</exception>
         public PrivateKeyFile(Stream privateKey, string passPhrase)
         {
             Open(privateKey, passPhrase);


### PR DESCRIPTION
While I was making use of the PrivateKeyFile constructors, I noticed the xml documentation state that a NullReferenceExeception would be thrown if the passPhrase was null.  This made my code just a little bit more complex.
Upon investigation, I found that documentation did not reflect the implementation.  This pull request is to update that piece of documentation.