### PR TITLE
Preserve exception stack trace in Session.WaitOnHandle()

### DIFF
--- a/src/Renci.SshNet/Renci.SshNet.csproj
+++ b/src/Renci.SshNet/Renci.SshNet.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>Renci.SshNet</AssemblyName>
     <AssemblyOriginatorKeyFile>../Renci.SshNet.snk</AssemblyOriginatorKeyFile>
-    <LangVersion>5</LangVersion>
+    <LangVersion>latest</LangVersion>
     <SignAssembly>true</SignAssembly>
     <TargetFrameworks>net35;net40;netstandard1.3;netstandard2.0</TargetFrameworks>
   </PropertyGroup>


### PR DESCRIPTION
Throwing `_exception` loses the original stack trace, making it difficult to debug problems.
Original stack trace is now saved in the exception data for .NET 3.5 and 4.0 clients, or
correctly rethrown with the full stack for .NET Standard 1.3 and 2.0 clients.