### PR TITLE
Fix exception when reading duplicate sftp extensions

### DIFF
--- a/src/Renci.SshNet/Common/SshData.cs
+++ b/src/Renci.SshNet/Common/SshData.cs
@@ -251,7 +251,14 @@ namespace Renci.SshNet.Common
             {
                 var extensionName = ReadString(Ascii);
                 var extensionData = ReadString(Ascii);
-                result.Add(extensionName, extensionData);
+                if (result.ContainsKey(extensionName)) //if sftp extension is present multiple-times then keep the last one
+                {
+                    result[extensionName] = extensionData;
+                }
+                else
+                {
+                    result.Add(extensionName, extensionData);
+                }
             }
             return result;
         }


### PR DESCRIPTION
If the server return duplicated sftp extensions then we keep the last value instead of throwing an exception

Fix #726