### PR TITLE
Significantly improved performance and fixed bug with ShellStream's Expect methods.

### DIFF
--- a/src/Renci.SshNet.Tests/Classes/ServiceFactoryTest_CreateShellStream_ChannelOpenThrowsException.cs
+++ b/src/Renci.SshNet.Tests/Classes/ServiceFactoryTest_CreateShellStream_ChannelOpenThrowsException.cs
@@ -22,6 +22,7 @@ namespace Renci.SshNet.Tests.Classes
         private uint _height;
         private IDictionary<TerminalModes, uint> _terminalModeValues;
         private int _bufferSize;
+        private int _expectSize;
         private SshException _channelOpenException;
         private SshException _actualException;
 
@@ -30,12 +31,13 @@ namespace Renci.SshNet.Tests.Classes
             var random = new Random();
 
             _terminalName = random.Next().ToString();
-            _columns = (uint) random.Next();
-            _rows = (uint) random.Next();
-            _width = (uint) random.Next();
-            _height = (uint) random.Next();
+            _columns = (uint)random.Next();
+            _rows = (uint)random.Next();
+            _width = (uint)random.Next();
+            _height = (uint)random.Next();
             _terminalModeValues = new Dictionary<TerminalModes, uint>();
             _bufferSize = random.Next();
+            _expectSize = random.Next();
             _channelOpenException = new SshException();
 
             _actualException = null;
@@ -95,7 +97,8 @@ namespace Renci.SshNet.Tests.Classes
                                                   _width,
                                                   _height,
                                                   _terminalModeValues,
-                                                  _bufferSize);
+                                                  _bufferSize,
+                                                  _expectSize);
                 Assert.Fail();
             }
             catch (SshException ex)

--- a/src/Renci.SshNet.Tests/Classes/ServiceFactoryTest_CreateShellStream_SendPseudoTerminalRequestReturnsFalse.cs
+++ b/src/Renci.SshNet.Tests/Classes/ServiceFactoryTest_CreateShellStream_SendPseudoTerminalRequestReturnsFalse.cs
@@ -22,6 +22,7 @@ namespace Renci.SshNet.Tests.Classes
         private uint _height;
         private IDictionary<TerminalModes, uint> _terminalModeValues;
         private int _bufferSize;
+        private int _expectSize;
         private SshException _actualException;
 
         private void SetupData()
@@ -35,6 +36,7 @@ namespace Renci.SshNet.Tests.Classes
             _height = (uint)random.Next();
             _terminalModeValues = new Dictionary<TerminalModes, uint>();
             _bufferSize = random.Next();
+            _expectSize = random.Next();
             _actualException = null;
         }
 
@@ -94,7 +96,8 @@ namespace Renci.SshNet.Tests.Classes
                                                   _width,
                                                   _height,
                                                   _terminalModeValues,
-                                                  _bufferSize);
+                                                  _bufferSize,
+                                                  _expectSize);
                 Assert.Fail();
             }
             catch (SshException ex)

--- a/src/Renci.SshNet.Tests/Classes/ServiceFactoryTest_CreateShellStream_SendPseudoTerminalRequestThrowsException.cs
+++ b/src/Renci.SshNet.Tests/Classes/ServiceFactoryTest_CreateShellStream_SendPseudoTerminalRequestThrowsException.cs
@@ -22,6 +22,7 @@ namespace Renci.SshNet.Tests.Classes
         private uint _height;
         private IDictionary<TerminalModes, uint> _terminalModeValues;
         private int _bufferSize;
+        private int _expectSize;
         private SshException _sendPseudoTerminalRequestException;
         private SshException _actualException;
 
@@ -30,12 +31,13 @@ namespace Renci.SshNet.Tests.Classes
             var random = new Random();
 
             _terminalName = random.Next().ToString();
-            _columns = (uint) random.Next();
-            _rows = (uint) random.Next();
-            _width = (uint) random.Next();
-            _height = (uint) random.Next();
+            _columns = (uint)random.Next();
+            _rows = (uint)random.Next();
+            _width = (uint)random.Next();
+            _height = (uint)random.Next();
             _terminalModeValues = new Dictionary<TerminalModes, uint>();
             _bufferSize = random.Next();
+            _expectSize = random.Next();
             _sendPseudoTerminalRequestException = new SshException();
 
             _actualException = null;
@@ -97,7 +99,8 @@ namespace Renci.SshNet.Tests.Classes
                                                   _width,
                                                   _height,
                                                   _terminalModeValues,
-                                                  _bufferSize);
+                                                  _bufferSize,
+                                                  _expectSize);
                 Assert.Fail();
             }
             catch (SshException ex)

--- a/src/Renci.SshNet.Tests/Classes/ServiceFactoryTest_CreateShellStream_SendShellRequestReturnsFalse.cs
+++ b/src/Renci.SshNet.Tests/Classes/ServiceFactoryTest_CreateShellStream_SendShellRequestReturnsFalse.cs
@@ -22,6 +22,7 @@ namespace Renci.SshNet.Tests.Classes
         private uint _height;
         private IDictionary<TerminalModes, uint> _terminalModeValues;
         private int _bufferSize;
+        private int _expectSize;
         private SshException _actualException;
 
         private void SetupData()
@@ -29,12 +30,13 @@ namespace Renci.SshNet.Tests.Classes
             var random = new Random();
 
             _terminalName = random.Next().ToString();
-            _columns = (uint) random.Next();
-            _rows = (uint) random.Next();
-            _width = (uint) random.Next();
-            _height = (uint) random.Next();
+            _columns = (uint)random.Next();
+            _rows = (uint)random.Next();
+            _width = (uint)random.Next();
+            _height = (uint)random.Next();
             _terminalModeValues = new Dictionary<TerminalModes, uint>();
             _bufferSize = random.Next();
+            _expectSize = random.Next();
             _actualException = null;
         }
 
@@ -97,7 +99,8 @@ namespace Renci.SshNet.Tests.Classes
                                                   _width,
                                                   _height,
                                                   _terminalModeValues,
-                                                  _bufferSize);
+                                                  _bufferSize,
+                                                  _expectSize);
                 Assert.Fail();
             }
             catch (SshException ex)

--- a/src/Renci.SshNet.Tests/Classes/ServiceFactoryTest_CreateShellStream_SendShellRequestThrowsException.cs
+++ b/src/Renci.SshNet.Tests/Classes/ServiceFactoryTest_CreateShellStream_SendShellRequestThrowsException.cs
@@ -22,6 +22,7 @@ namespace Renci.SshNet.Tests.Classes
         private uint _height;
         private IDictionary<TerminalModes, uint> _terminalModeValues;
         private int _bufferSize;
+        private int _expectSize;
         private SshException _sendShellRequestException;
         private SshException _actualException;
 
@@ -30,12 +31,13 @@ namespace Renci.SshNet.Tests.Classes
             var random = new Random();
 
             _terminalName = random.Next().ToString();
-            _columns = (uint) random.Next();
-            _rows = (uint) random.Next();
-            _width = (uint) random.Next();
-            _height = (uint) random.Next();
+            _columns = (uint)random.Next();
+            _rows = (uint)random.Next();
+            _width = (uint)random.Next();
+            _height = (uint)random.Next();
             _terminalModeValues = new Dictionary<TerminalModes, uint>();
             _bufferSize = random.Next();
+            _expectSize = random.Next();
             _sendShellRequestException = new SshException();
             _actualException = null;
         }
@@ -99,7 +101,8 @@ namespace Renci.SshNet.Tests.Classes
                                                   _width,
                                                   _height,
                                                   _terminalModeValues,
-                                                  _bufferSize);
+                                                  _bufferSize,
+                                                  _expectSize);
                 Assert.Fail();
             }
             catch (SshException ex)

--- a/src/Renci.SshNet.Tests/Classes/ServiceFactoryTest_CreateShellStream_Success.cs
+++ b/src/Renci.SshNet.Tests/Classes/ServiceFactoryTest_CreateShellStream_Success.cs
@@ -22,6 +22,7 @@ namespace Renci.SshNet.Tests.Classes
         private uint _height;
         private IDictionary<TerminalModes, uint> _terminalModeValues;
         private int _bufferSize;
+        private int _expectSize;
         private ShellStream _shellStream;
 
         private void SetupData()
@@ -29,12 +30,13 @@ namespace Renci.SshNet.Tests.Classes
             var random = new Random();
 
             _terminalName = random.Next().ToString();
-            _columns = (uint) random.Next();
-            _rows = (uint) random.Next();
-            _width = (uint) random.Next();
-            _height = (uint) random.Next();
+            _columns = (uint)random.Next();
+            _rows = (uint)random.Next();
+            _width = (uint)random.Next();
+            _height = (uint)random.Next();
             _terminalModeValues = new Dictionary<TerminalModes, uint>();
             _bufferSize = random.Next();
+            _expectSize = random.Next();
         }
 
         private void CreateMocks()
@@ -97,7 +99,8 @@ namespace Renci.SshNet.Tests.Classes
                                                              _width,
                                                              _height,
                                                              _terminalModeValues,
-                                                             _bufferSize);
+                                                             _bufferSize,
+                                                             _expectSize);
         }
 
         [TestMethod]

--- a/src/Renci.SshNet.Tests/Classes/ShellStreamTest.cs
+++ b/src/Renci.SshNet.Tests/Classes/ShellStreamTest.cs
@@ -27,6 +27,7 @@ namespace Renci.SshNet.Tests.Classes
         private uint _heightPixels;
         private Dictionary<TerminalModes, uint> _terminalModes;
         private int _bufferSize;
+        private int _expectSize;
         private Mock<IChannelSession> _channelSessionMock;
 
         protected override void OnInit()
@@ -35,12 +36,13 @@ namespace Renci.SshNet.Tests.Classes
 
             var random = new Random();
             _terminalName = random.Next().ToString(CultureInfo.InvariantCulture);
-            _widthColumns = (uint) random.Next();
-            _heightRows = (uint) random.Next();
+            _widthColumns = (uint)random.Next();
+            _heightRows = (uint)random.Next();
             _widthPixels = (uint)random.Next();
             _heightPixels = (uint)random.Next();
             _terminalModes = new Dictionary<TerminalModes, uint>();
             _bufferSize = random.Next(100, 500);
+            _expectSize = random.Next(100, 500);
 
             _encoding = Encoding.UTF8;
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
@@ -61,15 +63,15 @@ namespace Renci.SshNet.Tests.Classes
             var shellStream = CreateShellStream();
 
             var channelDataPublishThread = new Thread(() =>
-                {
-                    _channelSessionMock.Raise(p => p.DataReceived += null,
-                        new ChannelDataEventArgs(5, _encoding.GetBytes(data1)));
-                    Thread.Sleep(50);
-                    _channelSessionMock.Raise(p => p.DataReceived += null,
-                        new ChannelDataEventArgs(5, _encoding.GetBytes(data2 + "\r\n")));
-                    _channelSessionMock.Raise(p => p.DataReceived += null,
-                        new ChannelDataEventArgs(5, _encoding.GetBytes(data3 + "\r\n")));
-                });
+            {
+                _channelSessionMock.Raise(p => p.DataReceived += null,
+                    new ChannelDataEventArgs(5, _encoding.GetBytes(data1)));
+                Thread.Sleep(50);
+                _channelSessionMock.Raise(p => p.DataReceived += null,
+                    new ChannelDataEventArgs(5, _encoding.GetBytes(data2 + "\r\n")));
+                _channelSessionMock.Raise(p => p.DataReceived += null,
+                    new ChannelDataEventArgs(5, _encoding.GetBytes(data3 + "\r\n")));
+            });
             channelDataPublishThread.Start();
 
             Assert.AreEqual(data1 + data2, shellStream.ReadLine());
@@ -120,7 +122,8 @@ namespace Renci.SshNet.Tests.Classes
                                    _widthPixels,
                                    _heightPixels,
                                    _terminalModes,
-                                   _bufferSize);
+                                   _bufferSize,
+                                   _expectSize);
         }
     }
 }

--- a/src/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferEmptyAndWriteLessBytesThanBufferSize.cs
+++ b/src/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferEmptyAndWriteLessBytesThanBufferSize.cs
@@ -23,6 +23,7 @@ namespace Renci.SshNet.Tests.Classes
         private Dictionary<TerminalModes, uint> _terminalModes;
         private ShellStream _shellStream;
         private int _bufferSize;
+        private int _expectSize;
 
         private byte[] _data;
         private int _offset;
@@ -41,12 +42,13 @@ namespace Renci.SshNet.Tests.Classes
             var random = new Random();
 
             _terminalName = random.Next().ToString();
-            _widthColumns = (uint) random.Next();
-            _heightRows = (uint) random.Next();
-            _widthPixels = (uint) random.Next();
-            _heightPixels = (uint) random.Next();
+            _widthColumns = (uint)random.Next();
+            _heightRows = (uint)random.Next();
+            _widthPixels = (uint)random.Next();
+            _heightPixels = (uint)random.Next();
             _terminalModes = new Dictionary<TerminalModes, uint>();
             _bufferSize = random.Next(100, 1000);
+            _expectSize = random.Next(100, 1000);
 
             _data = CryptoAbstraction.GenerateRandom(_bufferSize - 10);
             _offset = random.Next(1, 5);
@@ -101,7 +103,8 @@ namespace Renci.SshNet.Tests.Classes
                                            _widthPixels,
                                            _heightPixels,
                                            _terminalModes,
-                                           _bufferSize);
+                                           _bufferSize,
+                                           _expectSize);
         }
 
         private void Act()

--- a/src/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferEmptyAndWriteMoreBytesThanBufferSize.cs
+++ b/src/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferEmptyAndWriteMoreBytesThanBufferSize.cs
@@ -24,6 +24,7 @@ namespace Renci.SshNet.Tests.Classes
         private Dictionary<TerminalModes, uint> _terminalModes;
         private ShellStream _shellStream;
         private int _bufferSize;
+        private int _expectSize;
 
         private byte[] _data;
         private int _offset;
@@ -50,6 +51,7 @@ namespace Renci.SshNet.Tests.Classes
             _heightPixels = (uint)random.Next();
             _terminalModes = new Dictionary<TerminalModes, uint>();
             _bufferSize = random.Next(100, 1000);
+            _expectSize = random.Next(100, 1000);
 
             _data = CryptoAbstraction.GenerateRandom(_bufferSize * 2 + 10);
             _offset = 0;
@@ -111,7 +113,8 @@ namespace Renci.SshNet.Tests.Classes
                                            _widthPixels,
                                            _heightPixels,
                                            _terminalModes,
-                                           _bufferSize);
+                                           _bufferSize,
+                                           _expectSize);
         }
 
         private void Act()

--- a/src/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferEmptyAndWriteNumberOfBytesEqualToBufferSize.cs
+++ b/src/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferEmptyAndWriteNumberOfBytesEqualToBufferSize.cs
@@ -23,6 +23,7 @@ namespace Renci.SshNet.Tests.Classes
         private Dictionary<TerminalModes, uint> _terminalModes;
         private ShellStream _shellStream;
         private int _bufferSize;
+        private int _expectSize;
 
         private byte[] _data;
         private int _offset;
@@ -47,6 +48,7 @@ namespace Renci.SshNet.Tests.Classes
             _heightPixels = (uint)random.Next();
             _terminalModes = new Dictionary<TerminalModes, uint>();
             _bufferSize = random.Next(100, 1000);
+            _expectSize = random.Next(100, 1000);
 
             _data = CryptoAbstraction.GenerateRandom(_bufferSize);
             _offset = 0;
@@ -101,7 +103,8 @@ namespace Renci.SshNet.Tests.Classes
                                            _widthPixels,
                                            _heightPixels,
                                            _terminalModes,
-                                           _bufferSize);
+                                           _bufferSize,
+                                           _expectSize);
         }
 
         private void Act()

--- a/src/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferEmptyAndWriteZeroBytes.cs
+++ b/src/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferEmptyAndWriteZeroBytes.cs
@@ -23,6 +23,7 @@ namespace Renci.SshNet.Tests.Classes
         private Dictionary<TerminalModes, uint> _terminalModes;
         private ShellStream _shellStream;
         private int _bufferSize;
+        private int _expectSize;
 
         private byte[] _data;
         private int _offset;
@@ -47,6 +48,7 @@ namespace Renci.SshNet.Tests.Classes
             _heightPixels = (uint)random.Next();
             _terminalModes = new Dictionary<TerminalModes, uint>();
             _bufferSize = random.Next(100, 1000);
+            _expectSize = random.Next(100, 1000);
 
             _data = new byte[0];
             _offset = 0;
@@ -101,7 +103,8 @@ namespace Renci.SshNet.Tests.Classes
                                            _widthPixels,
                                            _heightPixels,
                                            _terminalModes,
-                                           _bufferSize);
+                                           _bufferSize,
+                                           _expectSize);
         }
 
         private void Act()

--- a/src/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferFullAndWriteLessBytesThanBufferSize.cs
+++ b/src/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferFullAndWriteLessBytesThanBufferSize.cs
@@ -23,6 +23,7 @@ namespace Renci.SshNet.Tests.Classes
         private Dictionary<TerminalModes, uint> _terminalModes;
         private ShellStream _shellStream;
         private int _bufferSize;
+        private int _expectSize;
 
         private byte[] _data;
         private int _offset;
@@ -48,6 +49,7 @@ namespace Renci.SshNet.Tests.Classes
             _heightPixels = (uint)random.Next();
             _terminalModes = new Dictionary<TerminalModes, uint>();
             _bufferSize = random.Next(100, 1000);
+            _expectSize = random.Next(100, 1000);
 
             _bufferData = CryptoAbstraction.GenerateRandom(_bufferSize);
             _data = CryptoAbstraction.GenerateRandom(_bufferSize - 10);
@@ -105,7 +107,8 @@ namespace Renci.SshNet.Tests.Classes
                                            _widthPixels,
                                            _heightPixels,
                                            _terminalModes,
-                                           _bufferSize);
+                                           _bufferSize,
+                                           _expectSize);
 
             _shellStream.Write(_bufferData, 0, _bufferData.Length);
         }

--- a/src/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferFullAndWriteZeroBytes.cs
+++ b/src/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferFullAndWriteZeroBytes.cs
@@ -23,6 +23,7 @@ namespace Renci.SshNet.Tests.Classes
         private Dictionary<TerminalModes, uint> _terminalModes;
         private ShellStream _shellStream;
         private int _bufferSize;
+        private int _expectSize;
 
         private byte[] _data;
         private int _offset;
@@ -42,12 +43,13 @@ namespace Renci.SshNet.Tests.Classes
             var random = new Random();
 
             _terminalName = random.Next().ToString();
-            _widthColumns = (uint) random.Next();
-            _heightRows = (uint) random.Next();
-            _widthPixels = (uint) random.Next();
-            _heightPixels = (uint) random.Next();
+            _widthColumns = (uint)random.Next();
+            _heightRows = (uint)random.Next();
+            _widthPixels = (uint)random.Next();
+            _heightPixels = (uint)random.Next();
             _terminalModes = new Dictionary<TerminalModes, uint>();
             _bufferSize = random.Next(100, 1000);
+            _expectSize = random.Next(100, 1000);
 
             _bufferData = CryptoAbstraction.GenerateRandom(_bufferSize);
             _data = new byte[0];
@@ -103,7 +105,8 @@ namespace Renci.SshNet.Tests.Classes
                                            _widthPixels,
                                            _heightPixels,
                                            _terminalModes,
-                                           _bufferSize);
+                                           _bufferSize,
+                                           _expectSize);
 
             _shellStream.Write(_bufferData, 0, _bufferData.Length);
         }

--- a/src/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferNotEmptyAndWriteLessBytesThanBufferCanContain.cs
+++ b/src/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferNotEmptyAndWriteLessBytesThanBufferCanContain.cs
@@ -23,6 +23,7 @@ namespace Renci.SshNet.Tests.Classes
         private Dictionary<TerminalModes, uint> _terminalModes;
         private ShellStream _shellStream;
         private int _bufferSize;
+        private int _expectSize;
 
         private byte[] _data;
         private int _offset;
@@ -42,12 +43,13 @@ namespace Renci.SshNet.Tests.Classes
             var random = new Random();
 
             _terminalName = random.Next().ToString();
-            _widthColumns = (uint) random.Next();
-            _heightRows = (uint) random.Next();
-            _widthPixels = (uint) random.Next();
-            _heightPixels = (uint) random.Next();
+            _widthColumns = (uint)random.Next();
+            _heightRows = (uint)random.Next();
+            _widthPixels = (uint)random.Next();
+            _heightPixels = (uint)random.Next();
             _terminalModes = new Dictionary<TerminalModes, uint>();
             _bufferSize = random.Next(100, 1000);
+            _expectSize = random.Next(100, 1000);
 
             _bufferData = CryptoAbstraction.GenerateRandom(_bufferSize - 60);
             _data = CryptoAbstraction.GenerateRandom(_bufferSize + 100);
@@ -103,7 +105,8 @@ namespace Renci.SshNet.Tests.Classes
                                            _widthPixels,
                                            _heightPixels,
                                            _terminalModes,
-                                           _bufferSize);
+                                           _bufferSize,
+                                           _expectSize);
 
             _shellStream.Write(_bufferData, 0, _bufferData.Length);
         }

--- a/src/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferNotEmptyAndWriteMoreBytesThanBufferCanContain.cs
+++ b/src/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferNotEmptyAndWriteMoreBytesThanBufferCanContain.cs
@@ -24,6 +24,7 @@ namespace Renci.SshNet.Tests.Classes
         private Dictionary<TerminalModes, uint> _terminalModes;
         private ShellStream _shellStream;
         private int _bufferSize;
+        private int _expectSize;
 
         private byte[] _data;
         private int _offset;
@@ -44,12 +45,13 @@ namespace Renci.SshNet.Tests.Classes
             var random = new Random();
 
             _terminalName = random.Next().ToString();
-            _widthColumns = (uint) random.Next();
-            _heightRows = (uint) random.Next();
-            _widthPixels = (uint) random.Next();
-            _heightPixels = (uint) random.Next();
+            _widthColumns = (uint)random.Next();
+            _heightRows = (uint)random.Next();
+            _widthPixels = (uint)random.Next();
+            _heightPixels = (uint)random.Next();
             _terminalModes = new Dictionary<TerminalModes, uint>();
             _bufferSize = random.Next(100, 1000);
+            _expectSize = random.Next(100, 1000);
 
             _bufferData = CryptoAbstraction.GenerateRandom(_bufferSize - 60);
             _data = CryptoAbstraction.GenerateRandom(_bufferSize - _bufferData.Length + random.Next(1, 10));
@@ -111,7 +113,8 @@ namespace Renci.SshNet.Tests.Classes
                                            _widthPixels,
                                            _heightPixels,
                                            _terminalModes,
-                                           _bufferSize);
+                                           _bufferSize,
+                                           _expectSize);
 
             _shellStream.Write(_bufferData, 0, _bufferData.Length);
         }
@@ -130,7 +133,7 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void FlushShouldSendRemainingBytesInBufferToServer()
         {
-           var expectedBytesSent = _data.Take(_bufferSize - _bufferData.Length, _data.Length + _bufferData.Length - _bufferSize);
+            var expectedBytesSent = _data.Take(_bufferSize - _bufferData.Length, _data.Length + _bufferData.Length - _bufferSize);
             byte[] actualBytesSent = null;
 
             _channelSessionMock.InSequence(_mockSequence)

--- a/src/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferNotEmptyAndWriteZeroBytes.cs
+++ b/src/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferNotEmptyAndWriteZeroBytes.cs
@@ -23,6 +23,7 @@ namespace Renci.SshNet.Tests.Classes
         private Dictionary<TerminalModes, uint> _terminalModes;
         private ShellStream _shellStream;
         private int _bufferSize;
+        private int _expectSize;
 
         private byte[] _data;
         private int _offset;
@@ -48,6 +49,7 @@ namespace Renci.SshNet.Tests.Classes
             _heightPixels = (uint)random.Next();
             _terminalModes = new Dictionary<TerminalModes, uint>();
             _bufferSize = random.Next(100, 1000);
+            _expectSize = random.Next(100, 1000);
 
             _bufferData = CryptoAbstraction.GenerateRandom(_bufferSize - 60);
             _data = new byte[0];
@@ -103,7 +105,8 @@ namespace Renci.SshNet.Tests.Classes
                                            _widthPixels,
                                            _heightPixels,
                                            _terminalModes,
-                                           _bufferSize);
+                                           _bufferSize,
+                                           _expectSize);
 
             _shellStream.Write(_bufferData, 0, _bufferData.Length);
         }

--- a/src/Renci.SshNet.Tests/Classes/SshClientTest_CreateShellStream_TerminalNameAndColumnsAndRowsAndWidthAndHeightAndBufferSizeAndTerminalModes_Connected.cs
+++ b/src/Renci.SshNet.Tests/Classes/SshClientTest_CreateShellStream_TerminalNameAndColumnsAndRowsAndWidthAndHeightAndBufferSizeAndTerminalModes_Connected.cs
@@ -19,6 +19,7 @@ namespace Renci.SshNet.Tests.Classes
         private uint _heightPixels;
         private Dictionary<TerminalModes, uint> _terminalModes;
         private int _bufferSize;
+        private int _expectSize;
         private ShellStream _expected;
         private ShellStream _actual;
 
@@ -29,12 +30,13 @@ namespace Renci.SshNet.Tests.Classes
             _connectionInfo = new ConnectionInfo("host", "user", new NoneAuthenticationMethod("userauth"));
 
             _terminalName = random.Next().ToString();
-            _widthColumns = (uint) random.Next();
-            _heightRows = (uint) random.Next();
-            _widthPixels = (uint) random.Next();
-            _heightPixels = (uint) random.Next();
+            _widthColumns = (uint)random.Next();
+            _heightRows = (uint)random.Next();
+            _widthPixels = (uint)random.Next();
+            _heightPixels = (uint)random.Next();
             _terminalModes = new Dictionary<TerminalModes, uint>();
             _bufferSize = random.Next(100, 1000);
+            _expectSize = random.Next(100, 1000);
 
             _expected = CreateShellStream();
         }
@@ -59,7 +61,8 @@ namespace Renci.SshNet.Tests.Classes
                                                                _widthPixels,
                                                                _heightPixels,
                                                                _terminalModes,
-                                                               _bufferSize))
+                                                               _bufferSize,
+                                                               _expectSize))
                                .Returns(_expected);
         }
 
@@ -92,7 +95,8 @@ namespace Renci.SshNet.Tests.Classes
                                                                 _widthPixels,
                                                                 _heightPixels,
                                                                 _terminalModes,
-                                                                _bufferSize),
+                                                                _bufferSize,
+                                                                _expectSize),
                                        Times.Once);
         }
 
@@ -130,6 +134,7 @@ namespace Renci.SshNet.Tests.Classes
                                    _widthPixels,
                                    _heightPixels,
                                    _terminalModes,
+                                   1,
                                    1);
         }
     }

--- a/src/Renci.SshNet.Tests/Classes/SshClientTest_CreateShellStream_TerminalNameAndColumnsAndRowsAndWidthAndHeightAndBufferSize_Connected.cs
+++ b/src/Renci.SshNet.Tests/Classes/SshClientTest_CreateShellStream_TerminalNameAndColumnsAndRowsAndWidthAndHeightAndBufferSize_Connected.cs
@@ -18,6 +18,7 @@ namespace Renci.SshNet.Tests.Classes
         private uint _widthPixels;
         private uint _heightPixels;
         private int _bufferSize;
+        private int _expectSize;
         private ShellStream _expected;
         private ShellStream _actual;
 
@@ -33,6 +34,7 @@ namespace Renci.SshNet.Tests.Classes
             _widthPixels = (uint)random.Next();
             _heightPixels = (uint)random.Next();
             _bufferSize = random.Next(100, 1000);
+            _expectSize = random.Next(100, 1000);
 
             _expected = CreateShellStream();
         }
@@ -57,7 +59,8 @@ namespace Renci.SshNet.Tests.Classes
                                                                _widthPixels,
                                                                _heightPixels,
                                                                null,
-                                                               _bufferSize))
+                                                               _bufferSize,
+                                                               _expectSize))
                                .Returns(_expected);
         }
 
@@ -89,7 +92,8 @@ namespace Renci.SshNet.Tests.Classes
                                                                 _widthPixels,
                                                                 _heightPixels,
                                                                 null,
-                                                                _bufferSize),
+                                                                _bufferSize,
+                                                                _expectSize),
                                        Times.Once);
         }
 
@@ -127,6 +131,7 @@ namespace Renci.SshNet.Tests.Classes
                                    _widthPixels,
                                    _heightPixels,
                                    null,
+                                   1,
                                    1);
         }
     }

--- a/src/Renci.SshNet/IServiceFactory.cs
+++ b/src/Renci.SshNet/IServiceFactory.cs
@@ -77,8 +77,9 @@ namespace Renci.SshNet
         /// <param name="rows">The terminal width in rows.</param>
         /// <param name="width">The terminal height in pixels.</param>
         /// <param name="height">The terminal height in pixels.</param>
-        /// <param name="bufferSize">Size of the buffer.</param>
         /// <param name="terminalModeValues">The terminal mode values.</param>
+        /// <param name="bufferSize">Size of the buffer.</param>
+        /// <param name="expectSize">Size of the expect buffer.</param>
         /// <returns>
         /// The created <see cref="ShellStream"/> instance.
         /// </returns>
@@ -100,7 +101,8 @@ namespace Renci.SshNet
                                       uint width,
                                       uint height,
                                       IDictionary<TerminalModes, uint> terminalModeValues,
-                                      int bufferSize);
+                                      int bufferSize,
+                                      int expectSize);
 
         /// <summary>
         /// Creates an <see cref="IRemotePathTransformation"/> that encloses a path in double quotes, and escapes

--- a/src/Renci.SshNet/ServiceFactory.cs
+++ b/src/Renci.SshNet/ServiceFactory.cs
@@ -132,7 +132,7 @@ namespace Renci.SshNet
             {
                 var fileAttributes = sftpSession.EndLStat(statAsyncResult);
                 fileSize = fileAttributes.Size;
-                maxPendingReads = Math.Min(10, (int) Math.Ceiling((double) fileAttributes.Size / chunkSize) + 1);
+                maxPendingReads = Math.Min(10, (int)Math.Ceiling((double)fileAttributes.Size / chunkSize) + 1);
             }
             catch (SshException ex)
             {
@@ -161,6 +161,7 @@ namespace Renci.SshNet
         /// <param name="height">The terminal height in pixels.</param>
         /// <param name="terminalModeValues">The terminal mode values.</param>
         /// <param name="bufferSize">The size of the buffer.</param>
+        /// <param name="expectSize">The size of the expect buffer.</param>
         /// <returns>
         /// The created <see cref="ShellStream"/> instance.
         /// </returns>
@@ -175,9 +176,9 @@ namespace Renci.SshNet
         /// to the drawable area of the window.
         /// </para>
         /// </remarks>
-        public ShellStream CreateShellStream(ISession session, string terminalName, uint columns, uint rows, uint width, uint height, IDictionary<TerminalModes, uint> terminalModeValues, int bufferSize)
+        public ShellStream CreateShellStream(ISession session, string terminalName, uint columns, uint rows, uint width, uint height, IDictionary<TerminalModes, uint> terminalModeValues, int bufferSize, int expectSize)
         {
-            return new ShellStream(session, terminalName, columns, rows, width, height, terminalModeValues, bufferSize);
+            return new ShellStream(session, terminalName, columns, rows, width, height, terminalModeValues, bufferSize, expectSize);
         }
 
         /// <summary>

--- a/src/Renci.SshNet/SshClient.cs
+++ b/src/Renci.SshNet/SshClient.cs
@@ -429,7 +429,7 @@ namespace Renci.SshNet
         /// </remarks>
         public ShellStream CreateShellStream(string terminalName, uint columns, uint rows, uint width, uint height, int bufferSize)
         {
-            return CreateShellStream(terminalName, columns, rows, width, height, bufferSize, null);
+            return CreateShellStream(terminalName, columns, rows, width, height, bufferSize, null, (int)columns);
         }
 
         /// <summary>
@@ -452,15 +452,45 @@ namespace Renci.SshNet
         /// You can get a detailed list of these cababilities by using the ‘infocmp’ command.
         /// </para>
         /// <para>
-        /// The column/row dimensions override the pixel dimensions(when non-zero). Pixel dimensions refer
+        /// The column/row dimensions override the pixel dimensions(when nonzero). Pixel dimensions refer
         /// to the drawable area of the window.
         /// </para>
         /// </remarks>
         public ShellStream CreateShellStream(string terminalName, uint columns, uint rows, uint width, uint height, int bufferSize, IDictionary<TerminalModes, uint> terminalModeValues)
         {
+            return CreateShellStream(terminalName, columns, rows, width, height, bufferSize, terminalModeValues, (int)columns);
+        }
+
+        /// <summary>
+        /// Creates the shell stream.
+        /// </summary>
+        /// <param name="terminalName">The <c>TERM</c> environment variable.</param>
+        /// <param name="columns">The terminal width in columns.</param>
+        /// <param name="rows">The terminal width in rows.</param>
+        /// <param name="width">The terminal height in pixels.</param>
+        /// <param name="height">The terminal height in pixels.</param>
+        /// <param name="bufferSize">The size of the buffer.</param>
+        /// <param name="terminalModeValues">The terminal mode values.</param>
+        /// <param name="expectSize">The size of the expect buffer.</param>
+        /// <returns>
+        /// The created <see cref="ShellStream"/> instance.
+        /// </returns>
+        /// <exception cref="SshConnectionException">Client is not connected.</exception>
+        /// <remarks>
+        /// <para>
+        /// The <c>TERM</c> environment variable contains an identifier for the text window's capabilities.
+        /// You can get a detailed list of these cababilities by using the ‘infocmp’ command.
+        /// </para>
+        /// <para>
+        /// The column/row dimensions override the pixel dimensions(when non-zero). Pixel dimensions refer
+        /// to the drawable area of the window.
+        /// </para>
+        /// </remarks>
+        public ShellStream CreateShellStream(string terminalName, uint columns, uint rows, uint width, uint height, int bufferSize, IDictionary<TerminalModes, uint> terminalModeValues, int expectSize)
+        {
             EnsureSessionIsOpen();
 
-            return ServiceFactory.CreateShellStream(Session, terminalName, columns, rows, width, height, terminalModeValues, bufferSize);
+            return ServiceFactory.CreateShellStream(Session, terminalName, columns, rows, width, height, terminalModeValues, bufferSize, expectSize);
         }
 
         /// <summary>


### PR DESCRIPTION
Expect's performance degrades quickly as the size of the _incoming Queue<byte> grows. The amount of work that needs to be done by Regex grows with each byte added. Using a Regex pattern to detect a Bash prompt, I ran into an issue while Expecting the prompt whilst doing a large yum update on a Linux server. The resulting queue size jumped into the megabyte region and running a Regex match against the _incoming queue brought the process to a crawl. What would normally take about 3 minutes on a bash shell, was taking hours. After more than 2 hours, I cancelled the process and started debugging the issue with JetBrains' dotTrace. 85% of the process execution time was spent on the Regex Match.

I added a parallel _expect Queue<byte> and a _expectSize parameter to the ShellStream to allow a synchronous buffer to run along side of the _incoming queue, but with a limited capacity equivalent to _expectSize. As a default overload for CreateShellStream, if the parameter is omitted, it uses the number of columns as a default _expectSize. This allows for a running windows for Regex to check its Expect pattern and that windows remains small independent of the actual size of the _incoming queue. In my tests, this completely eliminated the slow down caused by the ever increasing size of the _incoming queue. It allows for performance on par with being directly connected as a human against the bash shell.

Whilst working on this, I noticed an additional issue that was simple to resolve given the now available parallel _expect queue.

Considering the default Encoding is UTF-8, there Regex Match Index does not necessarily correspond to the actual byte position within the UTF-8 string as some characters can be double byte encoded, which affects the Index returned by Match. ASCII does not support double byte encoding, so for the purpose of Expect, it makes more sense to match against an ASCII encoding of the string instead of a UTF-8 encoding since the _incoming Queue<byte> is obviously encoding agnostic.

Running a seperate Expect queue allows to Match against an ASCII version for byte position fidelity whilst conserving the proper encoding when returning the string from Expect.

Here is a dotNetFiddle that demonstrates the Match Index position issue with UTF-8 encoding (pulled from real-world result that I debugged and encoded as a byte array for dotNetFiddle): https://dotnetfiddle.net/JM80ea