### PR TITLE
Add .SendData method for SshCommand

### DIFF
--- a/src/Renci.SshNet/SshCommand.cs
+++ b/src/Renci.SshNet/SshCommand.cs
@@ -471,6 +471,41 @@ namespace Renci.SshNet
             }
         }
 
+        /// <summary>
+        /// Sends a SSH_MSG_CHANNEL_DATA message with the specified payload.
+        /// </summary>
+        /// <param name="data">The payload to send.</param>
+        public void SendData(byte[] data)
+        {
+            _channel.SendData(data);
+        }
+
+        /// <summary>
+        /// Sends a SSH_MSG_CHANNEL_DATA message with the specified payload.
+        /// </summary>
+        /// <param name="data">An array of <see cref="byte"/> containing the payload to send.</param>
+        /// <param name="offset">The zero-based offset in <paramref name="data"/> at which to begin taking data from.</param>
+        /// <param name="size">The number of bytes of <paramref name="data"/> to send.</param>
+        /// <remarks>
+        /// <para>
+        /// When the size of the data to send exceeds the maximum packet size or the remote window
+        /// size does not allow the full data to be sent, then this method will send the data in
+        /// multiple chunks and will wait for the remote window size to be adjusted when it's zero.
+        /// </para>
+        /// <para>
+        /// This is done to support SSH servers will a small window size that do not agressively
+        /// increase their window size. We need to take into account that there may be SSH servers
+        /// that only increase their window size when it has reached zero.
+        /// </para>
+        /// </remarks>
+        public void SendData(byte[] data, int offset, int size)
+        {
+            _channel.SendData(data, offset, size);
+        }
+
+        /// <summary>
+        /// Waits on the wait handle <paramref name="waitHandle"/>.
+        /// </summary>
         /// <exception cref="SshOperationTimeoutException">Command '{0}' has timed out.</exception>
         /// <remarks>The actual command will be included in the exception message.</remarks>
         private void WaitOnHandle(WaitHandle waitHandle)


### PR DESCRIPTION
See  #802.

This  adds two methods `SshCommand.SendData` that expose `SshCommand._channel.SendData`s two overloads.

No tests yet, not quite sure how to test this.