### PR TITLE
remove readonly of AuthenticationConnection in Session

### DIFF
--- a/src/Renci.SshNet/Session.cs
+++ b/src/Renci.SshNet/Session.cs
@@ -85,7 +85,7 @@ namespace Renci.SshNet
         /// <remarks>
         /// Some server may restrict number to prevent authentication attacks
         /// </remarks>
-        private static readonly SemaphoreLight AuthenticationConnection = new SemaphoreLight(3);
+        private static SemaphoreLight AuthenticationConnection = new SemaphoreLight(3);
 
         /// <summary>
         /// Holds metada about session messages


### PR DESCRIPTION
remove `readonly` of `AuthenticationConnection` in [Session](https://github.com/sshnet/SSH.NET/blob/develop/src/Renci.SshNet/Session.cs) to support customize parallel connecting number.

Related Issues:
https://github.com/sshnet/SSH.NET/issues/215
https://github.com/sshnet/SSH.NET/issues/264
https://github.com/sshnet/SSH.NET/issues/409
https://github.com/sshnet/SSH.NET/issues/840