### PR TITLE
Renci optimize session issue #861

### DIFF
--- a/src/Renci.SshNet/Session.cs
+++ b/src/Renci.SshNet/Session.cs
@@ -565,19 +565,15 @@ namespace Renci.SshNet
             if (IsConnected)
                 return;
 
-            try
+            lock (this)
             {
-                AuthenticationConnection.Wait();
-
+                // If connected don't connect again
                 if (IsConnected)
                     return;
 
-                lock (this)
+                try
                 {
-                    // If connected don't connect again
-                    if (IsConnected)
-                        return;
-
+                    AuthenticationConnection.Wait();
                     // Reset connection specific information
                     Reset();
 
@@ -662,10 +658,10 @@ namespace Renci.SshNet
                     RegisterMessage("SSH_MSG_CHANNEL_EOF");
                     RegisterMessage("SSH_MSG_CHANNEL_CLOSE");
                 }
-            }
-            finally
-            {
-                AuthenticationConnection.Release();
+                finally
+                {
+                    AuthenticationConnection.Release();
+                }
             }
         }
 


### PR DESCRIPTION
Due to improper scope AuthenticationConnection semaphore lock is acquired more than once when connect() method is called more than once while a connect operation is still in progress. It exhausts the semaphore slot and keeps the other Connect operations waiting until one finishes. Change of scoping will help us acquireclock just before the connect operation begins.