### PR TITLE
Fix virus false-positive by Defender on Renci.SSHNet.Tests.dll

### DIFF
--- a/src/Renci.SshNet.Tests/Classes/PrivateKeyFileTest.cs
+++ b/src/Renci.SshNet.Tests/Classes/PrivateKeyFileTest.cs
@@ -435,7 +435,7 @@ namespace Renci.SshNet.Tests.Classes
         /// A test for <see cref="PrivateKeyFile(string, string)"/> ctor.
         ///</summary>
         [TestMethod()]
-        public void ConstructorWithFileNameAndPassphraseShouldThrowSshPassPhraseNullOrEmptyExceptionWhenPrivateKeyIsEncryptedAndPassphraseIsEmpty()
+        public void ConstructorWithFileNameAndPassphraseShouldThrowSshPassPhraseNullOrEmptyExceptionWhenNeededPassphraseIsEmpty()
         {
             var passphrase = string.Empty;
 
@@ -460,7 +460,7 @@ namespace Renci.SshNet.Tests.Classes
         /// A test for <see cref="PrivateKeyFile(string, string)"/> ctor.
         ///</summary>
         [TestMethod()]
-        public void ConstructorWithFileNameAndPassphraseShouldThrowSshPassPhraseNullOrEmptyExceptionWhenPrivateKeyIsEncryptedAndPassphraseIsNull()
+        public void ConstructorWithFileNameAndPassphraseShouldThrowSshPassPhraseNullOrEmptyExceptionWhenNeededPassphraseIsNull()
         {
             string passphrase = null;
 


### PR DESCRIPTION
This fixes issues #737, #747, #797, #490. Looks like MS Defender (and others) doesn't like the long function names 🙄 Or maybe it's the "PrivateKeyIsEncrypted" string. Since the issue has persisted for over 1 year and MS doesn't seem willing to fix the misdetection, this workaround is needed.

Here's the VirusTotal results for the NET4.0 builds with this patch:
debug: https://www.virustotal.com/gui/file/fc814f159b67c7d7d0c8f5890ef41ec335d6bd65b9864e5cad3bbd53c05cb79c/detection
release: https://www.virustotal.com/gui/file/caffb824ca1856161b6501b9ad14121f030c0c488e6f5973e4eb2f4227724fe7/detection

This is the report without this change:
https://www.virustotal.com/gui/file/eaf0adc64453402d4fbc229a9bb0713f1c91f7dec6f285b792966846864b4aea/detection

Weird.