### PR TITLE
Simplify sample code for verifying host identify

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,33 +143,17 @@ using (var client = new SftpClient(connectionInfo))
 Establish a SSH connection using user name and password, and reject the connection if the fingerprint of the server does not match the expected fingerprint:
 
 ```cs
-byte[] expectedFingerPrint = new byte[] {
-                                            0x66, 0x31, 0xaf, 0x00, 0x54, 0xb9, 0x87, 0x31,
-                                            0xff, 0x58, 0x1c, 0x31, 0xb1, 0xa2, 0x4c, 0x6b
-                                        };
+using System.Linq;
+using Renci.SshNet;
 
-using (var client = new SshClient("sftp.foo.com", "guest", "pwd"))
-{
-    client.HostKeyReceived += (sender, e) =>
-        {
-            if (expectedFingerPrint.Length == e.FingerPrint.Length)
-            {
-                for (var i = 0; i < expectedFingerPrint.Length; i++)
-                {
-                    if (expectedFingerPrint[i] != e.FingerPrint[i])
-                    {
-                        e.CanTrust = false;
-                        break;
-                    }
-                }
-            }
-            else
-            {
-                e.CanTrust = false;
-            }
-        };
-    client.Connect();
-}
+byte[] expectedFingerPrint = {
+    0x66, 0x31, 0xaf, 0x00, 0x54, 0xb9, 0x87, 0x31,
+    0xff, 0x58, 0x1c, 0x31, 0xb1, 0xa2, 0x4c, 0x6b
+};
+
+using var client = new SshClient("sftp.foo.com", "guest", "pwd");
+client.HostKeyReceived += (_, e) => e.CanTrust = expectedFingerPrint.SequenceEqual(e.FingerPrint);
+client.Connect();
 ```
 
 ## Supporting SSH.NET


### PR DESCRIPTION
* Include `using` directives to make it clear that `System.Linq` and `Renci.SshNet` are required
* Remove unnecessary `new byte[]` in `expectedFingerPrint` declaration
* Use [discard](https://docs.microsoft.com/en-us/dotnet/csharp/fundamentals/functional/discards) (i.e. `_`) instead of unused `sender` argument (C# 7.0)
* Use [Enumerable.SequenceEqual](https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable.sequenceequal) instead of manually comparing byte arrays
* `using var client` without braces (C# 8.0 feature)