### PR TITLE
Start MessageListener with ThreadAbstraction.ExecuteThreadLongRunning

### DIFF
--- a/src/Renci.SshNet/Abstractions/ThreadAbstraction.cs
+++ b/src/Renci.SshNet/Abstractions/ThreadAbstraction.cs
@@ -21,12 +21,16 @@ namespace Renci.SshNet.Abstractions
 
         public static void ExecuteThreadLongRunning(Action action)
         {
+            if (action == null)
+                throw new ArgumentNullException("action");
 #if FEATURE_THREAD_TAP
             var taskCreationOptions = System.Threading.Tasks.TaskCreationOptions.LongRunning;
             System.Threading.Tasks.Task.Factory.StartNew(action, taskCreationOptions);
 #else
-            var thread = new System.Threading.Thread(() => action());
-            thread.Start();
+            new System.Threading.Thread(() => action())
+            {
+                IsBackground = true
+            }.Start();
 #endif
         }
 

--- a/src/Renci.SshNet/Abstractions/ThreadAbstraction.cs
+++ b/src/Renci.SshNet/Abstractions/ThreadAbstraction.cs
@@ -10,28 +10,17 @@ namespace Renci.SshNet.Abstractions
         /// <param name="millisecondsTimeout">The number of milliseconds for which the thread is suspended.</param>
         public static void Sleep(int millisecondsTimeout)
         {
-#if FEATURE_THREAD_SLEEP
             System.Threading.Thread.Sleep(millisecondsTimeout);
-#elif FEATURE_THREAD_TAP
-            System.Threading.Tasks.Task.Delay(millisecondsTimeout).GetAwaiter().GetResult();
-#else
-            #error Suspend of the current thread is not implemented.
-#endif
         }
 
         public static void ExecuteThreadLongRunning(Action action)
         {
             if (action == null)
                 throw new ArgumentNullException("action");
-#if FEATURE_THREAD_TAP
-            var taskCreationOptions = System.Threading.Tasks.TaskCreationOptions.LongRunning;
-            System.Threading.Tasks.Task.Factory.StartNew(action, taskCreationOptions);
-#else
             new System.Threading.Thread(() => action())
             {
                 IsBackground = true
             }.Start();
-#endif
         }
 
         /// <summary>
@@ -40,16 +29,10 @@ namespace Renci.SshNet.Abstractions
         /// <param name="action">The action to execute.</param>
         public static void ExecuteThread(Action action)
         {
-#if FEATURE_THREAD_THREADPOOL
             if (action == null)
                 throw new ArgumentNullException("action");
 
             System.Threading.ThreadPool.QueueUserWorkItem(o => action());
-#elif FEATURE_THREAD_TAP
-            System.Threading.Tasks.Task.Run(action);
-#else
-            #error Execution of action in a separate thread is not implemented.
-#endif
         }
     }
 }

--- a/src/Renci.SshNet/Session.cs
+++ b/src/Renci.SshNet/Session.cs
@@ -618,7 +618,8 @@ namespace Renci.SshNet
                     _messageListenerCompleted.Reset();
 
                     // Start incoming request listener
-                    ThreadAbstraction.ExecuteThread(() => MessageListener());
+                    // ToDo: Make message pump async, to not consume a thread for every session
+                    ThreadAbstraction.ExecuteThreadLongRunning(() => MessageListener());
 
                     // Wait for key exchange to be completed
                     WaitOnHandle(_keyExchangeCompletedWaitHandle);


### PR DESCRIPTION
Changed the ```Session.Connect``` to use ```ThreadAbstraction.ExecuteThreadLongRunning``` to start the ```MessageListener```. 

The commit 5d173c8 also includes cleanup of ```ThreadAbstraction```, which I did because I wasn't sure anymore which target was used as a dependency. I feel this cleanup is beneficial in the long run, but if you feel this is too much for this PR let me know and I'll roll it back.

Fixes #824 