### PR TITLE
Start MessageListener with ThreadAbstraction.ExecuteThreadLongRunning #2

### DIFF
--- a/src/Renci.SshNet/Abstractions/ThreadAbstraction.cs
+++ b/src/Renci.SshNet/Abstractions/ThreadAbstraction.cs
@@ -21,12 +21,17 @@ namespace Renci.SshNet.Abstractions
 
         public static void ExecuteThreadLongRunning(Action action)
         {
+            if (action == null)
+                throw new ArgumentNullException("action");
+
 #if FEATURE_THREAD_TAP
             var taskCreationOptions = System.Threading.Tasks.TaskCreationOptions.LongRunning;
             System.Threading.Tasks.Task.Factory.StartNew(action, taskCreationOptions);
 #else
-            var thread = new System.Threading.Thread(() => action());
-            thread.Start();
+            new System.Threading.Thread(() => action())
+            {
+                IsBackground = true
+            }.Start();
 #endif
         }
 

--- a/src/Renci.SshNet/Session.cs
+++ b/src/Renci.SshNet/Session.cs
@@ -618,7 +618,8 @@ namespace Renci.SshNet
                     _messageListenerCompleted.Reset();
 
                     // Start incoming request listener
-                    ThreadAbstraction.ExecuteThread(() => MessageListener());
+                    // ToDo: Make message pump async, to not consume a thread for every session
+                    ThreadAbstraction.ExecuteThreadLongRunning(() => MessageListener());
 
                     // Wait for key exchange to be completed
                     WaitOnHandle(_keyExchangeCompletedWaitHandle);


### PR DESCRIPTION
Changed the Session.Connect to use ThreadAbstraction.ExecuteThreadLongRunning to start the MessageListener.

This is a replacement PR for #901.

Fixes #824