### PR TITLE
Add IAsyncEnumerable<SftpFile> to enumerate remote files

### DIFF
--- a/src/Renci.SshNet/ISftpClient.cs
+++ b/src/Renci.SshNet/ISftpClient.cs
@@ -719,13 +719,13 @@ namespace Renci.SshNet
         /// <exception cref="SftpPermissionDeniedException">Permission to list the contents of the directory was denied by the remote host. <para>-or-</para> A SSH command was denied by the server.</exception>
         /// <exception cref="SshException">A SSH error where <see cref="Exception.Message" /> is the message from the remote host.</exception>
         /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
         [Obsolete("Use EnumerateDirectoryAsync()")]
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
 #endif
-        Task<IEnumerable<SftpFile>> ListDirectoryAsync(string path, CancellationToken cancellationToken);
+        Task<IEnumerable<ISftpFile>> ListDirectoryAsync(string path, CancellationToken cancellationToken);
 
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
         /// <summary>
         /// Asynchronously enumerates the files in remote directory.
         /// </summary>
@@ -740,7 +740,7 @@ namespace Renci.SshNet
         /// <exception cref="SftpPermissionDeniedException">Permission to list the contents of the directory was denied by the remote host. <para>-or-</para> A SSH command was denied by the server.</exception>
         /// <exception cref="SshException">A SSH error where <see cref="Exception.Message" /> is the message from the remote host.</exception>
         /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
-        IAsyncEnumerable<SftpFile> EnumerateDirectoryAsync(string path, CancellationToken cancellationToken);
+        IAsyncEnumerable<ISftpFile> EnumerateDirectoryAsync(string path, CancellationToken cancellationToken);
 #endif
 #endif
 

--- a/src/Renci.SshNet/ISftpClient.cs
+++ b/src/Renci.SshNet/ISftpClient.cs
@@ -705,7 +705,6 @@ namespace Renci.SshNet
         IEnumerable<ISftpFile> ListDirectory(string path, Action<int> listCallback = null);
 
 #if FEATURE_TAP
-
         /// <summary>
         /// Asynchronously retrieves list of files in remote directory.
         /// </summary>
@@ -720,7 +719,29 @@ namespace Renci.SshNet
         /// <exception cref="SftpPermissionDeniedException">Permission to list the contents of the directory was denied by the remote host. <para>-or-</para> A SSH command was denied by the server.</exception>
         /// <exception cref="SshException">A SSH error where <see cref="Exception.Message" /> is the message from the remote host.</exception>
         /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
+#if NETSTANDARD2_1_OR_GREATER
+        [Obsolete("Use EnumerateDirectoryAsync()")]
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+#endif
         Task<IEnumerable<SftpFile>> ListDirectoryAsync(string path, CancellationToken cancellationToken);
+
+#if NETSTANDARD2_1_OR_GREATER
+        /// <summary>
+        /// Asynchronously enumerates the files in remote directory.
+        /// </summary>
+        /// <param name="path">The path.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to observe.</param>
+        /// <returns>
+        /// An <see cref="IAsyncEnumerable{SftpFile}"/> that represents the asynchronous enumeration operation.
+        /// The enumeration contains an async stream of <see cref="SftpFile"/> for the files in the directory specified by <paramref name="path" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="path" /> is <b>null</b>.</exception>
+        /// <exception cref="SshConnectionException">Client is not connected.</exception>
+        /// <exception cref="SftpPermissionDeniedException">Permission to list the contents of the directory was denied by the remote host. <para>-or-</para> A SSH command was denied by the server.</exception>
+        /// <exception cref="SshException">A SSH error where <see cref="Exception.Message" /> is the message from the remote host.</exception>
+        /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
+        IAsyncEnumerable<SftpFile> EnumerateDirectoryAsync(string path, CancellationToken cancellationToken);
+#endif
 #endif
 
         /// <summary>

--- a/src/Renci.SshNet/Renci.SshNet.csproj
+++ b/src/Renci.SshNet/Renci.SshNet.csproj
@@ -5,17 +5,15 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>Renci.SshNet</AssemblyName>
     <AssemblyOriginatorKeyFile>../Renci.SshNet.snk</AssemblyOriginatorKeyFile>
-    <LangVersion>6</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <SignAssembly>true</SignAssembly>
+    <TargetFrameworks>net35;net40;net472;netstandard1.3;netstandard2.1</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(VisualStudioVersion)' == '15.0' ">
     <TargetFrameworks>net35;net40;net472;netstandard1.3;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
-
-  <!--
-  <PropertyGroup Condition=" '$(VisualStudioVersion)' == '16.0' ">
-    <TargetFrameworks>net35;net40;netstandard1.3;netstandard2.0;netstandard2.1</TargetFrameworks>
-  </PropertyGroup>
-  -->
-
+  
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="SshNet.Security.Cryptography" Version="[1.3.0]" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />

--- a/src/Renci.SshNet/Security/Cryptography/EcdsaDigitalSignature.cs
+++ b/src/Renci.SshNet/Security/Cryptography/EcdsaDigitalSignature.cs
@@ -39,7 +39,7 @@ namespace Renci.SshNet.Security.Cryptography
             // for 521 sig_size is 132
             var sig_size = _key.KeyLength == 521 ? 132 : _key.KeyLength / 4;
             var ssh_data = new SshDataSignature(signature, sig_size);
-#if NETSTANDARD2_0
+#if !NETFRAMEWORK
             return _key.Ecdsa.VerifyData(input, ssh_data.Signature, _key.HashAlgorithm);
 #else
             var ecdsa = (ECDsaCng)_key.Ecdsa;
@@ -57,7 +57,7 @@ namespace Renci.SshNet.Security.Cryptography
         /// </returns>
         public override byte[] Sign(byte[] input)
         {
-#if NETSTANDARD2_0
+#if !NETFRAMEWORK
             var signed = _key.Ecdsa.SignData(input, _key.HashAlgorithm);
 #else
             var ecdsa = (ECDsaCng)_key.Ecdsa;

--- a/src/Renci.SshNet/Security/Cryptography/EcdsaKey.cs
+++ b/src/Renci.SshNet/Security/Cryptography/EcdsaKey.cs
@@ -18,7 +18,7 @@ namespace Renci.SshNet.Security
         internal const string ECDSA_P384_OID_VALUE = "1.3.132.0.34"; // Also called nistP384 or secP384r1
         internal const string ECDSA_P521_OID_VALUE = "1.3.132.0.35"; // Also called nistP521or secP521r1
 
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
         internal enum KeyBlobMagicNumber : int
         {
             BCRYPT_ECDSA_PUBLIC_P256_MAGIC = 0x31534345,
@@ -57,7 +57,7 @@ namespace Renci.SshNet.Security
             return string.Format("ecdsa-sha2-nistp{0}", KeyLength);
         }
 
-#if NETSTANDARD2_0
+#if !NETFRAMEWORK
         /// <summary>
         /// Gets the HashAlgorithm to use
         /// </summary>
@@ -144,7 +144,7 @@ namespace Renci.SshNet.Security
                 byte[] curve;
                 byte[] qx;
                 byte[] qy;
-#if NETSTANDARD2_0
+#if !NETFRAMEWORK
                 var parameter = Ecdsa.ExportParameters(false);
                 qx = parameter.Q.X;
                 qy = parameter.Q.Y;
@@ -278,7 +278,7 @@ namespace Renci.SshNet.Security
 
         private void Import(string curve_oid, byte[] publickey, byte[] privatekey)
         {
-#if NETSTANDARD2_0
+#if !NETFRAMEWORK
             var curve = ECCurve.CreateFromValue(curve_oid);
             var parameter = new ECParameters
             {

--- a/src/Renci.SshNet/SftpClient.cs
+++ b/src/Renci.SshNet/SftpClient.cs
@@ -552,11 +552,11 @@ namespace Renci.SshNet
         /// <exception cref="SftpPermissionDeniedException">Permission to list the contents of the directory was denied by the remote host. <para>-or-</para> A SSH command was denied by the server.</exception>
         /// <exception cref="SshException">A SSH error where <see cref="Exception.Message" /> is the message from the remote host.</exception>
         /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
         [Obsolete("Use EnumerateDirectoryAsync()")]
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
 #endif
-        public async Task<IEnumerable<SftpFile>> ListDirectoryAsync(string path, CancellationToken cancellationToken)
+        public async Task<IEnumerable<ISftpFile>> ListDirectoryAsync(string path, CancellationToken cancellationToken)
         {
             base.CheckDisposed();
             if (path == null)
@@ -598,7 +598,7 @@ namespace Renci.SshNet
             return result;
         }
 
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
         /// <summary>
         /// Asynchronously enumerates the files in remote directory.
         /// </summary>
@@ -613,14 +613,13 @@ namespace Renci.SshNet
         /// <exception cref="SftpPermissionDeniedException">Permission to list the contents of the directory was denied by the remote host. <para>-or-</para> A SSH command was denied by the server.</exception>
         /// <exception cref="SshException">A SSH error where <see cref="Exception.Message" /> is the message from the remote host.</exception>
         /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
-        public async IAsyncEnumerable<SftpFile> EnumerateDirectoryAsync(string path, [EnumeratorCancellation]CancellationToken cancellationToken)
+        public async IAsyncEnumerable<ISftpFile> EnumerateDirectoryAsync(string path, [EnumeratorCancellation]CancellationToken cancellationToken)
         {
             base.CheckDisposed();
             if (path == null)
                 throw new ArgumentNullException(nameof(path));
             if (_sftpSession == null)
                 throw new SshConnectionException("Client not connected.");
-            cancellationToken.ThrowIfCancellationRequested();
 
             var fullPath = await _sftpSession.GetCanonicalPathAsync(path, cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
@drieseng, this is my proposal on how to gradually implement ```IAsyncEnumerable``` for asynchronously enumerating remote files.

First, the prerequisites:
 - to get IAsyncEnumerable I had to add netstandard2.1 target
 - to get IAsyncEnumerable state machine compiler support I had to raise C# version to 8.0

The latter means SSH.NET would no longer compile with VS 2017 or earlier. Is this an issue?

I propose to have two distinct methods for enumerating remote files:
 1. ```Task<IEnumerable<SftpFile>> ListDirectoryAsync(string path, CancellationToken cancellationToken)```:
This method works asynchronously, but will only complete the task after all the files have been read from the remote.
 2. ```IAsyncEnumerable<SftpFile> EnumerateDirectoryAsync(string path, [EnumeratorCancellation]CancellationToken cancellationToken)```:
This method works asynchronously too, but will return remote files in chunks as the are received by a single ```RequestReadDirAsync``` call. This allows the caller to abort enumeration early if they satisfied their goal before reaching the end of enumeration.

Assuming the consumer is currently targeting net472, they would only have access to ListDirectoryAsync. If the consumer later changes its target to netstandard2.1 (or later, i.e. net5.0 or net6.0), they would still be able to call ListDirectoryAsync, but it will light up as obsolete. In addition, they would now be able to call EnumerateDirectoryAsync. This allows for gradual migration and does not present a breaking change for the caller when raising their target.

Any consumer of EnumerateDirectoryAsync would need to have access to ```async foreach```, which is a C# 8.0 feature, meaning the consumer can target netstandard2.1 or later. So I don't see any realistic scenario for using IAsyncEnumerable in pre-netstandard2.1 world.