### PR TITLE
Fix Seek Operations in SftpFileStream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,3 @@ project.lock.json
 
 # Build outputs
 build/target/
-
-# Visual Studio cache/options directory
-.vs/

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ project.lock.json
 
 # Build outputs
 build/target/
+
+# Visual Studio cache/options directory
+.vs/

--- a/src/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_Seek_PositionedAtBeginningOfStream_OriginEndAndOffsetNegative.cs
+++ b/src/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_Seek_PositionedAtBeginningOfStream_OriginEndAndOffsetNegative.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Renci.SshNet.Sftp;
+
+namespace Renci.SshNet.Tests.Classes.Sftp
+{
+    [TestClass]
+    public class SftpFileStreamTest_Seek_PositionedAtBeginningOfStream_OriginEndAndOffsetNegative : SftpFileStreamTestBase
+    {
+        private Random _random;
+        private string _path;
+        private FileMode _fileMode;
+        private FileAccess _fileAccess;
+        private int _bufferSize;
+        private uint _readBufferSize;
+        private uint _writeBufferSize;
+        private byte[] _handle;
+        private SftpFileStream _target;
+        private int _offset;
+        private SftpFileAttributes _attributes;
+        private EndOfStreamException _actualException;
+
+        protected override void SetupData()
+        {
+            base.SetupData();
+
+            _random = new Random();
+            _path = _random.Next().ToString();
+            _fileMode = FileMode.OpenOrCreate;
+            _fileAccess = FileAccess.Read;
+            _bufferSize = _random.Next(5, 1000);
+            _readBufferSize = (uint)_random.Next(5, 1000);
+            _writeBufferSize = (uint)_random.Next(5, 1000);
+            _handle = GenerateRandom(_random.Next(1, 10), _random);
+            _offset = _random.Next(int.MinValue, -1);
+            _attributes = SftpFileAttributes.Empty;
+        }
+
+        protected override void SetupMocks()
+        {
+            SftpSessionMock.InSequence(MockSequence)
+                           .Setup(p => p.RequestOpen(_path, Flags.Read | Flags.CreateNewOrOpen, false))
+                           .Returns(_handle);
+            SftpSessionMock.InSequence(MockSequence)
+                           .Setup(p => p.CalculateOptimalReadLength((uint)_bufferSize))
+                           .Returns(_readBufferSize);
+            SftpSessionMock.InSequence(MockSequence)
+                           .Setup(p => p.CalculateOptimalWriteLength((uint)_bufferSize, _handle))
+                           .Returns(_writeBufferSize);
+            SftpSessionMock.InSequence(MockSequence).Setup(p => p.IsOpen).Returns(true);
+            SftpSessionMock.InSequence(MockSequence)
+                           .Setup(p => p.RequestFStat(_handle, false))
+                           .Returns(_attributes);
+        }
+
+        protected override void Arrange()
+        {
+            base.Arrange();
+
+            _target = new SftpFileStream(SftpSessionMock.Object, _path, _fileMode, _fileAccess, _bufferSize);
+        }
+
+        protected override void Act()
+        {
+            try
+            {
+                _target.Seek(_offset, SeekOrigin.End);
+                Assert.Fail();
+            }
+            catch (EndOfStreamException ex)
+            {
+                _actualException = ex;
+            }
+        }
+
+        [TestMethod]
+        public void SeekShouldHaveThrownEndOfStreamException()
+        {
+            Assert.IsNotNull(_actualException);
+            Assert.IsNull(_actualException.InnerException);
+            Assert.AreEqual("Attempted to read past the end of the stream.", _actualException.Message);
+        }
+
+        [TestMethod]
+        public void IsOpenOnSftpSessionShouldHaveBeenInvokedOnce()
+        {
+            SftpSessionMock.Verify(p => p.IsOpen, Times.Once);
+        }
+
+        [TestMethod]
+        public void PositionShouldReturnZero()
+        {
+            SftpSessionMock.InSequence(MockSequence).Setup(p => p.IsOpen).Returns(true);
+
+            Assert.AreEqual(0L, _target.Position);
+
+            SftpSessionMock.Verify(p => p.IsOpen, Times.Exactly(2));
+        }
+    }
+}

--- a/src/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_Seek_PositionedAtBeginningOfStream_OriginEndAndOffsetPositive.cs
+++ b/src/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_Seek_PositionedAtBeginningOfStream_OriginEndAndOffsetPositive.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Renci.SshNet.Sftp;
+
+namespace Renci.SshNet.Tests.Classes.Sftp
+{
+    [TestClass]
+    public class SftpFileStreamTest_Seek_PositionedAtBeginningOfStream_OriginEndAndOffsetPositive : SftpFileStreamTestBase
+    {
+        private Random _random;
+        private string _path;
+        private FileMode _fileMode;
+        private FileAccess _fileAccess;
+        private int _bufferSize;
+        private uint _readBufferSize;
+        private uint _writeBufferSize;
+        private byte[] _handle;
+        private SftpFileStream _target;
+        private int _offset;
+        private SftpFileAttributes _attributes;
+        private long _actual;
+
+        protected override void SetupData()
+        {
+            base.SetupData();
+
+            _random = new Random();
+            _path = _random.Next().ToString();
+            _fileMode = FileMode.OpenOrCreate;
+            _fileAccess = FileAccess.Read;
+            _bufferSize = _random.Next(5, 1000);
+            _readBufferSize = (uint)_random.Next(5, 1000);
+            _writeBufferSize = (uint)_random.Next(5, 1000);
+            _handle = GenerateRandom(_random.Next(1, 10), _random);
+            _offset = _random.Next(1, int.MaxValue);
+            _attributes = SftpFileAttributes.Empty;
+        }
+
+        protected override void SetupMocks()
+        {
+            SftpSessionMock.InSequence(MockSequence)
+                           .Setup(p => p.RequestOpen(_path, Flags.Read | Flags.CreateNewOrOpen, false))
+                           .Returns(_handle);
+            SftpSessionMock.InSequence(MockSequence)
+                           .Setup(p => p.CalculateOptimalReadLength((uint)_bufferSize))
+                           .Returns(_readBufferSize);
+            SftpSessionMock.InSequence(MockSequence)
+                           .Setup(p => p.CalculateOptimalWriteLength((uint)_bufferSize, _handle))
+                           .Returns(_writeBufferSize);
+            SftpSessionMock.InSequence(MockSequence).Setup(p => p.IsOpen).Returns(true);
+            SftpSessionMock.InSequence(MockSequence)
+                           .Setup(p => p.RequestFStat(_handle, false))
+                           .Returns(_attributes);
+        }
+
+        protected override void Arrange()
+        {
+            base.Arrange();
+
+            _target = new SftpFileStream(SftpSessionMock.Object, _path, _fileMode, _fileAccess, _bufferSize);
+        }
+
+        protected override void Act()
+        {
+            _actual = _target.Seek(_offset, SeekOrigin.End);
+        }
+
+        [TestMethod]
+        public void SeekShouldHaveReturnedOffset()
+        {
+            Assert.AreEqual(_offset, _actual);
+        }
+
+        [TestMethod]
+        public void IsOpenOnSftpSessionShouldHaveBeenInvokedOnce()
+        {
+            SftpSessionMock.Verify(p => p.IsOpen, Times.Once);
+        }
+
+        [TestMethod]
+        public void PositionShouldReturnOffset()
+        {
+            SftpSessionMock.InSequence(MockSequence).Setup(p => p.IsOpen).Returns(true);
+
+            Assert.AreEqual(_offset, _target.Position);
+
+            SftpSessionMock.Verify(p => p.IsOpen, Times.Exactly(2));
+        }
+    }
+}

--- a/src/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_Seek_PositionedAtBeginningOfStream_OriginEndAndOffsetZero.cs
+++ b/src/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_Seek_PositionedAtBeginningOfStream_OriginEndAndOffsetZero.cs
@@ -16,8 +16,10 @@ namespace Renci.SshNet.Tests.Classes.Sftp
         private int _bufferSize;
         private uint _readBufferSize;
         private uint _writeBufferSize;
+        private int _length;
         private byte[] _handle;
         private SftpFileStream _target;
+        private int _offset;
         private SftpFileAttributes _attributes;
         private long _actual;
 
@@ -28,28 +30,38 @@ namespace Renci.SshNet.Tests.Classes.Sftp
             _random = new Random();
             _path = _random.Next().ToString();
             _fileMode = FileMode.OpenOrCreate;
-            _fileAccess = FileAccess.Read;
+            _fileAccess = FileAccess.Write;
             _bufferSize = _random.Next(5, 1000);
             _readBufferSize = (uint)_random.Next(5, 1000);
             _writeBufferSize = (uint)_random.Next(5, 1000);
+            _length = _random.Next(5, 10000);
             _handle = GenerateRandom(_random.Next(1, 10), _random);
+            _offset = 0;
             _attributes = SftpFileAttributes.Empty;
         }
 
         protected override void SetupMocks()
         {
             SftpSessionMock.InSequence(MockSequence)
-                           .Setup(p => p.RequestOpen(_path, Flags.Read | Flags.CreateNewOrOpen, false))
+                           .Setup(session => session.RequestOpen(_path, Flags.Write | Flags.CreateNewOrOpen, false))
                            .Returns(_handle);
             SftpSessionMock.InSequence(MockSequence)
-                           .Setup(p => p.CalculateOptimalReadLength((uint)_bufferSize))
+                           .Setup(session => session.CalculateOptimalReadLength((uint)_bufferSize))
                            .Returns(_readBufferSize);
             SftpSessionMock.InSequence(MockSequence)
-                           .Setup(p => p.CalculateOptimalWriteLength((uint)_bufferSize, _handle))
+                           .Setup(session => session.CalculateOptimalWriteLength((uint)_bufferSize, _handle))
                            .Returns(_writeBufferSize);
-            SftpSessionMock.InSequence(MockSequence).Setup(p => p.IsOpen).Returns(true);
             SftpSessionMock.InSequence(MockSequence)
-                           .Setup(p => p.RequestFStat(_handle, false))
+                           .Setup(session => session.IsOpen)
+                           .Returns(true);
+            SftpSessionMock.InSequence(MockSequence)
+                           .Setup(session => session.RequestFStat(_handle, false))
+                           .Returns(_attributes);
+            SftpSessionMock.InSequence(MockSequence)
+                           .Setup(session => session.RequestFSetStat(_handle, _attributes));
+            SftpSessionMock.InSequence(MockSequence).Setup(session => session.IsOpen).Returns(true);
+            SftpSessionMock.InSequence(MockSequence)
+                           .Setup(session => session.RequestFStat(_handle, false))
                            .Returns(_attributes);
         }
 
@@ -58,33 +70,34 @@ namespace Renci.SshNet.Tests.Classes.Sftp
             base.Arrange();
 
             _target = new SftpFileStream(SftpSessionMock.Object, _path, _fileMode, _fileAccess, _bufferSize);
+            _target.SetLength(_length);
         }
 
         protected override void Act()
         {
-            _actual = _target.Seek(0L, SeekOrigin.End);
+            _actual = _target.Seek(_offset, SeekOrigin.End);
         }
 
         [TestMethod]
-        public void SeekShouldHaveReturnedZero()
+        public void SeekShouldHaveReturnedSize()
         {
-            Assert.AreEqual(0L, _actual);
+            Assert.AreEqual(_attributes.Size, _actual);
         }
 
         [TestMethod]
-        public void IsOpenOnSftpSessionShouldHaveBeenInvokedOnce()
+        public void IsOpenOnSftpSessionShouldHaveBeenInvokedTwice()
         {
-            SftpSessionMock.Verify(p => p.IsOpen, Times.Once);
+            SftpSessionMock.Verify(session => session.IsOpen, Times.Exactly(2));
         }
 
         [TestMethod]
-        public void PositionShouldReturnZero()
+        public void PositionShouldReturnSize()
         {
-            SftpSessionMock.InSequence(MockSequence).Setup(p => p.IsOpen).Returns(true);
+            SftpSessionMock.InSequence(MockSequence).Setup(session => session.IsOpen).Returns(true);
 
-            Assert.AreEqual(0L, _target.Position);
+            Assert.AreEqual(_attributes.Size, _target.Position);
 
-            SftpSessionMock.Verify(p => p.IsOpen, Times.Exactly(2));
+            SftpSessionMock.Verify(session => session.IsOpen, Times.Exactly(3));
         }
     }
 }

--- a/src/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_Seek_PositionedAtBeginningOfStream_OriginEndAndOffsetZero.cs
+++ b/src/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_Seek_PositionedAtBeginningOfStream_OriginEndAndOffsetZero.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Renci.SshNet.Sftp;
+
+namespace Renci.SshNet.Tests.Classes.Sftp
+{
+    [TestClass]
+    public class SftpFileStreamTest_Seek_PositionedAtBeginningOfStream_OriginEndAndOffsetZero : SftpFileStreamTestBase
+    {
+        private Random _random;
+        private string _path;
+        private FileMode _fileMode;
+        private FileAccess _fileAccess;
+        private int _bufferSize;
+        private uint _readBufferSize;
+        private uint _writeBufferSize;
+        private byte[] _handle;
+        private SftpFileStream _target;
+        private SftpFileAttributes _attributes;
+        private long _actual;
+
+        protected override void SetupData()
+        {
+            base.SetupData();
+
+            _random = new Random();
+            _path = _random.Next().ToString();
+            _fileMode = FileMode.OpenOrCreate;
+            _fileAccess = FileAccess.Read;
+            _bufferSize = _random.Next(5, 1000);
+            _readBufferSize = (uint)_random.Next(5, 1000);
+            _writeBufferSize = (uint)_random.Next(5, 1000);
+            _handle = GenerateRandom(_random.Next(1, 10), _random);
+            _attributes = SftpFileAttributes.Empty;
+        }
+
+        protected override void SetupMocks()
+        {
+            SftpSessionMock.InSequence(MockSequence)
+                           .Setup(p => p.RequestOpen(_path, Flags.Read | Flags.CreateNewOrOpen, false))
+                           .Returns(_handle);
+            SftpSessionMock.InSequence(MockSequence)
+                           .Setup(p => p.CalculateOptimalReadLength((uint)_bufferSize))
+                           .Returns(_readBufferSize);
+            SftpSessionMock.InSequence(MockSequence)
+                           .Setup(p => p.CalculateOptimalWriteLength((uint)_bufferSize, _handle))
+                           .Returns(_writeBufferSize);
+            SftpSessionMock.InSequence(MockSequence).Setup(p => p.IsOpen).Returns(true);
+            SftpSessionMock.InSequence(MockSequence)
+                           .Setup(p => p.RequestFStat(_handle, false))
+                           .Returns(_attributes);
+        }
+
+        protected override void Arrange()
+        {
+            base.Arrange();
+
+            _target = new SftpFileStream(SftpSessionMock.Object, _path, _fileMode, _fileAccess, _bufferSize);
+        }
+
+        protected override void Act()
+        {
+            _actual = _target.Seek(0L, SeekOrigin.End);
+        }
+
+        [TestMethod]
+        public void SeekShouldHaveReturnedZero()
+        {
+            Assert.AreEqual(0L, _actual);
+        }
+
+        [TestMethod]
+        public void IsOpenOnSftpSessionShouldHaveBeenInvokedOnce()
+        {
+            SftpSessionMock.Verify(p => p.IsOpen, Times.Once);
+        }
+
+        [TestMethod]
+        public void PositionShouldReturnZero()
+        {
+            SftpSessionMock.InSequence(MockSequence).Setup(p => p.IsOpen).Returns(true);
+
+            Assert.AreEqual(0L, _target.Position);
+
+            SftpSessionMock.Verify(p => p.IsOpen, Times.Exactly(2));
+        }
+    }
+}

--- a/src/Renci.SshNet/Sftp/SftpFileStream.cs
+++ b/src/Renci.SshNet/Sftp/SftpFileStream.cs
@@ -788,26 +788,6 @@ namespace Renci.SshNet.Sftp
                 {
                     // Flush the write buffer and then seek.
                     FlushWriteBuffer();
-
-                    switch (origin)
-                    {
-                        case SeekOrigin.Begin:
-                            newPosn = offset;
-                            break;
-                        case SeekOrigin.Current:
-                            newPosn = _position + offset;
-                            break;
-                        case SeekOrigin.End:
-                            var attributes = _session.RequestFStat(_handle, false);
-                            newPosn = attributes.Size - offset;
-                            break;
-                    }
-
-                    if (newPosn == -1)
-                    {
-                        throw new EndOfStreamException("End of stream.");
-                    }
-                    _position = newPosn;
                 }
                 else
                 {
@@ -838,29 +818,28 @@ namespace Renci.SshNet.Sftp
                     // Abandon the read buffer.
                     _bufferPosition = 0;
                     _bufferLen = 0;
-
-                    // Seek to the new position.
-                    switch (origin)
-                    {
-                        case SeekOrigin.Begin:
-                            newPosn = offset;
-                            break;
-                        case SeekOrigin.Current:
-                            newPosn = _position + offset;
-                            break;
-                        case SeekOrigin.End:
-                            var attributes = _session.RequestFStat(_handle, false);
-                            newPosn = attributes.Size - offset;
-                            break;
-                    }
-
-                    if (newPosn < 0)
-                    {
-                        throw new EndOfStreamException();
-                    }
-
-                    _position = newPosn;
                 }
+
+                // Seek to the new position.
+                switch (origin)
+                {
+                    case SeekOrigin.Begin:
+                        newPosn = offset;
+                        break;
+                    case SeekOrigin.Current:
+                        newPosn = _position + offset;
+                        break;
+                    case SeekOrigin.End:
+                        var attributes = _session.RequestFStat(_handle, false);
+                        newPosn = attributes.Size + offset;
+                        break;
+                }
+
+                if (newPosn < 0)
+                {
+                    throw new EndOfStreamException("End of stream.");
+                }
+                _position = newPosn;
                 return _position;
             }
         }

--- a/src/Renci.SshNet/Sftp/SftpFileStream.cs
+++ b/src/Renci.SshNet/Sftp/SftpFileStream.cs
@@ -833,12 +833,15 @@ namespace Renci.SshNet.Sftp
                         var attributes = _session.RequestFStat(_handle, false);
                         newPosn = attributes.Size + offset;
                         break;
+                    default:
+                        throw new ArgumentException("Invalid seek origin.", "origin");
                 }
 
                 if (newPosn < 0)
                 {
-                    throw new EndOfStreamException("End of stream.");
+                    throw new EndOfStreamException();
                 }
+
                 _position = newPosn;
                 return _position;
             }

--- a/src/Renci.SshNet/Sftp/SftpFileStream.cs
+++ b/src/Renci.SshNet/Sftp/SftpFileStream.cs
@@ -834,7 +834,7 @@ namespace Renci.SshNet.Sftp
                         newPosn = attributes.Size + offset;
                         break;
                     default:
-                        throw new ArgumentException("Invalid seek origin.", "origin");
+                        throw new ArgumentException(message: "Invalid seek origin.", paramName: "origin");
                 }
 
                 if (newPosn < 0)


### PR DESCRIPTION
Changed `SftpFileStream.Seek()` to add offset instead of subtracting when `origin` is set to `SeekOrigin.End`. Fixes #909, fixes #1018.