### PR TITLE
Optimize AppVeyor network stack for number of dynamic connections

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,9 @@
 os: Visual Studio 2019
 
+init:
+ - netsh int ipv4 set dynamicport tcp start=1025 num=64510
+ - powershell "New-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters' -Name 'TcpTimedWaitDelay' -Value '15' -PropertyType 'DWord'"
+
 before_build:
   - nuget restore src\Renci.SshNet.VS2019.sln
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,6 @@ os: Visual Studio 2019
 
 init:
  - netsh int ipv4 set dynamicport tcp start=1025 num=64510
- - powershell "New-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters' -Name 'TcpTimedWaitDelay' -Value '15' -PropertyType 'DWord'"
 
 before_build:
   - nuget restore src\Renci.SshNet.VS2019.sln


### PR DESCRIPTION
Many internet sources indicate that the root cause for ```System.Net.Sockets.SocketException: Only one usage of each socket address (protocol/network address/port) is normally permitted.``` is port exhaustion. In case of SSH.NET tests, this could be caused by a large number of connections opened and closed in quick succession. This was already discussed in https://github.com/sshnet/SSH.NET/pull/877#issuecomment-923982783.

In this PR I have both increased the number of ports that can be used for client side connections and decreased the time that the network stack needs to wait before reusing bindings. More information on these settings [here](https://docs.microsoft.com/en-us/biztalk/technical-guides/settings-that-can-be-modified-to-improve-network-performance).
As this only affects the AppVeyor build VM, I do not expect any regressions or side effects.

This will (hopefully) fix #921.
