### PR TITLE
Fix PipeStream.Read returning 0 prematurely 

### DIFF
--- a/src/Renci.SshNet.Tests/Classes/Common/PipeStreamTest.cs
+++ b/src/Renci.SshNet.Tests/Classes/Common/PipeStreamTest.cs
@@ -63,7 +63,7 @@ namespace Renci.SshNet.Tests.Classes.Common
 
             var readBuffer = new byte[2];
             var bytesRead = target.Read(readBuffer, 0, readBuffer.Length);
-            Assert.AreEqual(2, bytesRead);
+            Assert.AreEqual(readBuffer.Length, bytesRead);
             Assert.AreEqual(0x0a, readBuffer[0]);
             Assert.AreEqual(0x0d, readBuffer[1]);
 
@@ -78,8 +78,18 @@ namespace Renci.SshNet.Tests.Classes.Common
 
             target.BlockLastReadBuffer = true;
             readBuffer = new byte[2];
-            bytesRead = target.Read(readBuffer, 0, readBuffer.Length);
-            Assert.AreEqual(2, bytesRead);
+            int bufferOffset = 0;
+            while (bufferOffset < readBuffer.Length)
+            {
+                bytesRead = target.Read(readBuffer, bufferOffset, readBuffer.Length -  bufferOffset);
+                if (bytesRead == 0)
+                {
+                    Assert.Fail("PipeStream.Read returned 0");
+                }
+
+                bufferOffset += bytesRead;
+            }
+            Assert.AreEqual(readBuffer.Length, bufferOffset);
             Assert.AreEqual(0x09, readBuffer[0]);
             Assert.AreEqual(0x05, readBuffer[1]);
         }

--- a/src/Renci.SshNet.Tests/Classes/Common/PipeStreamTest.cs
+++ b/src/Renci.SshNet.Tests/Classes/Common/PipeStreamTest.cs
@@ -76,6 +76,7 @@ namespace Renci.SshNet.Tests.Classes.Common
                     });
             writeToStreamThread.Start();
 
+            target.BlockLastReadBuffer = true;
             readBuffer = new byte[2];
             bytesRead = target.Read(readBuffer, 0, readBuffer.Length);
             Assert.AreEqual(2, bytesRead);

--- a/src/Renci.SshNet.Tests/Classes/Common/PipeStream_Close_BlockingRead.cs
+++ b/src/Renci.SshNet.Tests/Classes/Common/PipeStream_Close_BlockingRead.cs
@@ -15,6 +15,7 @@ namespace Renci.SshNet.Tests.Classes.Common
         protected override void Arrange()
         {
             _pipeStream = new PipeStream();
+            _pipeStream.BlockLastReadBuffer = true;
 
             _pipeStream.WriteByte(10);
             _pipeStream.WriteByte(13);

--- a/src/Renci.SshNet/Common/PipeStream.cs
+++ b/src/Renci.SshNet/Common/PipeStream.cs
@@ -220,7 +220,7 @@
         /// <returns><c>True</c> if data available; otherwise<c>false</c>.</returns>
         private bool ReadAvailable(int count)
         {
-            return (Length >= count || !BlockLastReadBuffer);
+            return BlockLastReadBuffer ? Length >= count : Length > 0;
         }
 
         ///<summary>


### PR DESCRIPTION
Fixes PipeStream.Read to block until more data is received or the session is closed.
This will fix #12, fix #164, fix #440, fix #650