### PR TITLE
Add SshCommand.ExecuteAsync()

### DIFF
--- a/src/Renci.SshNet/Channels/Channel.cs
+++ b/src/Renci.SshNet/Channels/Channel.cs
@@ -562,14 +562,11 @@ namespace Renci.SshNet.Channels
                     // this also ensures don't raise the Closed event more than once
                     IsOpen = false;
 
-                    if (_closeMessageReceived)
+                    // raise event signaling that both ends of the channel have been closed
+                    var closed = Closed;
+                    if (closed != null)
                     {
-                        // raise event signaling that both ends of the channel have been closed
-                        var closed = Closed;
-                        if (closed != null)
-                        {
-                            closed(this, new ChannelEventArgs(LocalChannelNumber));
-                        }
+                        closed(this, new ChannelEventArgs(LocalChannelNumber));
                     }
                 }
             }


### PR DESCRIPTION
This is my attempt at #931, reusing some code from #937.

```Channel.Close()``` was modified to always trigger ```Channel.Closed``` event, allowing us to detect that the channel was closed locally.

The ```SshCommand.ExecuteAsync()``` aborts the initial task in case cancellation is requested:
 - Is sends a SIGTERM signal to the server to try to abort the command run at the server
 - It closes the ```Channel```
 - It notifies the caller about cancellation

Because this code uses TAP over APM and ```CommandAsyncResult``` has no means to convey any exceptions thrown during execution, there are some workarounds to properly notify the caller that the task was cancelled.

@kendallb can you have a look at this and check if it works for you?