### PR TITLE
WIP: Implement support for rsa-sha2-256 key exchange.

### DIFF
--- a/src/Renci.SshNet/ConnectionInfo.cs
+++ b/src/Renci.SshNet/ConnectionInfo.cs
@@ -389,6 +389,7 @@ namespace Renci.SshNet
 #endif
                     {"ssh-rsa", data => new KeyHostAlgorithm("ssh-rsa", new RsaKey(), data)},
                     {"ssh-dss", data => new KeyHostAlgorithm("ssh-dss", new DsaKey(), data)},
+                    {"rsa-sha2-256", data => new KeyHostAlgorithm("rsa-sha2-256", new RsaWithSha256SignatureKey(), data)},
                     //{"x509v3-sign-rsa", () => { ... },
                     //{"x509v3-sign-dss", () => { ... },
                     //{"spki-sign-rsa", () => { ... },

--- a/src/Renci.SshNet/IPrivateKeySource.cs
+++ b/src/Renci.SshNet/IPrivateKeySource.cs
@@ -10,6 +10,6 @@ namespace Renci.SshNet
         /// <summary>
         /// Gets the host key.
         /// </summary>
-        HostAlgorithm HostKey { get; }
+        HostAlgorithm[] HostKeys { get; }
     }
 }

--- a/src/Renci.SshNet/PrivateKeyFile.cs
+++ b/src/Renci.SshNet/PrivateKeyFile.cs
@@ -77,7 +77,7 @@ namespace Renci.SshNet
         /// <summary>
         /// Gets the host key.
         /// </summary>
-        public HostAlgorithm HostKey { get; private set; }
+        public HostAlgorithm[] HostKeys { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PrivateKeyFile"/> class.
@@ -85,7 +85,7 @@ namespace Renci.SshNet
         /// <param name="key">The key.</param>
         public PrivateKeyFile(Key key)
         {
-            HostKey = new KeyHostAlgorithm(key.ToString(), key);
+            HostKeys = new KeyHostAlgorithm[] { new KeyHostAlgorithm(key.ToString(), key) };
         }
 
         /// <summary>
@@ -214,22 +214,24 @@ namespace Renci.SshNet
             switch (keyName)
             {
                 case "RSA":
-                    _key = new RsaKey(decryptedData);
-                    HostKey = new KeyHostAlgorithm("ssh-rsa", _key);
+                    HostKeys = new KeyHostAlgorithm[] {
+                        new KeyHostAlgorithm("rsa-sha2-256", new RsaWithSha256SignatureKey(decryptedData)),
+                        new KeyHostAlgorithm("ssh-rsa", new RsaKey(decryptedData)),
+                    };
                     break;
                 case "DSA":
                     _key = new DsaKey(decryptedData);
-                    HostKey = new KeyHostAlgorithm("ssh-dss", _key);
+                    HostKeys = new KeyHostAlgorithm[] { new KeyHostAlgorithm("ssh-dss", _key) };
                     break;
 #if FEATURE_ECDSA
                 case "EC":
                     _key = new EcdsaKey(decryptedData);
-                    HostKey = new KeyHostAlgorithm(_key.ToString(), _key);
+                    HostKeys = new KeyHostAlgorithm[] { new KeyHostAlgorithm(_key.ToString(), _key) };
                     break;
 #endif
                 case "OPENSSH":
                     _key = ParseOpenSshV1Key(decryptedData, passPhrase);
-                    HostKey = new KeyHostAlgorithm(_key.ToString(), _key);
+                    HostKeys = new KeyHostAlgorithm[] { new KeyHostAlgorithm(_key.ToString(), _key) };
                     break;
                 case "SSH2 ENCRYPTED":
                     var reader = new SshDataReader(decryptedData);
@@ -281,7 +283,7 @@ namespace Renci.SshNet
                         var q = reader.ReadBigIntWithBits();//p
                         var p = reader.ReadBigIntWithBits();//q
                         _key = new RsaKey(modulus, exponent, d, p, q, inverseQ);
-                        HostKey = new KeyHostAlgorithm("ssh-rsa", _key);
+                        HostKeys = new KeyHostAlgorithm[] { new KeyHostAlgorithm("ssh-rsa", _key) };
                     }
                     else if (keyType == "dl-modp{sign{dsa-nist-sha1},dh{plain}}")
                     {
@@ -296,7 +298,7 @@ namespace Renci.SshNet
                         var y = reader.ReadBigIntWithBits();
                         var x = reader.ReadBigIntWithBits();
                         _key = new DsaKey(p, q, g, y, x);
-                        HostKey = new KeyHostAlgorithm("ssh-dss", _key);
+                        HostKeys = new KeyHostAlgorithm[] { new KeyHostAlgorithm("ssh-dss", _key) };
                     }
                     else
                     {

--- a/src/Renci.SshNet/Security/Cryptography/RsaSha256DigitalSignature.cs
+++ b/src/Renci.SshNet/Security/Cryptography/RsaSha256DigitalSignature.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Security.Cryptography;
+using Renci.SshNet.Abstractions;
+using Renci.SshNet.Common;
+using Renci.SshNet.Security.Cryptography.Ciphers;
+
+namespace Renci.SshNet.Security.Cryptography
+{
+    /// <summary>
+    /// Implements RSA digital signature algorithm.
+    /// </summary>
+    public class RsaSha256DigitalSignature : CipherDigitalSignature, IDisposable
+    {
+        private HashAlgorithm _hash;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RsaSha256DigitalSignature"/> class.
+        /// </summary>
+        /// <param name="rsaKey">The RSA key.</param>
+        public RsaSha256DigitalSignature(RsaWithSha256SignatureKey rsaKey)
+            : base(new ObjectIdentifier(2, 16, 840, 1, 101, 3, 4, 2, 1), new RsaCipher(rsaKey))
+        {
+            _hash = SHA256.Create();
+        }
+
+        /// <summary>
+        /// Hashes the specified input.
+        /// </summary>
+        /// <param name="input">The input.</param>
+        /// <returns>
+        /// Hashed data.
+        /// </returns>
+        protected override byte[] Hash(byte[] input)
+        {
+            return _hash.ComputeHash(input);
+        }
+
+        #region IDisposable Members
+
+        private bool _isDisposed;
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases unmanaged and - optionally - managed resources
+        /// </summary>
+        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_isDisposed)
+                return;
+
+            if (disposing)
+            {
+                var hash = _hash;
+                if (hash != null)
+                {
+                    hash.Dispose();
+                    _hash = null;
+                }
+
+                _isDisposed = true;
+            }
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="RsaSha256DigitalSignature"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~RsaSha256DigitalSignature()
+        {
+            Dispose(false);
+        }
+
+        #endregion
+    }
+}

--- a/src/Renci.SshNet/Security/Cryptography/RsaWithSha256SignatureKey.cs
+++ b/src/Renci.SshNet/Security/Cryptography/RsaWithSha256SignatureKey.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Renci.SshNet.Common;
+using Renci.SshNet.Security.Cryptography;
+
+namespace Renci.SshNet.Security
+{
+    /// <summary>
+    /// Contains RSA private and public key
+    /// </summary>
+    public class RsaWithSha256SignatureKey : RsaKey
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RsaWithSha256SignatureKey"/> class.
+        /// </summary>
+        public RsaWithSha256SignatureKey()
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RsaWithSha256SignatureKey"/> class.
+        /// </summary>
+        /// <param name="data">DER encoded private key data.</param>
+        public RsaWithSha256SignatureKey(byte[] data)
+            : base(data)
+        {
+            if (_privateKey.Length != 8)
+                throw new InvalidOperationException("Invalid private key.");
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RsaWithSha256SignatureKey"/> class.
+        /// </summary>
+        /// <param name="modulus">The modulus.</param>
+        /// <param name="exponent">The exponent.</param>
+        /// <param name="d">The d.</param>
+        /// <param name="p">The p.</param>
+        /// <param name="q">The q.</param>
+        /// <param name="inverseQ">The inverse Q.</param>
+        public RsaWithSha256SignatureKey(BigInteger modulus, BigInteger exponent, BigInteger d, BigInteger p, BigInteger q,
+            BigInteger inverseQ) : base(modulus, exponent, d, p, q, inverseQ)
+        {
+        }
+
+        private RsaSha256DigitalSignature _digitalSignature;
+
+        /// <summary>
+        /// Gets the digital signature.
+        /// </summary>
+        protected override DigitalSignature DigitalSignature
+        {
+            get
+            {
+                if (_digitalSignature == null)
+                {
+                    _digitalSignature = new RsaSha256DigitalSignature(this);
+                }
+
+                return _digitalSignature;
+            }
+        }
+
+        /// <summary>
+        /// Gets the Key String.
+        /// </summary>
+        public override string ToString()
+        {
+            return "rsa-sha2-256";
+        }
+    }
+}


### PR DESCRIPTION
There doesn't appear to be any way to select different exchange methods depending on what the server supports for the same key, so this commit allows IPrivateKeySource to expose multiple key exchange methods for the same key and will try each one.

Tested on Ubuntu 18.04 and 22.04 with default SSH server config and with only ssh-rsa and rsa-sha2-256 key exchange enabled.

Not sure if this is necessarily the best design to go with, so haven't updated the tests yet.

A simpler approach would be to just replace ssh-rsa with rsa-sha2-256, which would prevent communication with old servers (OpenSSH 7.2 added rsa-sha2-256 support in 2016).

Based on @ml054's work in https://github.com/sshnet/SSH.NET/issues/825#issuecomment-1139440419