### PR TITLE
Add IBaseClient for BaseClient and ISftpClient to inherit from

### DIFF
--- a/src/Renci.SshNet/BaseClient.cs
+++ b/src/Renci.SshNet/BaseClient.cs
@@ -13,7 +13,7 @@ namespace Renci.SshNet
     /// <summary>
     /// Serves as base class for client implementations, provides common client functionality.
     /// </summary>
-    public abstract class BaseClient : IDisposable, IBaseClient
+    public abstract class BaseClient : IBaseClient, IDisposable
     {
         /// <summary>
         /// Holds value indicating whether the connection info is owned by this client.

--- a/src/Renci.SshNet/BaseClient.cs
+++ b/src/Renci.SshNet/BaseClient.cs
@@ -13,7 +13,7 @@ namespace Renci.SshNet
     /// <summary>
     /// Serves as base class for client implementations, provides common client functionality.
     /// </summary>
-    public abstract class BaseClient : IDisposable
+    public abstract class BaseClient : IDisposable, IBaseClient
     {
         /// <summary>
         /// Holds value indicating whether the connection info is owned by this client.
@@ -387,7 +387,7 @@ namespace Renci.SshNet
             }
         }
 
-#region IDisposable Members
+        #region IDisposable Members
 
         private bool _isDisposed;
 
@@ -446,7 +446,7 @@ namespace Renci.SshNet
             Dispose(false);
         }
 
-#endregion
+        #endregion
 
         /// <summary>
         /// Stops the keep-alive timer, and waits until all timer callbacks have been

--- a/src/Renci.SshNet/IBaseClient.cs
+++ b/src/Renci.SshNet/IBaseClient.cs
@@ -1,0 +1,104 @@
+﻿using Renci.SshNet.Common;
+using System;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Renci.SshNet
+{
+    /// <summary>
+    /// Serves as base class for client implementations, provides common client functionality.
+    /// </summary>
+    public interface IBaseClient
+    {
+        /// <summary>
+        /// Gets the connection info.
+        /// </summary>
+        /// <value>
+        /// The connection info.
+        /// </value>
+        /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
+        ConnectionInfo ConnectionInfo { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this client is connected to the server.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this client is connected; otherwise, <c>false</c>.
+        /// </value>
+        /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
+        bool IsConnected { get; }
+
+        /// <summary>
+        /// Gets or sets the keep-alive interval.
+        /// </summary>
+        /// <value>
+        /// The keep-alive interval. Specify negative one (-1) milliseconds to disable the
+        /// keep-alive. This is the default value.
+        /// </value>
+        /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
+        TimeSpan KeepAliveInterval { get; set; }
+
+        /// <summary>
+        /// Occurs when an error occurred.
+        /// </summary>
+        /// <example>
+        ///   <code source="..\..\src\Renci.SshNet.Tests\Classes\SshClientTest.cs" region="Example SshClient Connect ErrorOccurred" language="C#" title="Handle ErrorOccurred event" />
+        /// </example>
+        event EventHandler<ExceptionEventArgs> ErrorOccurred;
+
+        /// <summary>
+        /// Occurs when host key received.
+        /// </summary>
+        /// <example>
+        ///   <code source="..\..\src\Renci.SshNet.Tests\Classes\SshClientTest.cs" region="Example SshClient Connect HostKeyReceived" language="C#" title="Handle HostKeyReceived event" />
+        /// </example>
+        event EventHandler<HostKeyEventArgs> HostKeyReceived;
+
+        /// <summary>
+        /// Connects client to the server.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">The client is already connected.</exception>
+        /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
+        /// <exception cref="SocketException">Socket connection to the SSH server or proxy server could not be established, or an error occurred while resolving the hostname.</exception>
+        /// <exception cref="SshConnectionException">SSH session could not be established.</exception>
+        /// <exception cref="SshAuthenticationException">Authentication of SSH session failed.</exception>
+        /// <exception cref="ProxyException">Failed to establish proxy connection.</exception>
+        void Connect();
+
+        /// <summary>
+        /// Asynchronously connects client to the server.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to observe.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous connect operation.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">The client is already connected.</exception>
+        /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
+        /// <exception cref="SocketException">Socket connection to the SSH server or proxy server could not be established, or an error occurred while resolving the hostname.</exception>
+        /// <exception cref="SshConnectionException">SSH session could not be established.</exception>
+        /// <exception cref="SshAuthenticationException">Authentication of SSH session failed.</exception>
+        /// <exception cref="ProxyException">Failed to establish proxy connection.</exception>
+        Task ConnectAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Disconnects client from the server.
+        /// </summary>
+        /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
+        void Disconnect();
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        void Dispose();
+
+        /// <summary>
+        /// Sends a keep-alive message to the server.
+        /// </summary>
+        /// <remarks>
+        /// Use <see cref="KeepAliveInterval"/> to configure the client to send a keep-alive at regular
+        /// intervals.
+        /// </remarks>
+        /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
+        void SendKeepAlive();
+    }
+}

--- a/src/Renci.SshNet/IBaseClient.cs
+++ b/src/Renci.SshNet/IBaseClient.cs
@@ -2,7 +2,9 @@
 using System;
 using System.Net.Sockets;
 using System.Threading;
+#if FEATURE_TAP
 using System.Threading.Tasks;
+#endif
 
 namespace Renci.SshNet
 {
@@ -66,6 +68,7 @@ namespace Renci.SshNet
         /// <exception cref="ProxyException">Failed to establish proxy connection.</exception>
         void Connect();
 
+#if FEATURE_TAP
         /// <summary>
         /// Asynchronously connects client to the server.
         /// </summary>
@@ -79,6 +82,7 @@ namespace Renci.SshNet
         /// <exception cref="SshAuthenticationException">Authentication of SSH session failed.</exception>
         /// <exception cref="ProxyException">Failed to establish proxy connection.</exception>
         Task ConnectAsync(CancellationToken cancellationToken);
+#endif
 
         /// <summary>
         /// Disconnects client from the server.

--- a/src/Renci.SshNet/ISftpClient.cs
+++ b/src/Renci.SshNet/ISftpClient.cs
@@ -720,7 +720,7 @@ namespace Renci.SshNet
         /// <exception cref="SftpPermissionDeniedException">Permission to list the contents of the directory was denied by the remote host. <para>-or-</para> A SSH command was denied by the server.</exception>
         /// <exception cref="SshException">A SSH error where <see cref="Exception.Message" /> is the message from the remote host.</exception>
         /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
-        Task<IEnumerable<SftpFile>> ListDirectoryAsync(string path, CancellationToken cancellationToken);
+        Task<IEnumerable<ISftpFile>> ListDirectoryAsync(string path, CancellationToken cancellationToken);
 #endif
 
         /// <summary>

--- a/src/Renci.SshNet/ISftpClient.cs
+++ b/src/Renci.SshNet/ISftpClient.cs
@@ -14,7 +14,7 @@ namespace Renci.SshNet
     /// <summary>
     /// Implementation of the SSH File Transfer Protocol (SFTP) over SSH.
     /// </summary>
-    public interface ISftpClient : IDisposable
+    public interface ISftpClient : IBaseClient, IDisposable
     {
         /// <summary>
         /// Gets or sets the maximum size of the buffer in bytes.

--- a/src/Renci.SshNet/SftpClient.cs
+++ b/src/Renci.SshNet/SftpClient.cs
@@ -552,7 +552,7 @@ namespace Renci.SshNet
         /// <exception cref="SftpPermissionDeniedException">Permission to list the contents of the directory was denied by the remote host. <para>-or-</para> A SSH command was denied by the server.</exception>
         /// <exception cref="SshException">A SSH error where <see cref="Exception.Message" /> is the message from the remote host.</exception>
         /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
-        public async Task<IEnumerable<SftpFile>> ListDirectoryAsync(string path, CancellationToken cancellationToken)
+        public async Task<IEnumerable<ISftpFile>> ListDirectoryAsync(string path, CancellationToken cancellationToken)
         {
             base.CheckDisposed();
             if (path == null)


### PR DESCRIPTION
Fixes #890.

This will aid in unit testing by allowing developers to mock functionality from IBaseClient and ISftpClient. Currently, the only way to do that is to develop a wrapper around the functionality.