### PR TITLE
Bugfix/shell stream stopping event on chanell close

### DIFF
--- a/src/Renci.SshNet.Tests/Classes/ShellStreamTest.cs
+++ b/src/Renci.SshNet.Tests/Classes/ShellStreamTest.cs
@@ -46,6 +46,7 @@ namespace Renci.SshNet.Tests.Classes
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _channelSessionMock = new Mock<IChannelSession>(MockBehavior.Strict);
+            
         }
 
         [TestMethod] // issue #2190

--- a/src/Renci.SshNet.Tests/Classes/SshClientTest_CreateShellStream_TerminalNameAndColumnsAndRowsAndWidthAndHeightAndBufferSizeAndTerminalModes_Connected.cs
+++ b/src/Renci.SshNet.Tests/Classes/SshClientTest_CreateShellStream_TerminalNameAndColumnsAndRowsAndWidthAndHeightAndBufferSizeAndTerminalModes_Connected.cs
@@ -17,6 +17,8 @@ namespace Renci.SshNet.Tests.Classes
         private uint _heightRows;
         private uint _widthPixels;
         private uint _heightPixels;
+        private EventHandler<EventArgs> _starting;
+        private EventHandler<EventArgs> _stopping;
         private Dictionary<TerminalModes, uint> _terminalModes;
         private int _bufferSize;
         private ShellStream _expected;
@@ -59,7 +61,9 @@ namespace Renci.SshNet.Tests.Classes
                                                                _widthPixels,
                                                                _heightPixels,
                                                                _terminalModes,
-                                                               _bufferSize))
+                                                               _bufferSize,
+                                                               _starting, 
+                                                               _stopping))
                                .Returns(_expected);
         }
 
@@ -79,7 +83,9 @@ namespace Renci.SshNet.Tests.Classes
                                                    _widthPixels,
                                                    _heightPixels,
                                                    _bufferSize,
-                                                   _terminalModes);
+                                                   _terminalModes,
+                                                   _starting,
+                                                   _stopping);
         }
 
         [TestMethod]
@@ -92,7 +98,9 @@ namespace Renci.SshNet.Tests.Classes
                                                                 _widthPixels,
                                                                 _heightPixels,
                                                                 _terminalModes,
-                                                                _bufferSize),
+                                                                _bufferSize,
+                                                                _starting,
+                                                                _stopping),
                                        Times.Once);
         }
 

--- a/src/Renci.SshNet.Tests/Classes/SshClientTest_CreateShellStream_TerminalNameAndColumnsAndRowsAndWidthAndHeightAndBufferSize_Connected.cs
+++ b/src/Renci.SshNet.Tests/Classes/SshClientTest_CreateShellStream_TerminalNameAndColumnsAndRowsAndWidthAndHeightAndBufferSize_Connected.cs
@@ -18,6 +18,8 @@ namespace Renci.SshNet.Tests.Classes
         private uint _widthPixels;
         private uint _heightPixels;
         private int _bufferSize;
+        private EventHandler<EventArgs> _starting;
+        private EventHandler<EventArgs> _stopping;
         private ShellStream _expected;
         private ShellStream _actual;
 
@@ -57,7 +59,10 @@ namespace Renci.SshNet.Tests.Classes
                                                                _widthPixels,
                                                                _heightPixels,
                                                                null,
-                                                               _bufferSize))
+                                                               _bufferSize,
+                                                               _starting,
+                                                               _stopping
+                                                               ))
                                .Returns(_expected);
         }
 
@@ -89,7 +94,9 @@ namespace Renci.SshNet.Tests.Classes
                                                                 _widthPixels,
                                                                 _heightPixels,
                                                                 null,
-                                                                _bufferSize),
+                                                                _bufferSize,
+                                                                _starting, 
+                                                                _stopping),
                                        Times.Once);
         }
 

--- a/src/Renci.SshNet.Tests/Renci.SshNet.Tests.csproj
+++ b/src/Renci.SshNet.Tests/Renci.SshNet.Tests.csproj
@@ -99,6 +99,20 @@
     <MSTestV1UnitTestFrameworkAssemblyCandidate>$(MSBuildProgramFiles32)\Microsoft Visual Studio\2019\Preview\Common7\IDE\PublicAssemblies\Microsoft.VisualStudio.QualityTools.UnitTestFramework.dll</MSTestV1UnitTestFrameworkAssemblyCandidate>
     <MSTestV1UnitTestFrameworkAssembly Condition="'$(MSTestV1UnitTestFrameworkAssembly)' == '' and Exists('$(MSTestV1UnitTestFrameworkAssemblyCandidate)')">$(MSTestV1UnitTestFrameworkAssemblyCandidate)</MSTestV1UnitTestFrameworkAssembly>
   </PropertyGroup>
+	<PropertyGroup Condition=" '$(VisualStudioVersion)' == '17.0' ">
+		<!-- Look for Microsoft.VisualStudio.QualityTools.UnitTestFramework.dll in VS 2019 Enterprise -->
+		<MSTestV1UnitTestFrameworkAssemblyCandidate>$(MSBuildProgramFiles32)\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\PublicAssemblies\Microsoft.VisualStudio.QualityTools.UnitTestFramework.dll</MSTestV1UnitTestFrameworkAssemblyCandidate>
+		<MSTestV1UnitTestFrameworkAssembly Condition="'$(MSTestV1UnitTestFrameworkAssembly)' == '' and Exists('$(MSTestV1UnitTestFrameworkAssemblyCandidate)')">$(MSTestV1UnitTestFrameworkAssemblyCandidate)</MSTestV1UnitTestFrameworkAssembly>
+		<!-- Fall back to VS 2022 Professional -->
+		<MSTestV1UnitTestFrameworkAssemblyCandidate>$(MSBuildProgramFiles32)\Microsoft Visual Studio\2022\Professional\Common7\IDE\PublicAssemblies\Microsoft.VisualStudio.QualityTools.UnitTestFramework.dll</MSTestV1UnitTestFrameworkAssemblyCandidate>
+		<MSTestV1UnitTestFrameworkAssembly Condition="'$(MSTestV1UnitTestFrameworkAssembly)' == '' and Exists('$(MSTestV1UnitTestFrameworkAssemblyCandidate)')">$(MSTestV1UnitTestFrameworkAssemblyCandidate)</MSTestV1UnitTestFrameworkAssembly>
+		<!-- Fall back to VS 2022 Community -->
+		<MSTestV1UnitTestFrameworkAssemblyCandidate>$(MSBuildProgramFiles32)\Microsoft Visual Studio\2022\Community\Common7\IDE\PublicAssemblies\Microsoft.VisualStudio.QualityTools.UnitTestFramework.dll</MSTestV1UnitTestFrameworkAssemblyCandidate>
+		<MSTestV1UnitTestFrameworkAssembly Condition="'$(MSTestV1UnitTestFrameworkAssembly)' == '' and Exists('$(MSTestV1UnitTestFrameworkAssemblyCandidate)')">$(MSTestV1UnitTestFrameworkAssemblyCandidate)</MSTestV1UnitTestFrameworkAssembly>
+		<!-- Fall back to VS 2022 Preview -->
+		<MSTestV1UnitTestFrameworkAssemblyCandidate>$(MSBuildProgramFiles32)\Microsoft Visual Studio\2022\Preview\Common7\IDE\PublicAssemblies\Microsoft.VisualStudio.QualityTools.UnitTestFramework.dll</MSTestV1UnitTestFrameworkAssemblyCandidate>
+		<MSTestV1UnitTestFrameworkAssembly Condition="'$(MSTestV1UnitTestFrameworkAssembly)' == '' and Exists('$(MSTestV1UnitTestFrameworkAssemblyCandidate)')">$(MSTestV1UnitTestFrameworkAssemblyCandidate)</MSTestV1UnitTestFrameworkAssembly>
+	</PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net35'">
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework">

--- a/src/Renci.SshNet/IServiceFactory.cs
+++ b/src/Renci.SshNet/IServiceFactory.cs
@@ -78,7 +78,9 @@ namespace Renci.SshNet
         /// <param name="width">The terminal height in pixels.</param>
         /// <param name="height">The terminal height in pixels.</param>
         /// <param name="bufferSize">Size of the buffer.</param>
-        /// <param name="terminalModeValues">The terminal mode values.</param>
+        /// <param name="terminalModeValues">List of Terminal Modes</param>
+        /// <param name="starting">Optional Starting Event handler</param>
+        /// <param name="stopping">Optional Stopping Event handler</param>
         /// <returns>
         /// The created <see cref="ShellStream"/> instance.
         /// </returns>
@@ -100,7 +102,10 @@ namespace Renci.SshNet
                                       uint width,
                                       uint height,
                                       IDictionary<TerminalModes, uint> terminalModeValues,
-                                      int bufferSize);
+                                      int bufferSize,
+                                      EventHandler<EventArgs> starting = null,
+                                      EventHandler<EventArgs> stopping = null
+                                      );
 
         /// <summary>
         /// Creates an <see cref="IRemotePathTransformation"/> that encloses a path in double quotes, and escapes

--- a/src/Renci.SshNet/ServiceFactory.cs
+++ b/src/Renci.SshNet/ServiceFactory.cs
@@ -161,6 +161,9 @@ namespace Renci.SshNet
         /// <param name="height">The terminal height in pixels.</param>
         /// <param name="terminalModeValues">The terminal mode values.</param>
         /// <param name="bufferSize">The size of the buffer.</param>
+        /// <param name="starting">Optional Starting Event handler</param>
+        /// <param name="stopping">Optional Stopping Event handler</param>
+        /// 
         /// <returns>
         /// The created <see cref="ShellStream"/> instance.
         /// </returns>
@@ -175,9 +178,9 @@ namespace Renci.SshNet
         /// to the drawable area of the window.
         /// </para>
         /// </remarks>
-        public ShellStream CreateShellStream(ISession session, string terminalName, uint columns, uint rows, uint width, uint height, IDictionary<TerminalModes, uint> terminalModeValues, int bufferSize)
+        public ShellStream CreateShellStream(ISession session, string terminalName, uint columns, uint rows, uint width, uint height, IDictionary<TerminalModes, uint> terminalModeValues, int bufferSize, EventHandler<EventArgs> starting = null, EventHandler<EventArgs> stopping = null)
         {
-            return new ShellStream(session, terminalName, columns, rows, width, height, terminalModeValues, bufferSize);
+            return new ShellStream(session, terminalName, columns, rows, width, height, terminalModeValues, bufferSize, starting, stopping);
         }
 
         /// <summary>
@@ -251,5 +254,7 @@ namespace Renci.SshNet
         {
             return new SocketFactory();
         }
+
+
     }
 }

--- a/src/Renci.SshNet/ShellStream.cs
+++ b/src/Renci.SshNet/ShellStream.cs
@@ -113,7 +113,10 @@ namespace Renci.SshNet
                 {
                     throw new SshException("The request to start a shell was not accepted by the server. Consult the server log for more information.");
                 }
-                Starting(this, new EventArgs());
+                if (Starting != null)
+                {
+                    Starting(this, new EventArgs());
+                }
             }
             catch
             {
@@ -783,7 +786,11 @@ namespace Renci.SshNet
 
         private void Channel_Closed(object sender, ChannelEventArgs e)
         {
-            ThreadAbstraction.ExecuteThread(() => Stopping(this, new EventArgs()));
+            if (Stopping != null)
+            {
+                ThreadAbstraction.ExecuteThread(() => Stopping(this, new EventArgs()));
+            }
+
             // FYI: Dispose should Probably NOT be called here as a class should NOT dispose of
             // itself: It will be owned by someone else.  Calling it here means it will be disappear
             // out from under the owner. BUT removing it here now is a breaking change and because there

--- a/src/Renci.SshNet/ShellStream.cs
+++ b/src/Renci.SshNet/ShellStream.cs
@@ -42,6 +42,11 @@ namespace Renci.SshNet
         public event EventHandler<EventArgs> Stopping;
 
         /// <summary>
+        /// Occurs when a channel has been established and the stream is about to start
+        /// </summary>
+        public event EventHandler<EventArgs> Starting;
+
+        /// <summary>
         /// Gets a value that indicates whether data is available on the <see cref="ShellStream"/> to be read.
         /// </summary>
         /// <value>
@@ -108,6 +113,7 @@ namespace Renci.SshNet
                 {
                     throw new SshException("The request to start a shell was not accepted by the server. Consult the server log for more information.");
                 }
+                Starting(this, new EventArgs());
             }
             catch
             {

--- a/src/Renci.SshNet/SshClient.cs
+++ b/src/Renci.SshNet/SshClient.cs
@@ -1,10 +1,10 @@
-﻿using System;
+﻿using Renci.SshNet.Common;
+using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Text;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Net;
-using Renci.SshNet.Common;
+using System.Text;
 
 namespace Renci.SshNet
 {
@@ -413,6 +413,8 @@ namespace Renci.SshNet
         /// <param name="width">The terminal height in pixels.</param>
         /// <param name="height">The terminal height in pixels.</param>
         /// <param name="bufferSize">The size of the buffer.</param>
+        /// <param name="starting">Optional Starting Event handler</param>
+        /// <param name="stopping">Optional Stopping Event handler</param> 
         /// <returns>
         /// The created <see cref="ShellStream"/> instance.
         /// </returns>
@@ -427,9 +429,9 @@ namespace Renci.SshNet
         /// to the drawable area of the window.
         /// </para>
         /// </remarks>
-        public ShellStream CreateShellStream(string terminalName, uint columns, uint rows, uint width, uint height, int bufferSize)
+        public ShellStream CreateShellStream(string terminalName, uint columns, uint rows, uint width, uint height, int bufferSize, EventHandler<EventArgs> starting = null, EventHandler<EventArgs> stopping = null)
         {
-            return CreateShellStream(terminalName, columns, rows, width, height, bufferSize, null);
+            return CreateShellStream(terminalName, columns, rows, width, height, bufferSize, null, starting, stopping);
         }
 
         /// <summary>
@@ -442,6 +444,9 @@ namespace Renci.SshNet
         /// <param name="height">The terminal height in pixels.</param>
         /// <param name="bufferSize">The size of the buffer.</param>
         /// <param name="terminalModeValues">The terminal mode values.</param>
+        /// <param name="starting">Optional Starting Event handler</param>
+        /// <param name="stopping">Optional Stopping Event handler</param>
+        /// 
         /// <returns>
         /// The created <see cref="ShellStream"/> instance.
         /// </returns>
@@ -456,11 +461,11 @@ namespace Renci.SshNet
         /// to the drawable area of the window.
         /// </para>
         /// </remarks>
-        public ShellStream CreateShellStream(string terminalName, uint columns, uint rows, uint width, uint height, int bufferSize, IDictionary<TerminalModes, uint> terminalModeValues)
+        public ShellStream CreateShellStream(string terminalName, uint columns, uint rows, uint width, uint height, int bufferSize, IDictionary<TerminalModes, uint> terminalModeValues, EventHandler<EventArgs> starting = null, EventHandler<EventArgs> stopping = null)
         {
             EnsureSessionIsOpen();
 
-            return ServiceFactory.CreateShellStream(Session, terminalName, columns, rows, width, height, terminalModeValues, bufferSize);
+            return ServiceFactory.CreateShellStream(Session, terminalName, columns, rows, width, height, terminalModeValues, bufferSize, starting, stopping);
         }
 
         /// <summary>


### PR DESCRIPTION
The ShellStream on channel close disposes of itself instead of leaving the task to the owner of the object.

Requires Starting and Stopping semantics same as for underlying shell. 

Full Bug fix for #44

