### PR TITLE
Use License Expression for NuGet Package

### DIFF
--- a/build/nuget/SSH.NET.nuspec
+++ b/build/nuget/SSH.NET.nuspec
@@ -6,7 +6,7 @@
         <title>SSH.NET</title>
         <authors>Renci</authors>
         <owners>olegkap,drieseng</owners>
-        <licenseUrl>https://github.com/sshnet/SSH.NET/blob/master/LICENSE</licenseUrl>
+        <license type="expression">MIT</license>
         <projectUrl>https://github.com/sshnet/SSH.NET/</projectUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>SSH.NET is a Secure Shell (SSH) library for .NET, optimized for parallelism and with broad framework support.</description>


### PR DESCRIPTION
licenseUrl is deprecated, see https://github.com/NuGet/Announcements/issues/32