### PR TITLE
Enable C# 11, System.Span, and utilize UTF-8 literals

### DIFF
--- a/src/Renci.SshNet.Tests/Classes/Connection/ProtocolVersionExchangeTest_ServerResponseInvalid_SshIdentificationOnlyContainsProtocolVersion.cs
+++ b/src/Renci.SshNet.Tests/Classes/Connection/ProtocolVersionExchangeTest_ServerResponseInvalid_SshIdentificationOnlyContainsProtocolVersion.cs
@@ -58,7 +58,7 @@ namespace Renci.SshNet.Tests.Classes.Connection
             _timeout = TimeSpan.FromSeconds(5);
             _serverEndPoint = new IPEndPoint(IPAddress.Loopback, 8122);
             _dataReceivedByServer = new List<byte>();
-            _serverIdentification = Encoding.UTF8.GetBytes("SSH-2.0\r\n");
+            _serverIdentification = "SSH-2.0\r\n"u8.ToArray();
 
             _server = new AsyncSocketListener(_serverEndPoint);
             _server.Start();

--- a/src/Renci.SshNet.Tests/Renci.SshNet.Tests.csproj
+++ b/src/Renci.SshNet.Tests/Renci.SshNet.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net462;net6.0;net7.0</TargetFrameworks>
+    <LangVersion>11</LangVersion>
     <!--
           Even though we're not interested in producing XML docs for test projects, we have to enable this in order to have the .NET Compiler
           Platform analyzers produce the IDE0005 (Remove unnecessary import) diagnostic.

--- a/src/Renci.SshNet/PrivateKeyFile.cs
+++ b/src/Renci.SshNet/PrivateKeyFile.cs
@@ -405,9 +405,9 @@ namespace Renci.SshNet
             var keyReader = new SshDataReader(keyFileData);
 
             // check magic header
-            var authMagic = Encoding.UTF8.GetBytes("openssh-key-v1\0");
+            var authMagic = "openssh-key-v1\0"u8;
             var keyHeaderBytes = keyReader.ReadBytes(authMagic.Length);
-            if (!authMagic.IsEqualTo(keyHeaderBytes))
+            if (!authMagic.SequenceEqual(keyHeaderBytes))
             {
                 throw new SshException("This openssh key does not contain the 'openssh-key-v1' format magic header");
             }

--- a/src/Renci.SshNet/Renci.SshNet.csproj
+++ b/src/Renci.SshNet/Renci.SshNet.csproj
@@ -3,6 +3,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>Renci.SshNet</AssemblyName>
     <TargetFrameworks>net462;netstandard2.0;net6.0;net7.0</TargetFrameworks>
+    <LangVersion>11</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">
@@ -11,6 +12,10 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0' ">
     <PackageReference Include="SshNet.Security.Cryptography" Version="[1.3.0]" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0' ">

--- a/src/Renci.SshNet/Renci.SshNet.csproj
+++ b/src/Renci.SshNet/Renci.SshNet.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="SshNet.Security.Cryptography" Version="[1.3.0]" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net462' ">
     <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>
 

--- a/src/Renci.SshNet/Security/Cryptography/EcdsaKey.cs
+++ b/src/Renci.SshNet/Security/Cryptography/EcdsaKey.cs
@@ -148,7 +148,7 @@ namespace Renci.SshNet.Security
         {
             get
             {
-                byte[] curve;
+                ReadOnlySpan<byte> curve;
                 byte[] qx;
                 byte[] qy;
 #if NETFRAMEWORK
@@ -167,16 +167,16 @@ namespace Renci.SshNet.Security
                 switch (magic)
                 {
                     case KeyBlobMagicNumber.BCRYPT_ECDSA_PUBLIC_P256_MAGIC:
-                        curve = Encoding.ASCII.GetBytes("nistp256");
+                        curve = "nistp256"u8;
                         break;
                     case KeyBlobMagicNumber.BCRYPT_ECDSA_PUBLIC_P384_MAGIC:
-                        curve = Encoding.ASCII.GetBytes("nistp384");
+                        curve = "nistp384"u8;
                         break;
                     case KeyBlobMagicNumber.BCRYPT_ECDSA_PUBLIC_P521_MAGIC:
-                        curve = Encoding.ASCII.GetBytes("nistp521");
+                        curve = "nistp521"u8;
                         break;
                     default:
-                        throw new SshException("Unexpected Curve Magic: " + magic);
+                        throw new SshException($"Unexpected Curve Magic: {magic}");
                 }
 #pragma warning restore IDE0010 // Add missing cases
 #else
@@ -187,15 +187,15 @@ namespace Renci.SshNet.Security
                 {
                     case "ECDSA_P256":
                     case "nistP256":
-                        curve = Encoding.ASCII.GetBytes("nistp256");
+                        curve = "nistp256"u8;
                         break;
                     case "ECDSA_P384":
                     case "nistP384":
-                        curve = Encoding.ASCII.GetBytes("nistp384");
+                        curve = "nistp384"u8;
                         break;
                     case "ECDSA_P521":
                     case "nistP521":
-                        curve = Encoding.ASCII.GetBytes("nistp521");
+                        curve = "nistp521"u8;
                         break;
                     default:
                         throw new SshException("Unexpected Curve Name: " + parameter.Curve.Oid.FriendlyName);
@@ -210,7 +210,7 @@ namespace Renci.SshNet.Security
                 Buffer.BlockCopy(qy, 0, q, qx.Length + 1, qy.Length);
 
                 // returns Curve-Name and x/y as ECPoint
-                return new[] { new BigInteger(curve.Reverse()), new BigInteger(q.Reverse()) };
+                return new[] { new BigInteger(curve.ToArray().Reverse()), new BigInteger(q.Reverse()) };
             }
             set
             {


### PR DESCRIPTION
This PR enables the use of C# 11 and support for Span<T> within the library.