### PR TITLE
Enable getting and deleting symbolic links

### DIFF
--- a/src/Renci.SshNet/ISftpClient.cs
+++ b/src/Renci.SshNet/ISftpClient.cs
@@ -492,6 +492,18 @@ namespace Renci.SshNet
         void DeleteFile(string path);
 
         /// <summary>
+        /// Deletes remote symbolic link specified by path.
+        /// </summary>
+        /// <param name="path">File to be deleted path.</param>
+        /// <exception cref="ArgumentException"><paramref name="path"/> is <b>null</b> or contains only whitespace characters.</exception>
+        /// <exception cref="SshConnectionException">Client is not connected.</exception>
+        /// <exception cref="SftpPathNotFoundException"><paramref name="path"/> was not found on the remote host.</exception>
+        /// <exception cref="SftpPermissionDeniedException">Permission to delete the file was denied by the remote host. <para>-or-</para> A SSH command was denied by the server.</exception>
+        /// <exception cref="SshException">A SSH error where <see cref="Exception.Message"/> is the message from the remote host.</exception>
+        /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
+        void DeleteSymbolicLink(string path);
+
+        /// <summary>
         /// Asynchronously deletes remote file specified by path.
         /// </summary>
         /// <param name="path">File to be deleted path.</param>
@@ -581,6 +593,20 @@ namespace Renci.SshNet
         bool Exists(string path);
 
         /// <summary>
+        /// Checks whether symbolic link exists;
+        /// </summary>
+        /// <param name="path">The path.</param>
+        /// <returns>
+        /// <c>true</c> if directory or file exists; otherwise <c>false</c>.
+        /// </returns>
+        /// <exception cref="ArgumentException"><paramref name="path"/> is <b>null</b> or contains only whitespace characters.</exception>
+        /// <exception cref="SshConnectionException">Client is not connected.</exception>
+        /// <exception cref="SftpPermissionDeniedException">Permission to perform the operation was denied by the remote host. <para>-or-</para> A SSH command was denied by the server.</exception>
+        /// <exception cref="SshException">A SSH error where <see cref="Exception.Message"/> is the message from the remote host.</exception>
+        /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
+        bool SymbolicLinkExists(string path);
+
+        /// <summary>
         /// Gets reference to remote file or directory.
         /// </summary>
         /// <param name="path">The path.</param>
@@ -592,6 +618,19 @@ namespace Renci.SshNet
         /// <exception cref="ArgumentNullException"><paramref name="path" /> is <b>null</b>.</exception>
         /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
         ISftpFile Get(string path);
+
+        /// <summary>
+        /// Gets reference to remote symbolic link.
+        /// </summary>
+        /// <param name="path">The path.</param>
+        /// <returns>
+        /// A reference to <see cref="ISftpFile"/> file object.
+        /// </returns>
+        /// <exception cref="SshConnectionException">Client is not connected.</exception>
+        /// <exception cref="SftpPathNotFoundException"><paramref name="path"/> was not found on the remote host.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="path" /> is <b>null</b>.</exception>
+        /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
+        ISftpFile GetSymbolicLink(string path);
 
         /// <summary>
         /// Gets the <see cref="SftpFileAttributes"/> of the file on the path.

--- a/src/Renci.SshNet/Sftp/ISftpSession.cs
+++ b/src/Renci.SshNet/Sftp/ISftpSession.cs
@@ -35,10 +35,11 @@ namespace Renci.SshNet.Sftp
         /// Resolves a given path into an absolute path on the server.
         /// </summary>
         /// <param name="path">The path to resolve.</param>
+        /// <param name="getRealPath">Boolean determining whether to get the ral path.</param>
         /// <returns>
         /// The absolute path.
         /// </returns>
-        string GetCanonicalPath(string path);
+        string GetCanonicalPath(string path, bool getRealPath = true);
 
         Task<string> GetCanonicalPathAsync(string path, CancellationToken cancellationToken);
 

--- a/src/Renci.SshNet/Sftp/SftpSession.cs
+++ b/src/Renci.SshNet/Sftp/SftpSession.cs
@@ -159,7 +159,6 @@ namespace Renci.SshNet.Sftp
         public async Task<string> GetCanonicalPathAsync(string path, CancellationToken cancellationToken)
         {
             var fullPath = GetFullRemotePath(path);
-
             var canonizedPath = string.Empty;
             var realPathFiles = await RequestRealPathAsync(fullPath, nullOnError: true, cancellationToken).ConfigureAwait(false);
             if (realPathFiles != null)

--- a/src/Renci.SshNet/Sftp/SftpSession.cs
+++ b/src/Renci.SshNet/Sftp/SftpSession.cs
@@ -89,12 +89,19 @@ namespace Renci.SshNet.Sftp
         /// Resolves a given path into an absolute path on the server.
         /// </summary>
         /// <param name="path">The path to resolve.</param>
+        /// <param name="getRealPath">Boolean determining whether to get the real path.</param>
         /// <returns>
         /// The absolute path.
         /// </returns>
-        public string GetCanonicalPath(string path)
+        public string GetCanonicalPath(string path, bool getRealPath = true)
         {
             var fullPath = GetFullRemotePath(path);
+
+            if (!getRealPath)
+            {
+                // getRealPath set to false allows us to get a reference to the symbolic link itself and not to the file it points to.
+                return fullPath;
+            }
 
             var canonizedPath = string.Empty;
 


### PR DESCRIPTION
The current functions in the `SftpClient `class don’t support interacting with symbolic links directly. By adding an additional parameter, `getRealPath`, to the `GetCanonicalPath `function, we can get a reference to the symbolic link instead of a reference to the file that it points to. The default value for this parameter is set to `true `so that the original behavior is maintained for existing code. 

The added functions `GetSymbolicLink`, `SymbolicLinkExists`, and `DeleteSymbolicLink` use `GetCanonicalPath `with `getRealPath `set to `false `to get and delete symbolic links.