### PR TITLE
Add MD5FingerPrint + SHA256FingerPrint properties on HostKeyEventArgs

### DIFF
--- a/src/Renci.SshNet/Common/HostKeyEventArgs.cs
+++ b/src/Renci.SshNet/Common/HostKeyEventArgs.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Globalization;
+using System.Linq;
 using Renci.SshNet.Abstractions;
 using Renci.SshNet.Security;
 
@@ -28,9 +30,23 @@ namespace Renci.SshNet.Common
         public string HostKeyName{ get; private set; }
 
         /// <summary>
-        /// Gets the finger print.
+        /// Gets the MD5 fingerprint of the host key.
         /// </summary>
         public byte[] FingerPrint { get; private set; }
+
+        /// <summary>
+        /// Gets the MD5 fingerprint of the host key in the same format as the ssh command,
+        /// i.e. hexadecimal bytes seperated by colons, but without the <c>MD5:</c> prefix.
+        /// </summary>
+        /// <example><c>97:70:33:82:fd:29:3a:73:39:af:6a:07:ad:f8:80:49</c></example>
+        public string MD5FingerPrint { get; private set; }
+
+        /// <summary>
+        /// Gets the SHA256 fingerprint of the host key in the same format as the ssh command,
+        /// i.e. non-padded base64, but without the <c>SHA256:</c> prefix.
+        /// </summary>
+        /// <example><c>ohD8VZEXGWo6Ez8GSEJQ9WpafgLFsOfLOtGGQCQo6Og</c></example>
+        public string SHA256FingerPrint { get; private set; }
 
         /// <summary>
         /// Gets the length of the key in bits.
@@ -54,6 +70,11 @@ namespace Renci.SshNet.Common
             using (var md5 = CryptoAbstraction.CreateMD5())
             {
                 FingerPrint = md5.ComputeHash(host.Data);
+                MD5FingerPrint = string.Join(":", FingerPrint.Select(e => e.ToString("x2", NumberFormatInfo.InvariantInfo)));
+            }
+            using (var sha256 = CryptoAbstraction.CreateSHA256())
+            {
+                SHA256FingerPrint = Convert.ToBase64String(sha256.ComputeHash(host.Data)).TrimEnd('=');
             }
         }
     }


### PR DESCRIPTION
To be aligned with how fingerprints are usually displayed. By the ssh command but also by Azure DevOps, GitHub, etc.