### PR TITLE
Rebased AsyncResult fix

### DIFF
--- a/test/Renci.SshNet.IntegrationTests/OldIntegrationTests/SftpClientTest.Upload.cs
+++ b/test/Renci.SshNet.IntegrationTests/OldIntegrationTests/SftpClientTest.Upload.cs
@@ -230,15 +230,7 @@ namespace Renci.SshNet.IntegrationTests.OldIntegrationTests
                 sftp.Disconnect();
 
                 Assert.IsTrue(hashMatches, "Hash does not match");
-                if (!uploadDownloadSizeOk)
-                {
-                    // TODO https://github.com/sshnet/SSH.NET/issues/1253
-                    Assert.Inconclusive("Uploaded and downloaded bytes should match, but test is not stable");
-                }
-                else
-                {
-                    Assert.IsTrue(uploadDownloadSizeOk, "Uploaded and downloaded bytes does not match");
-                }
+                Assert.IsTrue(uploadDownloadSizeOk, "Uploaded and downloaded bytes does not match");
             }
         }
 


### PR DESCRIPTION
This is #680 by @miroslavpokorny brought up to date.

I have been seeing occasional failures of the `Test_Sftp_Multiple_Async_Upload_And_Download_10Files_5MB_Each` test.

When choosing "Run until failure" in Visual Studio, the test failed after 20, 9, 45, 32 and 10 attempts. With this change, it ran successfully over 300 times before I stopped it.

Fixes #329 

Side note: I'm not really sure why these Begin/End methods have an extra "callback" parameter as well as an `AsyncCallback` parameter, but I'm hoping we can just get rid of these methods soon anyway, or at least have them [wrap](https://github.com/dotnet/runtime/blob/main/src/libraries/Common/src/System/Threading/Tasks/TaskToAsyncResult.cs) a task based implementation
