### PR TITLE
Improve tests for (Get|Set)LastAccessTime(Utc)

### DIFF
--- a/src/Renci.SshNet.IntegrationTests/Common/DateTimeAssert.cs
+++ b/src/Renci.SshNet.IntegrationTests/Common/DateTimeAssert.cs
@@ -1,0 +1,11 @@
+﻿namespace Renci.SshNet.IntegrationTests.Common
+{
+    public static class DateTimeAssert
+    {
+        public static void AreEqual(DateTime expected, DateTime actual)
+        {
+            Assert.AreEqual(expected, actual, $"Expected {expected:o}, but was {actual:o}.");
+            Assert.AreEqual(expected.Kind, actual.Kind);
+        }
+    }
+}

--- a/src/Renci.SshNet.IntegrationTests/Common/DateTimeExtensions.cs
+++ b/src/Renci.SshNet.IntegrationTests/Common/DateTimeExtensions.cs
@@ -1,0 +1,12 @@
+﻿namespace Renci.SshNet.IntegrationTests.Common
+{
+    public static class DateTimeExtensions
+    {
+        public static DateTime TruncateToWholeSeconds(this DateTime dateTime)
+        {
+            return dateTime.AddMilliseconds(-dateTime.Millisecond)
+                           .AddMicroseconds(-dateTime.Microsecond)
+                           .AddTicks(-(dateTime.Nanosecond / 100));
+        }
+    }
+}

--- a/src/Renci.SshNet.IntegrationTests/SftpTests.cs
+++ b/src/Renci.SshNet.IntegrationTests/SftpTests.cs
@@ -6153,15 +6153,15 @@ namespace Renci.SshNet.IntegrationTests
             try
             {
                 var time = client.GetLastAccessTime(testFilePath);
-                Assert.AreEqual(currentTime.Year, time.Year);
-                Assert.AreEqual(currentTime.Month, time.Month);
-                Assert.AreEqual(currentTime.Day, time.Day);
 
-                var newTime = new DateTime(1986, 03, 15, 01, 02, 03);
+                DateTimeAssert.AreEqual(currentTime.TruncateToWholeSeconds(), time);
+
+                var newTime = new DateTime(1986, 03, 15, 01, 02, 03, 123, DateTimeKind.Local);
 
                 client.SetLastAccessTime(testFilePath, newTime);
                 time = client.GetLastAccessTime(testFilePath);
-                Assert.AreEqual(newTime, time);
+
+                DateTimeAssert.AreEqual(newTime.TruncateToWholeSeconds(), time);
             }
             finally
             {
@@ -6185,16 +6185,15 @@ namespace Renci.SshNet.IntegrationTests
             try
             {
                 var time = client.GetLastAccessTimeUtc(testFilePath);
-                Assert.AreEqual(currentTime.Year, time.Year);
-                Assert.AreEqual(currentTime.Month, time.Month);
-                Assert.AreEqual(currentTime.Day, time.Day);
 
-                var newTime = new DateTime(1986, 03, 15, 01, 02, 03);
-                DateTime.SpecifyKind(newTime, DateTimeKind.Utc);
+                DateTimeAssert.AreEqual(currentTime.TruncateToWholeSeconds(), time);
+
+                var newTime = new DateTime(1986, 03, 15, 01, 02, 03, 123, DateTimeKind.Utc);
 
                 client.SetLastAccessTimeUtc(testFilePath, newTime);
                 time = client.GetLastAccessTimeUtc(testFilePath);
-                Assert.AreEqual(newTime, time);
+
+                DateTimeAssert.AreEqual(newTime.TruncateToWholeSeconds(), time);
             }
             finally
             {
@@ -6217,15 +6216,15 @@ namespace Renci.SshNet.IntegrationTests
             try
             {
                 var time = client.GetLastWriteTime(testFilePath);
-                Assert.AreEqual(currentTime.Year, time.Year);
-                Assert.AreEqual(currentTime.Month, time.Month);
-                Assert.AreEqual(currentTime.Day, time.Day);
 
-                var newTime = new DateTime(1986, 03, 15, 01, 02, 03);
+                DateTimeAssert.AreEqual(currentTime.TruncateToWholeSeconds(), time);
+
+                var newTime = new DateTime(1986, 03, 15, 01, 02, 03, 123, DateTimeKind.Local);
 
                 client.SetLastWriteTime(testFilePath, newTime);
                 time = client.GetLastWriteTime(testFilePath);
-                Assert.AreEqual(newTime, time);
+
+                DateTimeAssert.AreEqual(newTime.TruncateToWholeSeconds(), time);
             }
             finally
             {
@@ -6248,16 +6247,15 @@ namespace Renci.SshNet.IntegrationTests
             try
             {
                 var time = client.GetLastWriteTimeUtc(testFilePath);
-                Assert.AreEqual(currentTime.Year, time.Year);
-                Assert.AreEqual(currentTime.Month, time.Month);
-                Assert.AreEqual(currentTime.Day, time.Day);
 
-                var newTime = new DateTime(1986, 03, 15, 01, 02, 03);
-                DateTime.SpecifyKind(newTime, DateTimeKind.Utc);
+                DateTimeAssert.AreEqual(currentTime.TruncateToWholeSeconds(), time);
+
+                var newTime = new DateTime(1986, 03, 15, 01, 02, 03, 123, DateTimeKind.Utc);
 
                 client.SetLastWriteTimeUtc(testFilePath, newTime);
                 time = client.GetLastWriteTimeUtc(testFilePath);
-                Assert.AreEqual(newTime, time);
+
+                DateTimeAssert.AreEqual(newTime.TruncateToWholeSeconds(), time);
             }
             finally
             {

--- a/src/Renci.SshNet.sln
+++ b/src/Renci.SshNet.sln
@@ -48,6 +48,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Renci.SshNet.IntegrationTes
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Renci.SshNet.TestTools.OpenSSH", "Renci.SshNet.TestTools.OpenSSH\Renci.SshNet.TestTools.OpenSSH.csproj", "{78239046-2019-494E-B6EC-240AF787E4D0}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E8A42832-1183-4E66-9141-DEBA662374DF}"
+	ProjectSection(SolutionItems) = preProject
+		global.json = global.json
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -158,6 +163,7 @@ Global
 		{94EE3919-19FA-4D9B-8DA9-249050B15232} = {2D6CAE62-D053-476F-9BDD-2B1F27FA9C5D}
 		{A6C3FFD3-16A5-44D3-8C1F-3613D6DD17D1} = {2D6CAE62-D053-476F-9BDD-2B1F27FA9C5D}
 		{D21A4D03-0AC2-4613-BB6D-74D2D16A72CC} = {04E8CC26-116E-4116-9558-7ED542548E70}
+		{E8A42832-1183-4E66-9141-DEBA662374DF} = {04E8CC26-116E-4116-9558-7ED542548E70}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BAD6019D-4AF7-4E15-99A0-8036E16FC0E5}


### PR DESCRIPTION
Update tests for `GetLastAccessTime(Utc)` and `SetLastAccessTime(Utc)` to also verify the time component and the **Kind** of the **DateTime** value returned by ` GetLastAccessTime(Utc)`.