### PR TITLE
Reduces heap allocations for the some byte[] uses

### DIFF
--- a/src/Renci.SshNet/Common/SshData.cs
+++ b/src/Renci.SshNet/Common/SshData.cs
@@ -221,7 +221,7 @@ namespace Renci.SshNet.Common
         /// <exception cref="InvalidOperationException">Attempt to read past the end of the stream.</exception>
         protected uint ReadUInt32()
         {
-            return Pack.BigEndianToUInt32(ReadBytes(4));
+            return _stream.ReadUInt32();
         }
 
         /// <summary>
@@ -233,7 +233,7 @@ namespace Renci.SshNet.Common
         /// <exception cref="InvalidOperationException">Attempt to read past the end of the stream.</exception>
         protected ulong ReadUInt64()
         {
-            return Pack.BigEndianToUInt64(ReadBytes(8));
+            return _stream.ReadUInt64();
         }
 
         /// <summary>

--- a/src/Renci.SshNet/Common/SshDataStream.cs
+++ b/src/Renci.SshNet/Common/SshDataStream.cs
@@ -188,8 +188,14 @@ namespace Renci.SshNet.Common
         /// </returns>
         public uint ReadUInt32()
         {
+#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+            Span<byte> span = stackalloc byte[4];
+            ReadBytes(span);
+            return System.Buffers.Binary.BinaryPrimitives.ReadUInt32BigEndian(span);
+#else
             var data = ReadBytes(4);
             return Pack.BigEndianToUInt32(data);
+#endif // NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
         }
 
         /// <summary>
@@ -200,8 +206,14 @@ namespace Renci.SshNet.Common
         /// </returns>
         public ulong ReadUInt64()
         {
+#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+            Span<byte> span = stackalloc byte[8];
+            ReadBytes(span);
+            return System.Buffers.Binary.BinaryPrimitives.ReadUInt64BigEndian(span);
+#else
             var data = ReadBytes(8);
             return Pack.BigEndianToUInt64(data);
+#endif // NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
         }
 
         /// <summary>
@@ -264,5 +276,21 @@ namespace Renci.SshNet.Common
 
             return data;
         }
+
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
+        /// <summary>
+        /// Reads data into the specified <paramref name="buffer" />.
+        /// </summary>
+        /// <param name="buffer">The buffer to read into.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="buffer"/> is larger than the total of bytes available.</exception>
+        private void ReadBytes(Span<byte> buffer)
+        {
+            var bytesRead = Read(buffer);
+            if (bytesRead < buffer.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(buffer), string.Format(CultureInfo.InvariantCulture, "The requested length ({0}) is greater than the actual number of bytes read ({1}).", buffer.Length, bytesRead));
+            }
+        }
+#endif // NETSTANDARD2_1 || NET6_0_OR_GREATER
     }
 }


### PR DESCRIPTION
Profiling reveals that creation of `byte[4]` arrays are our most common heap objects. Many of these come from reading integers from the byte stream where we allocate a small `byte[4]` or `byte[8]` array and then convert it to a 32 or 64-bit integer. 

Results from a simple test of using the `SftpClient` to upload and download some files:

**Before: when byte[] arrays were created for each integer read**
![Screenshot 2023-12-10 181955](https://github.com/sshnet/SSH.NET/assets/345183/f193f042-e72d-4ea2-b664-8835b11b2d92)

**After: when byte[] are allocated and read from the stack**
![Screenshot 2023-12-10 182136](https://github.com/sshnet/SSH.NET/assets/345183/fce41fee-9266-40ca-8ae8-d543c722b15f)

**Changes**
- Creates a new `SshDataStream.ReadBytes` overload that supports `Span<byte>` for .NET Standard 2.1+ and .NET 6+ targets.
- Updates `SshDataStream.ReadUInt32` and `SshDataStream.ReadUInt64` to read onto the stack and use newer `BinaryPrimitives` class for integer conversion for .NET Standard 2.1+ and .NET 6+ targets.
- Updates `SshData.ReadUInt32` and `SshData.ReadUInt64` to use the existing stream methods to avoid another temporary buffer.