### PR TITLE
Upgrade packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -34,9 +34,8 @@
         Use fixed version of analyzers.
     -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0-preview1.23165.1" PrivateAssets="all" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="all" />
     <PackageReference Include="Meziantou.Analyzer" Version="2.0.103" PrivateAssets="all" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.12.0.78982" PrivateAssets="all" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.16.0.82469" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/build/nuget/SSH.NET.nuspec
+++ b/build/nuget/SSH.NET.nuspec
@@ -17,10 +17,10 @@
         <tags>ssh scp sftp</tags>
         <dependencies>
           <group targetFramework="net462">
-            <dependency id="Microsoft.Bcl.AsyncInterfaces" version="[7.0.0]" />
+            <dependency id="Microsoft.Bcl.AsyncInterfaces" version="[8.0.0]" />
           </group>
           <group targetFramework="netstandard2.0">
-            <dependency id="Microsoft.Bcl.AsyncInterfaces" version="[7.0.0]" />
+            <dependency id="Microsoft.Bcl.AsyncInterfaces" version="[8.0.0]" />
             <dependency id="SshNet.Security.Cryptography" version="[1.3.0]" />
           </group>          
           <group targetFramework="netstandard2.1">

--- a/src/Renci.SshNet/Renci.SshNet.csproj
+++ b/src/Renci.SshNet/Renci.SshNet.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1' or '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0' or '$(TargetFramework)' == 'net8.0' ">

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -130,6 +130,11 @@ dotnet_diagnostic.CA1711.severity = none
 # We do not care about this for unit tests.
 dotnet_diagnostic.CA1720.severity = none
 
+# CA1861: Avoid constant arrays as arguments
+#
+# We do not care about this for unit tests.
+dotnet_diagnostic.CA1861.severity = none
+
 # CA5351: Do not use broken cryptographic algorithms
 #
 # We do not care about this for unit tests.

--- a/test/Renci.SshNet.IntegrationTests/HostConfig.cs
+++ b/test/Renci.SshNet.IntegrationTests/HostConfig.cs
@@ -29,7 +29,7 @@ namespace Renci.SshNet.IntegrationTests
                     while ((line = sr.ReadLine()) != null)
                     {
                         // skip comments
-                        if (line.StartsWith("#"))
+                        if (line.StartsWith('#'))
                         {
                             continue;
                         }


### PR DESCRIPTION
- Remove reference to [Microsoft.CodeAnalysis.NetAnalyzers](https://www.nuget.org/packages/Microsoft.CodeAnalysis.NetAnalyzers) (use the stable version by default)
- Upgrade [StyleCop.Analyzers](https://www.nuget.org/packages/StyleCop.Analyzers#versions-body-tab) to 1.2.0-beta.556 (fixes a collection expression whitespace issue - the motivation for this change)
- Upgrade [SonarAnalyzer.CSharp](https://www.nuget.org/packages/SonarAnalyzer.CSharp/#versions-body-tab) to 9.16.0.82469 (the release notes have some performance improvements 👍)
- Upgrade [Microsoft.Bcl.AsyncInterfaces](https://www.nuget.org/packages/Microsoft.Bcl.AsyncInterfaces) to 8.0.0 while we are here.

I did not upgrade [Meziantou.Analyzer](https://www.nuget.org/packages/Meziantou.Analyzer) because the release notes show some new analyzers so it probably needs more attention there.