### PR TITLE
Authenticate with ssh-rsa by default

### DIFF
--- a/src/Renci.SshNet/PrivateKeyFile.cs
+++ b/src/Renci.SshNet/PrivateKeyFile.cs
@@ -250,11 +250,11 @@ namespace Renci.SshNet
                 case "RSA":
                     var rsaKey = new RsaKey(decryptedData);
                     _key = rsaKey;
+                    _hostAlgorithms.Add(new KeyHostAlgorithm("ssh-rsa", _key));
 #pragma warning disable CA2000 // Dispose objects before losing scope
                     _hostAlgorithms.Add(new KeyHostAlgorithm("rsa-sha2-512", _key, new RsaDigitalSignature(rsaKey, HashAlgorithmName.SHA512)));
                     _hostAlgorithms.Add(new KeyHostAlgorithm("rsa-sha2-256", _key, new RsaDigitalSignature(rsaKey, HashAlgorithmName.SHA256)));
 #pragma warning restore CA2000 // Dispose objects before losing scope
-                    _hostAlgorithms.Add(new KeyHostAlgorithm("ssh-rsa", _key));
                     break;
                 case "DSA":
                     _key = new DsaKey(decryptedData);
@@ -268,11 +268,11 @@ namespace Renci.SshNet
                     _key = ParseOpenSshV1Key(decryptedData, passPhrase);
                     if (_key is RsaKey parsedRsaKey)
                     {
+                        _hostAlgorithms.Add(new KeyHostAlgorithm("ssh-rsa", _key));
 #pragma warning disable CA2000 // Dispose objects before losing scope
                         _hostAlgorithms.Add(new KeyHostAlgorithm("rsa-sha2-512", _key, new RsaDigitalSignature(parsedRsaKey, HashAlgorithmName.SHA512)));
                         _hostAlgorithms.Add(new KeyHostAlgorithm("rsa-sha2-256", _key, new RsaDigitalSignature(parsedRsaKey, HashAlgorithmName.SHA256)));
 #pragma warning restore CA2000 // Dispose objects before losing scope
-                        _hostAlgorithms.Add(new KeyHostAlgorithm("ssh-rsa", _key));
                     }
                     else
                     {
@@ -337,11 +337,11 @@ namespace Renci.SshNet
                         var p = reader.ReadBigIntWithBits(); // q
                         var decryptedRsaKey = new RsaKey(modulus, exponent, d, p, q, inverseQ);
                         _key = decryptedRsaKey;
+                        _hostAlgorithms.Add(new KeyHostAlgorithm("ssh-rsa", _key));
 #pragma warning disable CA2000 // Dispose objects before losing scope
                         _hostAlgorithms.Add(new KeyHostAlgorithm("rsa-sha2-512", _key, new RsaDigitalSignature(decryptedRsaKey, HashAlgorithmName.SHA512)));
                         _hostAlgorithms.Add(new KeyHostAlgorithm("rsa-sha2-256", _key, new RsaDigitalSignature(decryptedRsaKey, HashAlgorithmName.SHA256)));
 #pragma warning restore CA2000 // Dispose objects before losing scope
-                        _hostAlgorithms.Add(new KeyHostAlgorithm("ssh-rsa", _key));
                     }
                     else if (keyType == "dl-modp{sign{dsa-nist-sha1},dh{plain}}")
                     {

--- a/test/Renci.SshNet.Tests/Classes/Common/HostKeyEventArgsTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Common/HostKeyEventArgsTest.cs
@@ -88,7 +88,7 @@ namespace Renci.SshNet.Tests.Classes.Common
             using (var s = GetData("Key.RSA.txt"))
             {
                 var privateKey = new PrivateKeyFile(s);
-                return (KeyHostAlgorithm)privateKey.HostKeyAlgorithms.First();
+                return (KeyHostAlgorithm)privateKey.HostKeyAlgorithms.Single(x => x.Name == "rsa-sha2-512");
             }
         }
 

--- a/test/Renci.SshNet.Tests/Classes/PrivateKeyFileTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/PrivateKeyFileTest.cs
@@ -687,9 +687,11 @@ namespace Renci.SshNet.Tests.Classes
 
             var algorithms = rsaPrivateKeyFile.HostKeyAlgorithms.ToList();
 
-            Assert.AreEqual("rsa-sha2-512", algorithms[0].Name);
-            Assert.AreEqual("rsa-sha2-256", algorithms[1].Name);
-            Assert.AreEqual("ssh-rsa", algorithms[2].Name);
+            // ssh-rsa should be attempted first during authentication by default.
+            // See https://github.com/sshnet/SSH.NET/issues/1233#issuecomment-1871196405
+            Assert.AreEqual("ssh-rsa", algorithms[0].Name);
+            Assert.AreEqual("rsa-sha2-512", algorithms[1].Name);
+            Assert.AreEqual("rsa-sha2-256", algorithms[2].Name);
         }
     }
 }


### PR DESCRIPTION
... to appease servers which disconnect rather than send SSH_MSG_USERAUTH_FAILURE when they do not support sha2 signatures for client authentication (and who may or may not have otherwise sent the server-sig-algs extension which we do not currently implement).

It will still use a sha2 signature if the server does not allow ssh-rsa and sends SSH_MSG_USERAUTH_FAILURE. I would think a server which disables ssh-rsa would be more friendly/compliant than those which disconnect rather than sending SSH_MSG_USERAUTH_FAILURE (i.e. the risk of the opposite now happening, where a server disconnects on receiving ssh-rsa, is low - it is going back to the behaviour as before #1177).

See https://github.com/sshnet/SSH.NET/issues/1233#issuecomment-1871196405 for further discussion

Fixes #1233