### PR TITLE
Require Microsoft.Bcl.AsyncInterfaces >=1.0.0 instead of =8.0.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,6 @@
     <LangVersion>latest</LangVersion>
     <WarningLevel>9999</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
   </PropertyGroup>
 
   <!--

--- a/build/nuget/SSH.NET.nuspec
+++ b/build/nuget/SSH.NET.nuspec
@@ -17,10 +17,10 @@
         <tags>ssh scp sftp</tags>
         <dependencies>
           <group targetFramework="net462">
-            <dependency id="Microsoft.Bcl.AsyncInterfaces" version="[8.0.0]" />
+            <dependency id="Microsoft.Bcl.AsyncInterfaces" version="1.0.0" />
           </group>
           <group targetFramework="netstandard2.0">
-            <dependency id="Microsoft.Bcl.AsyncInterfaces" version="[8.0.0]" />
+            <dependency id="Microsoft.Bcl.AsyncInterfaces" version="1.0.0" />
             <dependency id="SshNet.Security.Cryptography" version="[1.3.0]" />
           </group>          
           <group targetFramework="netstandard2.1">

--- a/src/Renci.SshNet/Renci.SshNet.csproj
+++ b/src/Renci.SshNet/Renci.SshNet.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1' or '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0' or '$(TargetFramework)' == 'net8.0' ">


### PR DESCRIPTION
This technically fixes 2 different issues:
    - previously SSH.NET would require exactly(!) version 8.0.0, which would
      cause issues in the future if e.g. a project using SSH.NET would
      try to update to version 9.0.0. In this case the constraint on the
      exact version would cause NuGet to refuse to upgrade to 9.0.0 (#1287)
    - PowerShell Core seems to have problems with Version 8.0.0, therefore
      downgrade the requirement to 1.0.0 (see https://github.com/darkoperator/Posh-SSH/issues/558)

I had to re-enable AutoGenerateBindingRedirects, otherwise there is a
FileLoadException with net462 in one of the tests. I don't know why this
was disabled in 3ecbd1071d653bbf04254c08d14d7ce75d60688b .
