### PR TITLE
Tweak semaphore usage in Session

### DIFF
--- a/test/Renci.SshNet.IntegrationTests/OldIntegrationTests/SshCommandTest.cs
+++ b/test/Renci.SshNet.IntegrationTests/OldIntegrationTests/SshCommandTest.cs
@@ -443,46 +443,17 @@ namespace Renci.SshNet.IntegrationTests.OldIntegrationTests
         }
 
         [TestMethod]
-        public void Test_MultipleThread_Example_MultipleConnections()
-        {
-            try
-            {
-#region Example SshCommand RunCommand Parallel
-                Parallel.For(0, 100,
-                    () =>
-                    {
-                        var client = new SshClient(SshServerHostName, SshServerPort, User.UserName, User.Password);
-                        client.Connect();
-                        return client;
-                    },
-                    (int counter, ParallelLoopState pls, SshClient client) =>
-                    {
-                        var result = client.RunCommand("echo 123");
-                        Debug.WriteLine(string.Format("TestMultipleThreadMultipleConnections #{0}", counter));
-                        return client;
-                    },
-                    (SshClient client) =>
-                    {
-                        client.Disconnect();
-                        client.Dispose();
-                    }
-                );
-#endregion
-
-            }
-            catch (Exception exp)
-            {
-                Assert.Fail(exp.ToString());
-            }
-        }
-
-        [TestMethod]
         
         public void Test_MultipleThread_100_MultipleConnections()
         {
             try
             {
-                Parallel.For(0, 100,
+                var options = new ParallelOptions()
+                {
+                    MaxDegreeOfParallelism = 8
+                };
+
+                Parallel.For(0, 100, options,
                     () =>
                     {
                         var client = new SshClient(SshServerHostName, SshServerPort, User.UserName, User.Password);

--- a/test/Renci.SshNet.IntegrationTests/SftpTests.cs
+++ b/test/Renci.SshNet.IntegrationTests/SftpTests.cs
@@ -83,7 +83,7 @@ namespace Renci.SshNet.IntegrationTests
         public void Sftp_ConnectDisconnect_Parallel()
         {
             const int iterations = 10;
-            const int threads = 20;
+            const int threads = 5;
 
             var startEvent = new ManualResetEvent(false);
 


### PR DESCRIPTION
- Change _connectAndLazySemaphoreInitLock to a SemaphoreSlim and use it in ConnectAsync.
- Rename it to _connectLock and only use it for connecting. Replace its other usages (on SessionSemaphore and NextChannelNumber) with Interlocked operations.
- Remove AuthenticationConnection semaphore. This static member placed a process-wide limit on the number of connections an application can make. I agree with the argument in https://github.com/sshnet/SSH.NET/issues/409#issuecomment-457415542 (and in several other issues/PRs) that this should not be something that the library attempts to control.

The last change broke a few tests which do things like making 100 connections (exceeding OpenSSH MaxStartups value). I was tempted to delete these tests as I don't think they have much value, but instead I just limited their concurrency.

Best viewed with "Hide whitespace"