### PR TITLE
CI: remove install of net8.0 sdk on VS image

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,9 +33,6 @@ for:
     only:
       - image: Visual Studio 2022
 
-  install:
-    - ps: choco install dotnet-8.0-sdk --version=8.0.100
-
   before_build:
     - ps: mkdir artifacts -f
 


### PR DESCRIPTION
It is installed on the image now: https://www.appveyor.com/docs/windows-images-software/#net-framework