### PR TITLE
Add `Closed` event to `ShellStream`.

### DIFF
--- a/src/Renci.SshNet/ShellStream.cs
+++ b/src/Renci.SshNet/ShellStream.cs
@@ -45,6 +45,11 @@ namespace Renci.SshNet
         public event EventHandler<ExceptionEventArgs>? ErrorOccurred;
 
         /// <summary>
+        /// Occurs when the channel was closed.
+        /// </summary>
+        public event EventHandler<EventArgs>? Closed;
+
+        /// <summary>
         /// Gets a value indicating whether data is available on the <see cref="ShellStream"/> to be read.
         /// </summary>
         /// <value>
@@ -894,6 +899,7 @@ namespace Renci.SshNet
         private void Channel_Closed(object? sender, ChannelEventArgs e)
         {
             Dispose();
+            Closed?.Invoke(this, EventArgs.Empty);
         }
 
         private void Channel_DataReceived(object? sender, ChannelDataEventArgs e)

--- a/src/Renci.SshNet/ShellStream.cs
+++ b/src/Renci.SshNet/ShellStream.cs
@@ -8,6 +8,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Renci.SshNet.Abstractions;
 using Renci.SshNet.Channels;
 using Renci.SshNet.Common;
 
@@ -899,7 +900,12 @@ namespace Renci.SshNet
         private void Channel_Closed(object? sender, ChannelEventArgs e)
         {
             Dispose();
-            Closed?.Invoke(this, EventArgs.Empty);
+
+            if (Closed != null)
+            {
+                // Handle event on different thread
+                ThreadAbstraction.ExecuteThread(() => Closed?.Invoke(this, EventArgs.Empty));
+            }
         }
 
         private void Channel_DataReceived(object? sender, ChannelDataEventArgs e)


### PR DESCRIPTION
Lib consumer could hook to this event to detect if channel is closed by server **in time**.
Closes https://github.com/sshnet/SSH.NET/issues/44