### PR TITLE
Use latest .NET 8 SDK in Ubuntu build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ for:
       - image: Ubuntu2204
 
   install:
-    - sh: sudo apt-get update && sudo apt-get install -y dotnet-sdk-8.0=8.0.100-1
+    - sh: sudo apt-get update && sudo apt-get install -y dotnet-sdk-8.0
     
   before_build:
     - sh: mkdir artifacts -p

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,9 +10,6 @@ for:
   matrix:
     only:
       - image: Ubuntu2204
-
-  install:
-    - sh: sudo apt-get update && sudo apt-get install -y dotnet-sdk-8.0
     
   before_build:
     - sh: mkdir artifacts -p


### PR DESCRIPTION
Should fix build errors due to 8.0.100 deprecation: https://ci.appveyor.com/project/drieseng/ssh-net/build/job/w78f3klwhahrxwa7