### PR TITLE
Use BCL Timeout

### DIFF
--- a/src/Renci.SshNet/BaseClient.cs
+++ b/src/Renci.SshNet/BaseClient.cs
@@ -108,7 +108,7 @@ namespace Renci.SshNet
                     return;
                 }
 
-                if (value == SshNet.Session.InfiniteTimeSpan)
+                if (value == Timeout.InfiniteTimeSpan)
                 {
                     // stop the timer when the value is -1 milliseconds
                     StopKeepAliveTimer();
@@ -196,7 +196,7 @@ namespace Renci.SshNet
             ConnectionInfo = connectionInfo;
             _ownsConnectionInfo = ownsConnectionInfo;
             _serviceFactory = serviceFactory;
-            _keepAliveInterval = SshNet.Session.InfiniteTimeSpan;
+            _keepAliveInterval = Timeout.InfiniteTimeSpan;
         }
 
         /// <summary>
@@ -508,7 +508,7 @@ namespace Renci.SshNet
         /// </remarks>
         private void StartKeepAliveTimer()
         {
-            if (_keepAliveInterval == SshNet.Session.InfiniteTimeSpan)
+            if (_keepAliveInterval == Timeout.InfiniteTimeSpan)
             {
                 return;
             }

--- a/src/Renci.SshNet/Connection/ConnectorBase.cs
+++ b/src/Renci.SshNet/Connection/ConnectorBase.cs
@@ -103,7 +103,7 @@ namespace Renci.SshNet.Connection
         protected static byte SocketReadByte(Socket socket)
         {
             var buffer = new byte[1];
-            _ = SocketRead(socket, buffer, 0, 1, Session.InfiniteTimeSpan);
+            _ = SocketRead(socket, buffer, 0, 1, Timeout.InfiniteTimeSpan);
             return buffer[0];
         }
 
@@ -128,7 +128,7 @@ namespace Renci.SshNet.Connection
         /// <exception cref="SocketException">The read failed.</exception>
         protected static int SocketRead(Socket socket, byte[] buffer, int offset, int length)
         {
-            return SocketRead(socket, buffer, offset, length, Session.InfiniteTimeSpan);
+            return SocketRead(socket, buffer, offset, length, Timeout.InfiniteTimeSpan);
         }
 
         /// <summary>

--- a/src/Renci.SshNet/NetConfClient.cs
+++ b/src/Renci.SshNet/NetConfClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
+using System.Threading;
 using System.Xml;
 
 using Renci.SshNet.Common;
@@ -149,7 +150,7 @@ namespace Renci.SshNet
         internal NetConfClient(ConnectionInfo connectionInfo, bool ownsConnectionInfo, IServiceFactory serviceFactory)
             : base(connectionInfo, ownsConnectionInfo, serviceFactory)
         {
-            _operationTimeout = SshNet.Session.Infinite;
+            _operationTimeout = Timeout.Infinite;
             AutomaticMessageIdHandling = true;
         }
 

--- a/src/Renci.SshNet/ScpClient.cs
+++ b/src/Renci.SshNet/ScpClient.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Text.RegularExpressions;
+using System.Threading;
 
 using Renci.SshNet.Channels;
 using Renci.SshNet.Common;
@@ -211,7 +212,7 @@ namespace Renci.SshNet
         internal ScpClient(ConnectionInfo connectionInfo, bool ownsConnectionInfo, IServiceFactory serviceFactory)
             : base(connectionInfo, ownsConnectionInfo, serviceFactory)
         {
-            OperationTimeout = SshNet.Session.InfiniteTimeSpan;
+            OperationTimeout = Timeout.InfiniteTimeSpan;
             BufferSize = 1024 * 16;
             _remotePathTransformation = serviceFactory.CreateRemotePathDoubleQuoteTransformation();
         }

--- a/src/Renci.SshNet/Session.cs
+++ b/src/Renci.SshNet/Session.cs
@@ -31,14 +31,6 @@ namespace Renci.SshNet
         internal const byte LineFeed = 0x0a;
 
         /// <summary>
-        /// Specifies an infinite waiting period.
-        /// </summary>
-        /// <remarks>
-        /// The value of this field is <c>-1</c>.
-        /// </remarks>
-        internal const int Infinite = -1;
-
-        /// <summary>
         /// Specifies maximum packet size defined by the protocol.
         /// </summary>
         /// <value>
@@ -73,14 +65,6 @@ namespace Renci.SshNet
         /// </para>
         /// </remarks>
         private const int LocalChannelDataPacketSize = 1024 * 64;
-
-        /// <summary>
-        /// Specifies an infinite waiting period.
-        /// </summary>
-        /// <remarks>
-        /// The value of this field is <c>-1</c> millisecond.
-        /// </remarks>
-        internal static readonly TimeSpan InfiniteTimeSpan = new TimeSpan(0, 0, 0, 0, -1);
 
         /// <summary>
         /// Holds the factory to use for creating new services.
@@ -1895,7 +1879,7 @@ namespace Renci.SshNet
         /// <exception cref="SocketException">The read failed.</exception>
         private static int TrySocketRead(Socket socket, byte[] buffer, int offset, int length)
         {
-            return SocketAbstraction.Read(socket, buffer, offset, length, InfiniteTimeSpan);
+            return SocketAbstraction.Read(socket, buffer, offset, length, Timeout.InfiniteTimeSpan);
         }
 
         /// <summary>

--- a/src/Renci.SshNet/SftpClient.cs
+++ b/src/Renci.SshNet/SftpClient.cs
@@ -259,7 +259,7 @@ namespace Renci.SshNet
         internal SftpClient(ConnectionInfo connectionInfo, bool ownsConnectionInfo, IServiceFactory serviceFactory)
             : base(connectionInfo, ownsConnectionInfo, serviceFactory)
         {
-            _operationTimeout = SshNet.Session.Infinite;
+            _operationTimeout = Timeout.Infinite;
             _bufferSize = 1024 * 32;
         }
 

--- a/src/Renci.SshNet/SshCommand.cs
+++ b/src/Renci.SshNet/SshCommand.cs
@@ -184,7 +184,7 @@ namespace Renci.SshNet
             _session = session;
             CommandText = commandText;
             _encoding = encoding;
-            CommandTimeout = Session.InfiniteTimeSpan;
+            CommandTimeout = Timeout.InfiniteTimeSpan;
             _sessionErrorOccuredWaitHandle = new AutoResetEvent(initialState: false);
 
             _session.Disconnected += Session_Disconnected;

--- a/test/Renci.SshNet.Tests/Classes/BaseClientTest_Connected_KeepAlivesNotSentConcurrently.cs
+++ b/test/Renci.SshNet.Tests/Classes/BaseClientTest_Connected_KeepAlivesNotSentConcurrently.cs
@@ -70,7 +70,7 @@ namespace Renci.SshNet.Tests.Classes
             Thread.Sleep(200);
 
             // disable further keep-alives
-            _client.KeepAliveInterval = Session.InfiniteTimeSpan;
+            _client.KeepAliveInterval = Timeout.InfiniteTimeSpan;
 
             // wait until keep-alive has been sent at least once
             Assert.IsTrue(_keepAliveSent.WaitOne(500));

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelDirectTcpipTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelDirectTcpipTest.cs
@@ -66,7 +66,7 @@ namespace Renci.SshNet.Tests.Classes.Channels
                                                                                                           _remotePacketSize,
                                                                                                           _remoteChannelNumber))));
             _ = _sessionMock.Setup(p => p.WaitOnHandle(It.IsAny<EventWaitHandle>()))
-                            .Callback<WaitHandle>(p => p.WaitOne(Session.Infinite));
+                            .Callback<WaitHandle>(p => p.WaitOne());
 
             var localPortEndPoint = new IPEndPoint(IPAddress.Loopback, 8122);
             using (var localPortListener = new AsyncSocketListener(localPortEndPoint))
@@ -122,7 +122,7 @@ namespace Renci.SshNet.Tests.Classes.Channels
                                                                                                           _remotePacketSize,
                                                                                                           _remoteChannelNumber))));
             _ = _sessionMock.Setup(p => p.WaitOnHandle(It.IsAny<EventWaitHandle>()))
-                            .Callback<WaitHandle>(p => p.WaitOne(Session.Infinite));
+                            .Callback<WaitHandle>(p => p.WaitOne());
 
             var localPortEndPoint = new IPEndPoint(IPAddress.Loopback, 8122);
             using (var localPortListener = new AsyncSocketListener(localPortEndPoint))
@@ -183,7 +183,7 @@ namespace Renci.SshNet.Tests.Classes.Channels
                                                                                                           _remoteChannelNumber))));
             _ = _sessionMock.InSequence(sequence)
                             .Setup(p => p.WaitOnHandle(It.IsAny<EventWaitHandle>()))
-                            .Callback<WaitHandle>(p => p.WaitOne(Session.Infinite));
+                            .Callback<WaitHandle>(p => p.WaitOne());
             _ = _sessionMock.InSequence(sequence)
                             .Setup(p => p.IsConnected)
                             .Returns(true);

--- a/test/Renci.SshNet.Tests/Classes/Common/CountdownEventTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Common/CountdownEventTest.cs
@@ -89,7 +89,7 @@ namespace Renci.SshNet.Tests.Classes.Common
         public void Wait_TimeoutInfinite_ShouldBlockUntilCountdownEventIsSet()
         {
             var sleep = TimeSpan.FromMilliseconds(100);
-            var timeout = Session.InfiniteTimeSpan;
+            var timeout = Timeout.InfiniteTimeSpan;
 
             var countdownEvent = CreateCountdownEvent(1);
             var signalCount = 0;
@@ -205,7 +205,7 @@ namespace Renci.SshNet.Tests.Classes.Common
             Assert.IsFalse(countdownEvent.IsSet);
             Assert.IsFalse(countdownEvent.WaitHandle.WaitOne(0));
 
-            _ = countdownEvent.Wait(Session.InfiniteTimeSpan);
+            _ = countdownEvent.Wait(Timeout.InfiniteTimeSpan);
             countdownEvent.Dispose();
         }
 
@@ -225,7 +225,7 @@ namespace Renci.SshNet.Tests.Classes.Common
         public void WaitHandle_WaitOne_TimeoutInfinite_ShouldBlockUntilCountdownEventIsSet()
         {
             var sleep = TimeSpan.FromMilliseconds(100);
-            var timeout = Session.InfiniteTimeSpan;
+            var timeout = Timeout.InfiniteTimeSpan;
 
             var countdownEvent = CreateCountdownEvent(1);
             var signalCount = 0;
@@ -341,7 +341,7 @@ namespace Renci.SshNet.Tests.Classes.Common
             Assert.IsFalse(countdownEvent.IsSet);
             Assert.IsFalse(countdownEvent.WaitHandle.WaitOne(0));
 
-            _ = countdownEvent.Wait(Session.InfiniteTimeSpan);
+            _ = countdownEvent.Wait(Timeout.InfiniteTimeSpan);
             countdownEvent.Dispose();
         }
 

--- a/test/Renci.SshNet.Tests/Classes/SessionTest_ConnectToServerFails.cs
+++ b/test/Renci.SshNet.Tests/Classes/SessionTest_ConnectToServerFails.cs
@@ -155,7 +155,7 @@ namespace Renci.SshNet.Tests.Classes
             var session = (ISession)_session;
             var waitHandle = new ManualResetEvent(false);
 
-            var result = session.TryWait(waitHandle, Session.InfiniteTimeSpan);
+            var result = session.TryWait(waitHandle, Timeout.InfiniteTimeSpan);
 
             Assert.AreEqual(WaitResult.Disconnected, result);
         }
@@ -166,7 +166,7 @@ namespace Renci.SshNet.Tests.Classes
             var session = (ISession)_session;
             var waitHandle = new ManualResetEvent(false);
 
-            var result = session.TryWait(waitHandle, Session.InfiniteTimeSpan, out var exception);
+            var result = session.TryWait(waitHandle, Timeout.InfiniteTimeSpan, out var exception);
 
             Assert.AreEqual(WaitResult.Disconnected, result);
             Assert.IsNull(exception);
@@ -242,7 +242,7 @@ namespace Renci.SshNet.Tests.Classes
 
             try
             {
-                session.WaitOnHandle(waitHandle, Session.InfiniteTimeSpan);
+                session.WaitOnHandle(waitHandle, Timeout.InfiniteTimeSpan);
                 Assert.Fail();
             }
             catch (ArgumentNullException ex)

--- a/test/Renci.SshNet.Tests/Classes/SessionTest_Connected.cs
+++ b/test/Renci.SshNet.Tests/Classes/SessionTest_Connected.cs
@@ -203,7 +203,7 @@ namespace Renci.SshNet.Tests.Classes
 
             try
             {
-                _ = session.TryWait(waitHandle, Session.InfiniteTimeSpan);
+                _ = session.TryWait(waitHandle, Timeout.InfiniteTimeSpan);
                 Assert.Fail();
             }
             catch (ArgumentNullException ex)
@@ -246,7 +246,7 @@ namespace Renci.SshNet.Tests.Classes
 
             try
             {
-                session.TryWait(waitHandle, Session.InfiniteTimeSpan, out exception);
+                session.TryWait(waitHandle, Timeout.InfiniteTimeSpan, out exception);
                 Assert.Fail();
             }
             catch (ArgumentNullException ex)

--- a/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ConnectionReset.cs
+++ b/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ConnectionReset.cs
@@ -160,7 +160,7 @@ namespace Renci.SshNet.Tests.Classes
 
             try
             {
-                session.WaitOnHandle(waitHandle, Session.InfiniteTimeSpan);
+                session.WaitOnHandle(waitHandle, Timeout.InfiniteTimeSpan);
                 Assert.Fail();
             }
             catch (SshConnectionException ex)
@@ -177,7 +177,7 @@ namespace Renci.SshNet.Tests.Classes
             var session = (ISession) Session;
             var waitHandle = new ManualResetEvent(false);
 
-            var result = session.TryWait(waitHandle, Session.InfiniteTimeSpan);
+            var result = session.TryWait(waitHandle, Timeout.InfiniteTimeSpan);
 
             Assert.AreEqual(WaitResult.Disconnected, result);
         }
@@ -188,7 +188,7 @@ namespace Renci.SshNet.Tests.Classes
             var session = (ISession) Session;
             var waitHandle = new ManualResetEvent(false);
 
-            var result = session.TryWait(waitHandle, Session.InfiniteTimeSpan, out var exception);
+            var result = session.TryWait(waitHandle, Timeout.InfiniteTimeSpan, out var exception);
 
             Assert.AreEqual(WaitResult.Disconnected, result);
             Assert.IsNull(exception);

--- a/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_Disconnect.cs
+++ b/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_Disconnect.cs
@@ -156,7 +156,7 @@ namespace Renci.SshNet.Tests.Classes
 
             try
             {
-                session.WaitOnHandle(waitHandle, Session.InfiniteTimeSpan);
+                session.WaitOnHandle(waitHandle, Timeout.InfiniteTimeSpan);
                 Assert.Fail();
             }
             catch (SshConnectionException ex)
@@ -173,7 +173,7 @@ namespace Renci.SshNet.Tests.Classes
             var session = (ISession) Session;
             var waitHandle = new ManualResetEvent(false);
 
-            var result = session.TryWait(waitHandle, Session.InfiniteTimeSpan);
+            var result = session.TryWait(waitHandle, Timeout.InfiniteTimeSpan);
 
             Assert.AreEqual(WaitResult.Disconnected, result);
         }
@@ -184,7 +184,7 @@ namespace Renci.SshNet.Tests.Classes
             var session = (ISession) Session;
             var waitHandle = new ManualResetEvent(false);
 
-            var result = session.TryWait(waitHandle, Session.InfiniteTimeSpan, out var exception);
+            var result = session.TryWait(waitHandle, Timeout.InfiniteTimeSpan, out var exception);
 
             Assert.AreEqual(WaitResult.Disconnected, result);
             Assert.IsNull(exception);

--- a/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ServerSendsBadPacket.cs
+++ b/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ServerSendsBadPacket.cs
@@ -180,7 +180,7 @@ namespace Renci.SshNet.Tests.Classes
 
             try
             {
-                session.WaitOnHandle(waitHandle, Session.InfiniteTimeSpan);
+                session.WaitOnHandle(waitHandle, Timeout.InfiniteTimeSpan);
                 Assert.Fail();
             }
             catch (SshConnectionException ex)
@@ -197,7 +197,7 @@ namespace Renci.SshNet.Tests.Classes
             var session = (ISession) Session;
             var waitHandle = new ManualResetEvent(false);
 
-            var result = session.TryWait(waitHandle, Session.InfiniteTimeSpan);
+            var result = session.TryWait(waitHandle, Timeout.InfiniteTimeSpan);
 
             Assert.AreEqual(WaitResult.Disconnected, result);
         }
@@ -208,7 +208,7 @@ namespace Renci.SshNet.Tests.Classes
             var session = (ISession) Session;
             var waitHandle = new ManualResetEvent(false);
 
-            var result = session.TryWait(waitHandle, Session.InfiniteTimeSpan, out var exception);
+            var result = session.TryWait(waitHandle, Timeout.InfiniteTimeSpan, out var exception);
 
             Assert.AreEqual(WaitResult.Disconnected, result);
             Assert.IsNull(exception);

--- a/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ServerSendsDisconnectMessage.cs
+++ b/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ServerSendsDisconnectMessage.cs
@@ -181,7 +181,7 @@ namespace Renci.SshNet.Tests.Classes
 
             try
             {
-                session.WaitOnHandle(waitHandle, Session.InfiniteTimeSpan);
+                session.WaitOnHandle(waitHandle, Timeout.InfiniteTimeSpan);
                 Assert.Fail();
             }
             catch (SshConnectionException ex)
@@ -202,7 +202,7 @@ namespace Renci.SshNet.Tests.Classes
             var session = (ISession) Session;
             var waitHandle = new ManualResetEvent(false);
 
-            var result = session.TryWait(waitHandle, Session.InfiniteTimeSpan);
+            var result = session.TryWait(waitHandle, Timeout.InfiniteTimeSpan);
 
             Assert.AreEqual(WaitResult.Disconnected, result);
         }
@@ -213,7 +213,7 @@ namespace Renci.SshNet.Tests.Classes
             var session = (ISession) Session;
             var waitHandle = new ManualResetEvent(false);
 
-            var result = session.TryWait(waitHandle, Session.InfiniteTimeSpan, out var exception);
+            var result = session.TryWait(waitHandle, Timeout.InfiniteTimeSpan, out var exception);
 
             Assert.AreEqual(WaitResult.Disconnected, result);
             Assert.IsNull(exception);

--- a/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ServerSendsDisconnectMessageAndShutsDownSocket.cs
+++ b/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ServerSendsDisconnectMessageAndShutsDownSocket.cs
@@ -183,7 +183,7 @@ namespace Renci.SshNet.Tests.Classes
             var session = (ISession) Session;
             var waitHandle = new ManualResetEvent(false);
 
-            var result = session.TryWait(waitHandle, Session.InfiniteTimeSpan);
+            var result = session.TryWait(waitHandle, Timeout.InfiniteTimeSpan);
 
             Assert.AreEqual(WaitResult.Disconnected, result);
         }
@@ -194,7 +194,7 @@ namespace Renci.SshNet.Tests.Classes
             var session = (ISession) Session;
             var waitHandle = new ManualResetEvent(false);
 
-            var result = session.TryWait(waitHandle, Session.InfiniteTimeSpan, out var exception);
+            var result = session.TryWait(waitHandle, Timeout.InfiniteTimeSpan, out var exception);
 
             Assert.AreEqual(WaitResult.Disconnected, result);
             Assert.IsNull(exception);

--- a/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ServerSendsUnsupportedMessageType.cs
+++ b/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ServerSendsUnsupportedMessageType.cs
@@ -195,7 +195,7 @@ namespace Renci.SshNet.Tests.Classes
             var session = (ISession) Session;
             var waitHandle = new ManualResetEvent(false);
 
-            var result = session.TryWait(waitHandle, Session.InfiniteTimeSpan);
+            var result = session.TryWait(waitHandle, Timeout.InfiniteTimeSpan);
 
             Assert.AreEqual(WaitResult.Failed, result);
         }
@@ -206,7 +206,7 @@ namespace Renci.SshNet.Tests.Classes
             var session = (ISession) Session;
             var waitHandle = new ManualResetEvent(false);
 
-            var result = session.TryWait(waitHandle, Session.InfiniteTimeSpan, out var exception);
+            var result = session.TryWait(waitHandle, Timeout.InfiniteTimeSpan, out var exception);
 
             Assert.AreEqual(WaitResult.Failed, result);
             Assert.IsNotNull(exception);

--- a/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ServerShutsDownSendAfterSendingIncompletePacket.cs
+++ b/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ServerShutsDownSendAfterSendingIncompletePacket.cs
@@ -174,7 +174,7 @@ namespace Renci.SshNet.Tests.Classes
 
             try
             {
-                session.WaitOnHandle(waitHandle, Session.InfiniteTimeSpan);
+                session.WaitOnHandle(waitHandle, Timeout.InfiniteTimeSpan);
                 Assert.Fail();
             }
             catch (SshConnectionException ex)
@@ -191,7 +191,7 @@ namespace Renci.SshNet.Tests.Classes
             var session = (ISession) Session;
             var waitHandle = new ManualResetEvent(false);
 
-            var result = session.TryWait(waitHandle, Session.InfiniteTimeSpan);
+            var result = session.TryWait(waitHandle, Timeout.InfiniteTimeSpan);
 
             Assert.AreEqual(WaitResult.Disconnected, result);
         }
@@ -202,7 +202,7 @@ namespace Renci.SshNet.Tests.Classes
             var session = (ISession) Session;
             var waitHandle = new ManualResetEvent(false);
 
-            var result = session.TryWait(waitHandle, Session.InfiniteTimeSpan, out var exception);
+            var result = session.TryWait(waitHandle, Timeout.InfiniteTimeSpan, out var exception);
 
             Assert.AreEqual(WaitResult.Disconnected, result);
             Assert.IsNull(exception);

--- a/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ServerShutsDownSocket.cs
+++ b/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ServerShutsDownSocket.cs
@@ -167,7 +167,7 @@ namespace Renci.SshNet.Tests.Classes
 
             try
             {
-                session.WaitOnHandle(waitHandle, Session.InfiniteTimeSpan);
+                session.WaitOnHandle(waitHandle, Timeout.InfiniteTimeSpan);
                 Assert.Fail();
             }
             catch (SshConnectionException ex)
@@ -183,7 +183,7 @@ namespace Renci.SshNet.Tests.Classes
             var session = (ISession) Session;
             var waitHandle = new ManualResetEvent(false);
 
-            var result = session.TryWait(waitHandle, Session.InfiniteTimeSpan);
+            var result = session.TryWait(waitHandle, Timeout.InfiniteTimeSpan);
 
             Assert.AreEqual(WaitResult.Disconnected, result);
         }
@@ -213,7 +213,7 @@ namespace Renci.SshNet.Tests.Classes
             var session = (ISession) Session;
             var waitHandle = new ManualResetEvent(false);
 
-            var result = session.TryWait(waitHandle, Session.InfiniteTimeSpan, out var exception);
+            var result = session.TryWait(waitHandle, Timeout.InfiniteTimeSpan, out var exception);
 
             Assert.AreEqual(WaitResult.Disconnected, result);
             Assert.IsNull(exception);

--- a/test/Renci.SshNet.Tests/Classes/SessionTest_NotConnected.cs
+++ b/test/Renci.SshNet.Tests/Classes/SessionTest_NotConnected.cs
@@ -125,7 +125,7 @@ namespace Renci.SshNet.Tests.Classes
             var session = (ISession) _session;
             var waitHandle = new ManualResetEvent(false);
 
-            var result = session.TryWait(waitHandle, Session.InfiniteTimeSpan);
+            var result = session.TryWait(waitHandle, Timeout.InfiniteTimeSpan);
 
             Assert.AreEqual(WaitResult.Disconnected, result);
         }
@@ -136,7 +136,7 @@ namespace Renci.SshNet.Tests.Classes
             var session = (ISession) _session;
             var waitHandle = new ManualResetEvent(false);
 
-            var result = session.TryWait(waitHandle, Session.InfiniteTimeSpan, out var exception);
+            var result = session.TryWait(waitHandle, Timeout.InfiniteTimeSpan, out var exception);
 
             Assert.AreEqual(WaitResult.Disconnected, result);
             Assert.IsNull(exception);
@@ -212,7 +212,7 @@ namespace Renci.SshNet.Tests.Classes
 
             try
             {
-                session.WaitOnHandle(waitHandle, Session.InfiniteTimeSpan);
+                session.WaitOnHandle(waitHandle, Timeout.InfiniteTimeSpan);
                 Assert.Fail();
             }
             catch (ArgumentNullException ex)


### PR DESCRIPTION
I guess it was home baked to support .NET Framework lower than 4.5. See https://learn.microsoft.com/en-us/dotnet/api/system.threading.timeout.infinitetimespan?view=net-8.0#applies-to