### PR TITLE
SftpClient: handle the SFTP session being closed by the server

### DIFF
--- a/src/Renci.SshNet/BaseClient.cs
+++ b/src/Renci.SshNet/BaseClient.cs
@@ -237,13 +237,9 @@ namespace Renci.SshNet
 
             // The session may already/still be connected here because e.g. in SftpClient, IsConnected also checks the internal SFTP session
             var session = Session;
-            if (session is null)
+            if (session is null || !session.IsConnected)
             {
                 Session = CreateAndConnectSession();
-            }
-            else if (!session.IsConnected)
-            {
-                session.Connect();
             }
 
             try
@@ -305,13 +301,9 @@ namespace Renci.SshNet
 
             // The session may already/still be connected here because e.g. in SftpClient, IsConnected also checks the internal SFTP session
             var session = Session;
-            if (session is null)
+            if (session is null || !session.IsConnected)
             {
                 Session = await CreateAndConnectSessionAsync(cancellationToken).ConfigureAwait(false);
-            }
-            else if (!session.IsConnected)
-            {
-                await session.ConnectAsync(cancellationToken).ConfigureAwait(false);
             }
 
             try

--- a/src/Renci.SshNet/BaseClient.cs
+++ b/src/Renci.SshNet/BaseClient.cs
@@ -72,7 +72,7 @@ namespace Renci.SshNet
         /// <see langword="true"/> if this client is connected; otherwise, <see langword="false"/>.
         /// </value>
         /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
-        public bool IsConnected
+        public virtual bool IsConnected
         {
             get
             {
@@ -228,14 +228,23 @@ namespace Renci.SshNet
             // forwarded port with a client instead of with a session
             //
             // To be discussed with Oleg (or whoever is interested)
-            if (IsSessionConnected())
+            if (IsConnected)
             {
                 throw new InvalidOperationException("The client is already connected.");
             }
 
             OnConnecting();
 
-            Session = CreateAndConnectSession();
+            // The session may already/still be connected here because e.g. in SftpClient, IsConnected also checks the internal SFTP session
+            var session = Session;
+            if (session is null)
+            {
+                Session = CreateAndConnectSession();
+            }
+            else if (!session.IsConnected)
+            {
+                session.Connect();
+            }
 
             try
             {
@@ -287,14 +296,23 @@ namespace Renci.SshNet
             // forwarded port with a client instead of with a session
             //
             // To be discussed with Oleg (or whoever is interested)
-            if (IsSessionConnected())
+            if (IsConnected)
             {
                 throw new InvalidOperationException("The client is already connected.");
             }
 
             OnConnecting();
 
-            Session = await CreateAndConnectSessionAsync(cancellationToken).ConfigureAwait(false);
+            // The session may already/still be connected here because e.g. in SftpClient, IsConnected also checks the internal SFTP session
+            var session = Session;
+            if (session is null)
+            {
+                Session = await CreateAndConnectSessionAsync(cancellationToken).ConfigureAwait(false);
+            }
+            else if (!session.IsConnected)
+            {
+                await session.ConnectAsync(cancellationToken).ConfigureAwait(false);
+            }
 
             try
             {

--- a/src/Renci.SshNet/SftpClient.cs
+++ b/src/Renci.SshNet/SftpClient.cs
@@ -109,6 +109,22 @@ namespace Renci.SshNet
         }
 
         /// <summary>
+        /// Gets a value indicating whether this client is connected to the server and
+        /// the SFTP session is open.
+        /// </summary>
+        /// <value>
+        /// <see langword="true"/> if this client is connected and the SFTP session is open; otherwise, <see langword="false"/>.
+        /// </value>
+        /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
+        public override bool IsConnected
+        {
+            get
+            {
+                return base.IsConnected && _sftpSession.IsOpen;
+            }
+        }
+
+        /// <summary>
         /// Gets remote working directory.
         /// </summary>
         /// <exception cref="SshConnectionException">Client is not connected.</exception>
@@ -2473,7 +2489,15 @@ namespace Renci.SshNet
         {
             base.OnConnected();
 
-            _sftpSession = CreateAndConnectToSftpSession();
+            var sftpSession = _sftpSession;
+            if (sftpSession is null)
+            {
+                _sftpSession = CreateAndConnectToSftpSession();
+            }
+            else if (!sftpSession.IsOpen)
+            {
+                sftpSession.Connect();
+            }
         }
 
         /// <summary>

--- a/test/Renci.SshNet.IntegrationTests/ConnectivityTests.cs
+++ b/test/Renci.SshNet.IntegrationTests/ConnectivityTests.cs
@@ -288,6 +288,44 @@ namespace Renci.SshNet.IntegrationTests
         }
 
         [TestMethod]
+        public void SftpClient_HandleSftpSessionClose()
+        {
+            using (var client = new SftpClient(_connectionInfoFactory.Create()))
+            {
+                client.Connect();
+                Assert.IsTrue(client.IsConnected);
+
+                client.SftpSession.Disconnect();
+                Assert.IsFalse(client.IsConnected);
+
+                client.Connect();
+                Assert.IsTrue(client.IsConnected);
+
+                client.Disconnect();
+                Assert.IsFalse(client.IsConnected);
+            }
+        }
+
+        [TestMethod]
+        public async Task SftpClient_HandleSftpSessionCloseAsync()
+        {
+            using (var client = new SftpClient(_connectionInfoFactory.Create()))
+            {
+                await client.ConnectAsync(CancellationToken.None);
+                Assert.IsTrue(client.IsConnected);
+
+                client.SftpSession.Disconnect();
+                Assert.IsFalse(client.IsConnected);
+
+                await client.ConnectAsync(CancellationToken.None);
+                Assert.IsTrue(client.IsConnected);
+
+                client.Disconnect();
+                Assert.IsFalse(client.IsConnected);
+            }
+        }
+
+        [TestMethod]
         public void Common_DetectSessionKilledOnServer()
         {
             using (var client = new SftpClient(_connectionInfoFactory.Create()))


### PR DESCRIPTION
If the server closes the SFTP session but keeps the TCP connection open, this currently causes IsConnected to return true, but any operation fails with "the session is not open".

SftpClient.IsConnected now also check sftpSession.IsOpen. Connect() and ConnectAsync() were reworked to take into account that the Session may already/still be open, but the SFTP session may not. This is needed so a reconnect works.

fixes #843 
fixes #1153
fixes #369 