### PR TITLE
Handle unknown channel messages correctly

### DIFF
--- a/src/Renci.SshNet/Channels/Channel.cs
+++ b/src/Renci.SshNet/Channels/Channel.cs
@@ -714,8 +714,14 @@ namespace Renci.SshNet.Channels
                     }
                     else
                     {
-                        var reply = new ChannelFailureMessage(LocalChannelNumber);
-                        SendMessage(reply);
+                        var unknownRequestInfo = new UnknownRequestInfo(e.Message.RequestName);
+                        unknownRequestInfo.Load(e.Message.RequestData);
+
+                        if (unknownRequestInfo.WantReply)
+                        {
+                            var reply = new ChannelFailureMessage(LocalChannelNumber);
+                            SendMessage(reply);
+                        }
                     }
                 }
                 catch (Exception ex)

--- a/src/Renci.SshNet/Channels/Channel.cs
+++ b/src/Renci.SshNet/Channels/Channel.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Globalization;
 using System.Net.Sockets;
 using System.Threading;
 
@@ -715,8 +714,8 @@ namespace Renci.SshNet.Channels
                     }
                     else
                     {
-                        // TODO: we should also send a SSH_MSG_CHANNEL_FAILURE message
-                        throw new NotSupportedException(string.Format(CultureInfo.CurrentCulture, "Request '{0}' is not supported.", e.Message.RequestName));
+                        var reply = new ChannelFailureMessage(LocalChannelNumber);
+                        SendMessage(reply);
                     }
                 }
                 catch (Exception ex)

--- a/src/Renci.SshNet/Channels/Channel.cs
+++ b/src/Renci.SshNet/Channels/Channel.cs
@@ -719,7 +719,7 @@ namespace Renci.SshNet.Channels
 
                         if (unknownRequestInfo.WantReply)
                         {
-                            var reply = new ChannelFailureMessage(LocalChannelNumber);
+                            var reply = new ChannelFailureMessage(RemoteChannelNumber);
                             SendMessage(reply);
                         }
                     }

--- a/src/Renci.SshNet/Channels/IChannel.cs
+++ b/src/Renci.SshNet/Channels/IChannel.cs
@@ -60,6 +60,11 @@ namespace Renci.SshNet.Channels
         uint LocalPacketSize { get; }
 
         /// <summary>
+        /// Gets the remote channel number.
+        /// </summary>
+        uint RemoteChannelNumber { get; }
+
+        /// <summary>
         /// Gets the maximum size of a data packet that can be sent using the channel.
         /// </summary>
         /// <value>

--- a/src/Renci.SshNet/Messages/Connection/ChannelRequest/UnknownRequestInfo.cs
+++ b/src/Renci.SshNet/Messages/Connection/ChannelRequest/UnknownRequestInfo.cs
@@ -1,0 +1,22 @@
+﻿namespace Renci.SshNet.Messages.Connection
+{
+    /// <summary>
+    /// Represents an unknown request information that we can't handle.
+    /// </summary>
+    internal sealed class UnknownRequestInfo : RequestInfo
+    {
+        /// <summary>
+        /// Gets the name of the request.
+        /// </summary>
+        public override string RequestName { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnknownRequestInfo"/> class.
+        /// <paramref name="requestName">The name of the unknown request.</paramref>
+        /// </summary>
+        internal UnknownRequestInfo(string requestName)
+        {
+            RequestName = requestName;
+        }
+    }
+}

--- a/src/Renci.SshNet/SshCommand.cs
+++ b/src/Renci.SshNet/SshCommand.cs
@@ -454,7 +454,7 @@ namespace Renci.SshNet
 
                 if (exitStatusInfo.WantReply)
                 {
-                    var replyMessage = new ChannelSuccessMessage(_channel.LocalChannelNumber);
+                    var replyMessage = new ChannelSuccessMessage(_channel.RemoteChannelNumber);
                     _session.SendMessage(replyMessage);
                 }
             }
@@ -462,7 +462,7 @@ namespace Renci.SshNet
             {
                 if (e.Info.WantReply)
                 {
-                    var replyMessage = new ChannelFailureMessage(_channel.LocalChannelNumber);
+                    var replyMessage = new ChannelFailureMessage(_channel.RemoteChannelNumber);
                     _session.SendMessage(replyMessage);
                 }
             }

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionChannelRequestReceived_HandleUnknownMessage.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionChannelRequestReceived_HandleUnknownMessage.cs
@@ -17,6 +17,9 @@ namespace Renci.SshNet.Tests.Classes.Channels
         private uint _localWindowSize;
         private uint _localPacketSize;
         private uint _localChannelNumber;
+        private uint _remoteChannelNumber;
+        private uint _remoteWindowSize;
+        private uint _remotePacketSize;
         private ChannelStub _channel;
         private IList<ExceptionEventArgs> _channelExceptionRegister;
         private UnknownRequestInfoWithWantReply _requestInfo;
@@ -28,6 +31,9 @@ namespace Renci.SshNet.Tests.Classes.Channels
             _localWindowSize = (uint) random.Next(1000, int.MaxValue);
             _localPacketSize = _localWindowSize - 1;
             _localChannelNumber = (uint) random.Next(0, int.MaxValue);
+            _remoteChannelNumber = (uint) random.Next(0, int.MaxValue);
+            _remoteWindowSize = (uint) random.Next(0, int.MaxValue);
+            _remotePacketSize = (uint) random.Next(0, int.MaxValue);
             _channelExceptionRegister = new List<ExceptionEventArgs>();
             _requestInfo = new UnknownRequestInfoWithWantReply();
         }
@@ -44,6 +50,7 @@ namespace Renci.SshNet.Tests.Classes.Channels
             base.Arrange();
 
             _channel = new ChannelStub(SessionMock.Object, _localChannelNumber, _localWindowSize, _localPacketSize);
+            _channel.InitializeRemoteChannelInfo(_remoteChannelNumber, _remoteWindowSize, _remotePacketSize);
             _channel.SetIsOpen(true);
             _channel.Exception += (sender, args) => _channelExceptionRegister.Add(args);
         }
@@ -57,7 +64,7 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void FailureMessageWasSent()
         {
-            SessionMock.Verify(p => p.SendMessage(It.Is<ChannelFailureMessage>(m => m.LocalChannelNumber == _localChannelNumber)), Times.Once);
+            SessionMock.Verify(p => p.SendMessage(It.Is<ChannelFailureMessage>(m => m.LocalChannelNumber == _channel.RemoteChannelNumber)), Times.Once);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionChannelRequestReceived_HandleUnknownMessage.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionChannelRequestReceived_HandleUnknownMessage.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Moq;
+
+using Renci.SshNet.Common;
+using Renci.SshNet.Messages;
+using Renci.SshNet.Messages.Connection;
+
+namespace Renci.SshNet.Tests.Classes.Channels
+{
+    [TestClass]
+    public class ChannelTest_OnSessionChannelRequestReceived_HandleUnknownMessage : ChannelTestBase
+    {
+        private uint _localWindowSize;
+        private uint _localPacketSize;
+        private uint _localChannelNumber;
+        private ChannelStub _channel;
+        private IList<ExceptionEventArgs> _channelExceptionRegister;
+        private UnknownRequestInfo _requestInfo;
+
+        protected override void SetupData()
+        {
+            var random = new Random();
+
+            _localWindowSize = (uint) random.Next(1000, int.MaxValue);
+            _localPacketSize = _localWindowSize - 1;
+            _localChannelNumber = (uint) random.Next(0, int.MaxValue);
+            _channelExceptionRegister = new List<ExceptionEventArgs>();
+            _requestInfo = new UnknownRequestInfo();
+        }
+
+        protected override void SetupMocks()
+        {
+            _ = SessionMock.Setup(p => p.ConnectionInfo)
+                           .Returns(new ConnectionInfo("host", "user", new PasswordAuthenticationMethod("user", "password")));
+            _ = SessionMock.Setup(p => p.SendMessage(It.IsAny<Message>()));
+        }
+
+        protected override void Arrange()
+        {
+            base.Arrange();
+
+            _channel = new ChannelStub(SessionMock.Object, _localChannelNumber, _localWindowSize, _localPacketSize);
+            _channel.SetIsOpen(true);
+            _channel.Exception += (sender, args) => _channelExceptionRegister.Add(args);
+        }
+
+        protected override void Act()
+        {
+            SessionMock.Raise(s => s.ChannelRequestReceived += null,
+                               new MessageEventArgs<ChannelRequestMessage>(new ChannelRequestMessage(_localChannelNumber, _requestInfo)));
+        }
+
+        [TestMethod]
+        public void FailureMessageWasSent()
+        {
+            SessionMock.Verify(p => p.SendMessage(It.Is<ChannelFailureMessage>(m => m.LocalChannelNumber == _localChannelNumber)), Times.Once);
+        }
+
+        [TestMethod]
+        public void NoExceptionShouldHaveFired()
+        {
+            Assert.AreEqual(0, _channelExceptionRegister.Count);
+        }
+    }
+
+    internal class UnknownRequestInfo : RequestInfo
+    {
+        public override string RequestName
+        {
+            get
+            {
+                return nameof(UnknownRequestInfo);
+            }
+        }
+
+    }
+}

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionChannelRequestReceived_HandleUnknownMessage.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionChannelRequestReceived_HandleUnknownMessage.cs
@@ -19,7 +19,7 @@ namespace Renci.SshNet.Tests.Classes.Channels
         private uint _localChannelNumber;
         private ChannelStub _channel;
         private IList<ExceptionEventArgs> _channelExceptionRegister;
-        private UnknownRequestInfo _requestInfo;
+        private UnknownRequestInfoWithWantReply _requestInfo;
 
         protected override void SetupData()
         {
@@ -29,7 +29,7 @@ namespace Renci.SshNet.Tests.Classes.Channels
             _localPacketSize = _localWindowSize - 1;
             _localChannelNumber = (uint) random.Next(0, int.MaxValue);
             _channelExceptionRegister = new List<ExceptionEventArgs>();
-            _requestInfo = new UnknownRequestInfo();
+            _requestInfo = new UnknownRequestInfoWithWantReply();
         }
 
         protected override void SetupMocks()
@@ -67,15 +67,19 @@ namespace Renci.SshNet.Tests.Classes.Channels
         }
     }
 
-    internal class UnknownRequestInfo : RequestInfo
+    internal class UnknownRequestInfoWithWantReply : RequestInfo
     {
         public override string RequestName
         {
             get
             {
-                return nameof(UnknownRequestInfo);
+                return nameof(UnknownRequestInfoWithWantReply);
             }
         }
 
+        internal UnknownRequestInfoWithWantReply()
+        {
+            WantReply = true;
+        }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ShellStreamTest_ReadExpect.cs
+++ b/test/Renci.SshNet.Tests/Classes/ShellStreamTest_ReadExpect.cs
@@ -368,6 +368,8 @@ namespace Renci.SshNet.Tests.Classes
 
             public uint LocalPacketSize => throw new NotImplementedException();
 
+            public uint RemoteChannelNumber => throw new NotImplementedException();
+
             public uint RemotePacketSize => throw new NotImplementedException();
 
             public bool IsOpen => throw new NotImplementedException();


### PR DESCRIPTION
See discussion #1218 . Some servers send custom channel messages like 'keepalive@proftpd.org' as keep alive messages. This currently causes a NotSupportedException.

According to the spec https://datatracker.ietf.org/doc/html/rfc4254#section-5.4 :

"If the request is not recognized or is not
supported for the channel, SSH_MSG_CHANNEL_FAILURE is returned."

Send a failure message back instead of throwing an exception.

The  test is mostly copy&paste from ChannelTest_OnSessionChannelRequestReceived_OnRequest_Exception. I also reproduced the issue and tested the fix with an actual ProFTPD server locally.