### PR TITLE
add optional execution timestamp

### DIFF
--- a/src/Renci.SshNet/SshClient.cs
+++ b/src/Renci.SshNet/SshClient.cs
@@ -239,6 +239,19 @@ namespace Renci.SshNet
         }
 
         /// <summary>
+        /// Creates the command.
+        /// </summary>
+        /// <param name="commandText">The command text.</param>
+        /// <param name="logExecutionTimeStamp">Returns a timestamp of the time the command was executed with the result.</param>
+        /// <returns><see cref="SshCommand"/> object with execution time in the result.</returns>
+        public SshCommand CreateCommand(string commandText, bool logExecutionTimeStamp)
+        {
+            EnsureSessionIsOpen();
+
+            return new SshCommand(Session, commandText, ConnectionInfo.Encoding, logExecutionTimeStamp);
+        }
+
+        /// <summary>
         /// Creates and executes the command.
         /// </summary>
         /// <param name="commandText">The command text.</param>

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelForwardedTcpipTest_Dispose_SessionIsConnectedAndChannelIsOpen.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelForwardedTcpipTest_Dispose_SessionIsConnectedAndChannelIsOpen.cs
@@ -89,7 +89,6 @@ namespace Renci.SshNet.Tests.Classes.Channels
             _forwardedPortMock = new Mock<IForwardedPort>(MockBehavior.Strict);
 
             var sequence = new MockSequence();
-
             _ = _sessionMock.InSequence(sequence)
                             .Setup(p => p.IsConnected)
                             .Returns(true);

--- a/test/Renci.SshNet.Tests/Classes/SshClientTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/SshClientTest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Renci.SshNet.Common;
 using Renci.SshNet.Tests.Common;
 using Renci.SshNet.Tests.Properties;
@@ -76,7 +77,6 @@ namespace Renci.SshNet.Tests.Classes
                 var output = new MemoryStream();
                 var extendedOutput = new MemoryStream();
 
-
                 try
                 {
                     client.CreateShell(encoding, input, output, extendedOutput);
@@ -148,7 +148,6 @@ namespace Renci.SshNet.Tests.Classes
 
                 try
                 {
-
                     client.CreateShell(
                         encoding,
                         input,
@@ -182,7 +181,6 @@ namespace Renci.SshNet.Tests.Classes
 
                 try
                 {
-
                     client.CreateShell(input, output, extendedOutput);
                     Assert.Fail();
                 }
@@ -249,7 +247,6 @@ namespace Renci.SshNet.Tests.Classes
 
                 try
                 {
-
                     client.CreateShell(
                         input,
                         output,
@@ -297,6 +294,24 @@ namespace Renci.SshNet.Tests.Classes
                 try
                 {
                     client.CreateCommand("ls", Encoding.UTF8);
+                    Assert.Fail();
+                }
+                catch (SshConnectionException ex)
+                {
+                    Assert.IsNull(ex.InnerException);
+                    Assert.AreEqual("Client not connected.", ex.Message);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void CreateCommand_CommandTextAndIncludeExecutionTimeInResult()
+        {
+            using (var client = new SshClient(Resources.HOST, Resources.USERNAME, "invalid password"))
+            {
+                try
+                {
+                    client.CreateCommand("ls", true);
                     Assert.Fail();
                 }
                 catch (SshConnectionException ex)


### PR DESCRIPTION
When executing a command that outputs many lines of text its not possible to know when there was which output. In situations where you want to know how much time it took between outputs it would be helpful to see the exact time when the output occured. 

This is why i want to add an optional timestamp before the output of a command. 