### PR TITLE
git: checkout cs files with crlf

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,6 @@ insert_final_newline = true
 indent_style = space
 indent_size = 4
 tab_width = 4
-end_of_line = crlf
 
 [*.{xml,csproj,props}]
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 * text=auto
 
-*.cs text
+*.cs text eol=crlf
 *.xaml text
 *.sln eol=crlf
 *.csproj eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 * text=auto
 
-*.cs text eol=crlf
+*.cs text
 *.xaml text
 *.sln eol=crlf
 *.csproj eol=crlf


### PR DESCRIPTION
Currently, when you clone the repository on a Linux machine, all cs files have the wrong line endings. The .editorconfig file enforces crlf, but git will checkout the files with the default OS file encoding by default (lf).

This causes a `dotnet format whitespace --verify-no-changes` to complain about the line endings on a fresh working copy.

Tell git to checkout *.cs files with crlf to fix this. Note that existing linux working copies would need to run the following to fix the newlines after pulling in this change: `git rm -rf --cached . && git reset --hard HEAD`.

I noticed this while looking into enforcing formatting in CI, but that's for a separate PR.