### PR TITLE
Add an AOT compatibility test app

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,7 @@
         Assembly Info properties that apply to all projects/assemblies.
     -->
   <PropertyGroup>
+    <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)Renci.SshNet.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/Renci.SshNet.sln
+++ b/Renci.SshNet.sln
@@ -84,6 +84,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Renci.SshNet.Benchmarks", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Renci.SshNet.IntegrationBenchmarks", "test\Renci.SshNet.IntegrationBenchmarks\Renci.SshNet.IntegrationBenchmarks.csproj", "{6DFC1807-3F44-4302-A302-43F7D887C4E0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Renci.SshNet.AotCompatibilityTestApp", "test\Renci.SshNet.AotCompatibilityTestApp\Renci.SshNet.AotCompatibilityTestApp.csproj", "{F2E3FC50-4EF4-488C-B3D2-C45E99898D8B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -212,6 +214,26 @@ Global
 		{6DFC1807-3F44-4302-A302-43F7D887C4E0}.Release|x64.Build.0 = Release|Any CPU
 		{6DFC1807-3F44-4302-A302-43F7D887C4E0}.Release|x86.ActiveCfg = Release|Any CPU
 		{6DFC1807-3F44-4302-A302-43F7D887C4E0}.Release|x86.Build.0 = Release|Any CPU
+		{F2E3FC50-4EF4-488C-B3D2-C45E99898D8B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F2E3FC50-4EF4-488C-B3D2-C45E99898D8B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F2E3FC50-4EF4-488C-B3D2-C45E99898D8B}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{F2E3FC50-4EF4-488C-B3D2-C45E99898D8B}.Debug|ARM.Build.0 = Debug|Any CPU
+		{F2E3FC50-4EF4-488C-B3D2-C45E99898D8B}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{F2E3FC50-4EF4-488C-B3D2-C45E99898D8B}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{F2E3FC50-4EF4-488C-B3D2-C45E99898D8B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F2E3FC50-4EF4-488C-B3D2-C45E99898D8B}.Debug|x64.Build.0 = Debug|Any CPU
+		{F2E3FC50-4EF4-488C-B3D2-C45E99898D8B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F2E3FC50-4EF4-488C-B3D2-C45E99898D8B}.Debug|x86.Build.0 = Debug|Any CPU
+		{F2E3FC50-4EF4-488C-B3D2-C45E99898D8B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F2E3FC50-4EF4-488C-B3D2-C45E99898D8B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F2E3FC50-4EF4-488C-B3D2-C45E99898D8B}.Release|ARM.ActiveCfg = Release|Any CPU
+		{F2E3FC50-4EF4-488C-B3D2-C45E99898D8B}.Release|ARM.Build.0 = Release|Any CPU
+		{F2E3FC50-4EF4-488C-B3D2-C45E99898D8B}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{F2E3FC50-4EF4-488C-B3D2-C45E99898D8B}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{F2E3FC50-4EF4-488C-B3D2-C45E99898D8B}.Release|x64.ActiveCfg = Release|Any CPU
+		{F2E3FC50-4EF4-488C-B3D2-C45E99898D8B}.Release|x64.Build.0 = Release|Any CPU
+		{F2E3FC50-4EF4-488C-B3D2-C45E99898D8B}.Release|x86.ActiveCfg = Release|Any CPU
+		{F2E3FC50-4EF4-488C-B3D2-C45E99898D8B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,6 +36,7 @@ for:
   build_script:
     - echo build
     - dotnet build Renci.SshNet.sln -c Debug
+    - dotnet publish -c Release -r win-x64 /warnaserror .\test\Renci.SshNet.AotCompatibilityTestApp\
 
   test_script:
     - ps: echo "Run unit tests for .NET 8.0"

--- a/src/Renci.SshNet/Renci.SshNet.csproj
+++ b/src/Renci.SshNet/Renci.SshNet.csproj
@@ -30,7 +30,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0' ">
     <!-- Must be kept at version 1.0.0 or higher, see https://github.com/sshnet/SSH.NET/pull/1288 for details. -->
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="[1.0.0,)" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="[7.0.0,)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -42,6 +42,10 @@
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CsvHelper" Version="31.0.4" />
   </ItemGroup>
 
 </Project>

--- a/src/Renci.SshNet/Renci.SshNet.csproj
+++ b/src/Renci.SshNet/Renci.SshNet.csproj
@@ -30,7 +30,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0' ">
     <!-- Must be kept at version 1.0.0 or higher, see https://github.com/sshnet/SSH.NET/pull/1288 for details. -->
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="[7.0.0,)" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="[1.0.0,)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -42,10 +42,6 @@
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="CsvHelper" Version="31.0.4" />
   </ItemGroup>
 
 </Project>

--- a/src/Renci.SshNet/Renci.SshNet.csproj
+++ b/src/Renci.SshNet/Renci.SshNet.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <IsPackable>true</IsPackable>
     <PackageId>SSH.NET</PackageId>
     <Title>SSH.NET</Title>
     <Version>2024.0.0</Version>
@@ -24,9 +25,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0')) ">
-    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
-    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
-    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0' ">

--- a/src/Renci.SshNet/SshCommand.cs
+++ b/src/Renci.SshNet/SshCommand.cs
@@ -5,9 +5,12 @@ using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Threading;
 
+using CsvHelper;
+
 using Renci.SshNet.Abstractions;
 using Renci.SshNet.Channels;
 using Renci.SshNet.Common;
+using Renci.SshNet.Messages;
 using Renci.SshNet.Messages.Connection;
 using Renci.SshNet.Messages.Transport;
 
@@ -118,8 +121,12 @@ namespace Renci.SshNet
                                                      detectEncodingFromByteOrderMarks: true,
                                                      bufferSize: 1024,
                                                      leaveOpen: true))
+                    using (var csv = new CsvReader(sr, CultureInfo.InvariantCulture))
                     {
-                        _ = _result.Append(sr.ReadToEnd());
+                        foreach (var m in csv.GetRecords<Message>())
+                        {
+                            _ = _result.Append(m);
+                        }
                     }
                 }
 

--- a/src/Renci.SshNet/SshCommand.cs
+++ b/src/Renci.SshNet/SshCommand.cs
@@ -5,12 +5,9 @@ using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Threading;
 
-using CsvHelper;
-
 using Renci.SshNet.Abstractions;
 using Renci.SshNet.Channels;
 using Renci.SshNet.Common;
-using Renci.SshNet.Messages;
 using Renci.SshNet.Messages.Connection;
 using Renci.SshNet.Messages.Transport;
 
@@ -121,12 +118,8 @@ namespace Renci.SshNet
                                                      detectEncodingFromByteOrderMarks: true,
                                                      bufferSize: 1024,
                                                      leaveOpen: true))
-                    using (var csv = new CsvReader(sr, CultureInfo.InvariantCulture))
                     {
-                        foreach (var m in csv.GetRecords<Message>())
-                        {
-                            _ = _result.Append(m);
-                        }
+                        _ = _result.Append(sr.ReadToEnd());
                     }
                 }
 

--- a/test/Renci.SshNet.AotCompatibilityTestApp/Program.cs
+++ b/test/Renci.SshNet.AotCompatibilityTestApp/Program.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Renci.SshNet.AotCompatibilityTestApp
+{
+    public static class Program
+    {
+        public static void Main()
+        {
+            // This app is used to verify the trim- and AOT-friendliness of
+            // the library and its dependencies, by specifying <TrimmerRootAssembly>
+            // in the csproj and publishing with e.g. "dotnet publish -c Release -r win-x64"
+
+            // See https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming?pivots=dotnet-8-0
+            // and https://devblogs.microsoft.com/dotnet/creating-aot-compatible-libraries/
+
+            Console.WriteLine("Hello, AOT!");
+        }
+    }
+}

--- a/test/Renci.SshNet.AotCompatibilityTestApp/Renci.SshNet.AotCompatibilityTestApp.csproj
+++ b/test/Renci.SshNet.AotCompatibilityTestApp/Renci.SshNet.AotCompatibilityTestApp.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <PublishAot>true</PublishAot>
+    <SelfContained>true</SelfContained>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Renci.SshNet\Renci.SshNet.csproj" />
+    <TrimmerRootAssembly Include="Renci.SshNet" />
+  </ItemGroup>
+
+</Project>

--- a/test/Renci.SshNet.IntegrationTests/Renci.SshNet.IntegrationTests.csproj
+++ b/test/Renci.SshNet.IntegrationTests/Renci.SshNet.IntegrationTests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>net48;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
-    <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <NoWarn>$(NoWarn);SYSLIB0021;SYSLIB1045;SYSLIB0014;IDE0220;IDE0010</NoWarn>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>


### PR DESCRIPTION
Following the guides at
https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming?pivots=dotnet-8-0
and https://devblogs.microsoft.com/dotnet/creating-aot-compatible-libraries/,
add an application which is published for AOT in CI.

This process fully verifies all code-paths in the library and its dependencies
for trimming/AOT, which the analyzers are not themselves able to do.

(As a side benefit, now we are also checking the library builds in Release)

closes #934 