### PR TITLE
gitattributes: set diff=csharp on cs files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 * text=auto
 
-*.cs text
+*.cs text diff=csharp
 *.xaml text
 *.sln eol=crlf
 *.csproj eol=crlf


### PR DESCRIPTION
This makes a local "git diff" more readable because it will show the C# function above each diff "hunk header", see https://git-scm.com/docs/gitattributes#_defining_a_custom_hunk_header