### PR TITLE
fix flaky Sftp_BeginUploadFile test

### DIFF
--- a/test/Renci.SshNet.IntegrationTests/SftpTests.cs
+++ b/test/Renci.SshNet.IntegrationTests/SftpTests.cs
@@ -132,8 +132,13 @@ namespace Renci.SshNet.IntegrationTests
                     using (var memoryStream = new MemoryStream(Encoding.ASCII.GetBytes(content)))
                     {
                         IAsyncResult asyncResultCallback = null;
+                        var callbackCalled = new ManualResetEvent(false);
 
-                        var asyncResult = client.BeginUploadFile(memoryStream, remoteFile, ar => asyncResultCallback = ar);
+                        var asyncResult = client.BeginUploadFile(memoryStream, remoteFile, ar =>
+                        {
+                            asyncResultCallback = ar;
+                            callbackCalled.Set();
+                        });
 
                         Assert.IsTrue(asyncResult.AsyncWaitHandle.WaitOne(10000));
 
@@ -144,6 +149,8 @@ namespace Renci.SshNet.IntegrationTests
                         Assert.IsTrue(sftpUploadAsyncResult.IsCompleted);
                         Assert.IsFalse(sftpUploadAsyncResult.CompletedSynchronously);
                         Assert.AreEqual(expectedByteCount, sftpUploadAsyncResult.UploadedBytes);
+
+                        Assert.IsTrue(callbackCalled.WaitOne(10000));
 
                         // check async result callback
                         var sftpUploadAsyncResultCallback = asyncResultCallback as SftpUploadAsyncResult;

--- a/test/Renci.SshNet.IntegrationTests/SftpTests.cs
+++ b/test/Renci.SshNet.IntegrationTests/SftpTests.cs
@@ -132,7 +132,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var memoryStream = new MemoryStream(Encoding.ASCII.GetBytes(content)))
                     {
                         IAsyncResult asyncResultCallback = null;
-                        var callbackCalled = new ManualResetEvent(false);
+                        using var callbackCalled = new ManualResetEventSlim(false);
 
                         var asyncResult = client.BeginUploadFile(memoryStream, remoteFile, ar =>
                         {
@@ -150,7 +150,7 @@ namespace Renci.SshNet.IntegrationTests
                         Assert.IsFalse(sftpUploadAsyncResult.CompletedSynchronously);
                         Assert.AreEqual(expectedByteCount, sftpUploadAsyncResult.UploadedBytes);
 
-                        Assert.IsTrue(callbackCalled.WaitOne(10000));
+                        Assert.IsTrue(callbackCalled.Wait(10000));
 
                         // check async result callback
                         var sftpUploadAsyncResultCallback = asyncResultCallback as SftpUploadAsyncResult;


### PR DESCRIPTION
this test can randomly fail because it assumes that the callback has been called when the AsyncWaitHandle was set. But this is not necessarily the case because AsyncResult.SetAsCompleted does it the other way around.

example: https://ci.appveyor.com/project/drieseng/ssh-net/builds/49831002/job/1237d4lg46j22pf0