### PR TITLE
fix flaky Connectivity Tests

### DIFF
--- a/test/Renci.SshNet.IntegrationTests/ConnectivityTests.cs
+++ b/test/Renci.SshNet.IntegrationTests/ConnectivityTests.cs
@@ -171,6 +171,7 @@ namespace Renci.SshNet.IntegrationTests
 
                 try
                 {
+                    WaitForConnectionInterruption(client);
                     client.ListDirectory("/");
                     Assert.Fail();
                 }
@@ -260,9 +261,9 @@ namespace Renci.SshNet.IntegrationTests
                 client.Connect();
 
                 var disruptor = _sshConnectionDisruptor.BreakConnections();
-                Thread.Sleep(100);
                 try
                 {
+                    WaitForConnectionInterruption(client);
                     client.ListDirectory("/");
                     Assert.Fail();
                 }


### PR DESCRIPTION
these two tests were not waiting for the interruption (all other usages of BreakConnections() did). This could cause random failures because e.g. the wrong exception is thrown.

example: https://ci.appveyor.com/project/drieseng/ssh-net/builds/49831433/job/4urb0upx63bvxcgu