### PR TITLE
fix flaky ReceiveOnServerSocketShouldReturnZero test

### DIFF
--- a/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_Disconnect.cs
+++ b/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_Disconnect.cs
@@ -15,10 +15,10 @@ namespace Renci.SshNet.Tests.Classes
     {
         protected override void Act()
         {
-            ManualResetEvent clientDisconnected = new ManualResetEvent(false);
+            using ManualResetEventSlim clientDisconnected = new ManualResetEventSlim(false);
             ServerListener.Disconnected += (socket) => clientDisconnected.Set();
             Session.Disconnect();
-            clientDisconnected.WaitOne(10000);
+            clientDisconnected.Wait(10000);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_Disconnect.cs
+++ b/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_Disconnect.cs
@@ -15,7 +15,10 @@ namespace Renci.SshNet.Tests.Classes
     {
         protected override void Act()
         {
+            ManualResetEvent clientDisconnected = new ManualResetEvent(false);
+            ServerListener.Disconnected += (socket) => clientDisconnected.Set();
             Session.Disconnect();
+            clientDisconnected.WaitOne(10000);
         }
 
         [TestMethod]


### PR DESCRIPTION
ReceiveOnServerSocketShouldReturnZero assumed that the disconnect already happened on the server side, but it never waits for this. This could cause ServerSocket.Receive to still return valid data and fail the test.

example: https://ci.appveyor.com/project/drieseng/ssh-net/builds/49836561/job/wen5tjd1c7wgxrfh