### PR TITLE
make ConnectShouldActivateKeepAliveIfSessionIs test less flaky

### DIFF
--- a/test/Renci.SshNet.Tests/Classes/BaseClientTest_NotConnected_KeepAliveInterval_NotNegativeOne.cs
+++ b/test/Renci.SshNet.Tests/Classes/BaseClientTest_NotConnected_KeepAliveInterval_NotNegativeOne.cs
@@ -70,7 +70,7 @@ namespace Renci.SshNet.Tests.Classes
             _client.Connect();
 
             // allow keep-alive to be sent at least twice with some margin for error
-            Thread.Sleep(5 * _keepAliveInterval);
+            Thread.Sleep(5 * (int)_keepAliveInterval.TotalMilliseconds);
 
             // At least two keep-alives should be sent
             SessionMock.Verify(p => p.TrySendMessage(It.IsAny<IgnoreMessage>()), Times.AtLeast(2));

--- a/test/Renci.SshNet.Tests/Classes/BaseClientTest_NotConnected_KeepAliveInterval_NotNegativeOne.cs
+++ b/test/Renci.SshNet.Tests/Classes/BaseClientTest_NotConnected_KeepAliveInterval_NotNegativeOne.cs
@@ -69,11 +69,11 @@ namespace Renci.SshNet.Tests.Classes
 
             _client.Connect();
 
-            // allow keep-alive to be sent twice
-            Thread.Sleep(250);
+            // allow keep-alive to be sent at least twice with some margin for error
+            Thread.Sleep(5 * _keepAliveInterval);
 
-            // Exactly two keep-alives should be sent
-            SessionMock.Verify(p => p.TrySendMessage(It.IsAny<IgnoreMessage>()), Times.Exactly(2));
+            // At least two keep-alives should be sent
+            SessionMock.Verify(p => p.TrySendMessage(It.IsAny<IgnoreMessage>()), Times.AtLeast(2));
         }
 
         private class MyClient : BaseClient


### PR DESCRIPTION
wait longer and expect at least two instead of exactly two.

example: https://ci.appveyor.com/project/drieseng/ssh-net/builds/49849877/job/9rrtw6j8eu3i5p8o?fullLog=true