### PR TITLE
fix flaky SFTP file time tests

### DIFF
--- a/test/Renci.SshNet.IntegrationTests/Common/DateTimeAssert.cs
+++ b/test/Renci.SshNet.IntegrationTests/Common/DateTimeAssert.cs
@@ -7,12 +7,5 @@
             Assert.AreEqual(expected, actual, $"Expected {expected:o}, but was {actual:o}.");
             Assert.AreEqual(expected.Kind, actual.Kind);
         }
-
-        public static void AreEqual(DateTime expected, DateTime actual, TimeSpan maxDelta)
-        {
-            TimeSpan actualDelta = (expected - actual).Duration();
-            Assert.IsTrue(actualDelta <= maxDelta, $"Expected max delta of {maxDelta} between {expected:o} and {actual:o}, but was {actualDelta}");
-            Assert.AreEqual(expected.Kind, actual.Kind);
-        }
     }
 }

--- a/test/Renci.SshNet.IntegrationTests/Common/DateTimeAssert.cs
+++ b/test/Renci.SshNet.IntegrationTests/Common/DateTimeAssert.cs
@@ -7,5 +7,12 @@
             Assert.AreEqual(expected, actual, $"Expected {expected:o}, but was {actual:o}.");
             Assert.AreEqual(expected.Kind, actual.Kind);
         }
+
+        public static void AreEqual(DateTime expected, DateTime actual, TimeSpan maxDelta)
+        {
+            TimeSpan actualDelta = (expected - actual).Duration();
+            Assert.IsTrue(actualDelta <= maxDelta, $"Expected max delta of {maxDelta} between {expected:o} and {actual:o}, but was {actualDelta}");
+            Assert.AreEqual(expected.Kind, actual.Kind);
+        }
     }
 }

--- a/test/Renci.SshNet.IntegrationTests/SftpTests.cs
+++ b/test/Renci.SshNet.IntegrationTests/SftpTests.cs
@@ -6142,20 +6142,15 @@ namespace Renci.SshNet.IntegrationTests
             client.Connect();
 
             using var fileStream = new MemoryStream(Encoding.UTF8.GetBytes(testContent));
-            var currentTime = DateTime.Now;
 
             client.UploadFile(fileStream, testFilePath);
 
             try
             {
-                var time = client.GetLastAccessTime(testFilePath);
-
-                DateTimeAssert.AreEqual(currentTime.TruncateToWholeSeconds(), time, TimeSpan.FromSeconds(1));
-
                 var newTime = new DateTime(1986, 03, 15, 01, 02, 03, 123, DateTimeKind.Local);
 
                 client.SetLastAccessTime(testFilePath, newTime);
-                time = client.GetLastAccessTime(testFilePath);
+                var time = client.GetLastAccessTime(testFilePath);
 
                 DateTimeAssert.AreEqual(newTime.TruncateToWholeSeconds(), time);
             }
@@ -6175,19 +6170,14 @@ namespace Renci.SshNet.IntegrationTests
             client.Connect();
 
             using var fileStream = new MemoryStream(Encoding.UTF8.GetBytes(testContent));
-            var currentTime = DateTime.UtcNow;
 
             client.UploadFile(fileStream, testFilePath);
             try
             {
-                var time = client.GetLastAccessTimeUtc(testFilePath);
-
-                DateTimeAssert.AreEqual(currentTime.TruncateToWholeSeconds(), time, TimeSpan.FromSeconds(1));
-
                 var newTime = new DateTime(1986, 03, 15, 01, 02, 03, 123, DateTimeKind.Utc);
 
                 client.SetLastAccessTimeUtc(testFilePath, newTime);
-                time = client.GetLastAccessTimeUtc(testFilePath);
+                var time = client.GetLastAccessTimeUtc(testFilePath);
 
                 DateTimeAssert.AreEqual(newTime.TruncateToWholeSeconds(), time);
             }
@@ -6206,19 +6196,14 @@ namespace Renci.SshNet.IntegrationTests
             client.Connect();
 
             using var fileStream = new MemoryStream(Encoding.UTF8.GetBytes(testContent));
-            var currentTime = DateTime.Now;
 
             client.UploadFile(fileStream, testFilePath);
             try
             {
-                var time = client.GetLastWriteTime(testFilePath);
-
-                DateTimeAssert.AreEqual(currentTime.TruncateToWholeSeconds(), time, TimeSpan.FromSeconds(1));
-
                 var newTime = new DateTime(1986, 03, 15, 01, 02, 03, 123, DateTimeKind.Local);
 
                 client.SetLastWriteTime(testFilePath, newTime);
-                time = client.GetLastWriteTime(testFilePath);
+                var time = client.GetLastWriteTime(testFilePath);
 
                 DateTimeAssert.AreEqual(newTime.TruncateToWholeSeconds(), time);
             }

--- a/test/Renci.SshNet.IntegrationTests/SftpTests.cs
+++ b/test/Renci.SshNet.IntegrationTests/SftpTests.cs
@@ -6150,7 +6150,7 @@ namespace Renci.SshNet.IntegrationTests
             {
                 var time = client.GetLastAccessTime(testFilePath);
 
-                DateTimeAssert.AreEqual(currentTime.TruncateToWholeSeconds(), time);
+                DateTimeAssert.AreEqual(currentTime.TruncateToWholeSeconds(), time, TimeSpan.FromSeconds(1));
 
                 var newTime = new DateTime(1986, 03, 15, 01, 02, 03, 123, DateTimeKind.Local);
 
@@ -6182,7 +6182,7 @@ namespace Renci.SshNet.IntegrationTests
             {
                 var time = client.GetLastAccessTimeUtc(testFilePath);
 
-                DateTimeAssert.AreEqual(currentTime.TruncateToWholeSeconds(), time);
+                DateTimeAssert.AreEqual(currentTime.TruncateToWholeSeconds(), time, TimeSpan.FromSeconds(1));
 
                 var newTime = new DateTime(1986, 03, 15, 01, 02, 03, 123, DateTimeKind.Utc);
 
@@ -6213,7 +6213,7 @@ namespace Renci.SshNet.IntegrationTests
             {
                 var time = client.GetLastWriteTime(testFilePath);
 
-                DateTimeAssert.AreEqual(currentTime.TruncateToWholeSeconds(), time);
+                DateTimeAssert.AreEqual(currentTime.TruncateToWholeSeconds(), time, TimeSpan.FromSeconds(1));
 
                 var newTime = new DateTime(1986, 03, 15, 01, 02, 03, 123, DateTimeKind.Local);
 


### PR DESCRIPTION
These asserts currently assume that DateTime.Now and the creation timestamp on the server happen within the same second.

Note that I didn't change the asserts below where an explicit timestamp is set. From my understanding, these should not be affected.

example: https://ci.appveyor.com/project/drieseng/ssh-net/builds/49850731/job/u6lk0cyipbxkp4jd