### PR TITLE
fix build with .NET 9.0 SDK

### DIFF
--- a/test/Renci.SshNet.IntegrationTests/SftpTests.cs
+++ b/test/Renci.SshNet.IntegrationTests/SftpTests.cs
@@ -729,7 +729,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(expectedBytes.IsEqualTo(actualBytes));
                     }
                 }
@@ -810,7 +810,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(expectedBytes.IsEqualTo(actualBytes));
                     }
                 }
@@ -855,7 +855,8 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
+
                         Assert.IsTrue(expectedBytes.IsEqualTo(actualBytes));
                     }
                 }
@@ -935,7 +936,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(expectedBytes.IsEqualTo(actualBytes));
                     }
                 }
@@ -984,7 +985,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(expectedBytes.IsEqualTo(actualBytes));
                     }
                 }
@@ -1067,7 +1068,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(expectedBytes.IsEqualTo(actualBytes));
                     }
                 }
@@ -1114,7 +1115,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(initialContentBytes.IsEqualTo(actualBytes));
                     }
 
@@ -1131,7 +1132,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(expectedContentBytes.IsEqualTo(actualBytes));
                     }
                 }
@@ -1227,7 +1228,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(initialContentBytes.IsEqualTo(actualBytes));
                     }
                 }
@@ -1274,7 +1275,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(initialContentBytes.IsEqualTo(actualBytes));
                     }
 
@@ -1291,7 +1292,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(expectedContentBytes.IsEqualTo(actualBytes));
                     }
                 }
@@ -1389,7 +1390,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(initialContentBytes.IsEqualTo(actualBytes));
                     }
                 }
@@ -1556,7 +1557,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(linesBytes.IsEqualTo(actualBytes));
                     }
                 }
@@ -1648,7 +1649,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(linesBytes.IsEqualTo(actualBytes));
                     }
                 }
@@ -1736,7 +1737,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(expectedBytes.IsEqualTo(actualBytes));
                     }
                 }
@@ -1822,7 +1823,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(expectedBytes.IsEqualTo(actualBytes));
                     }
                 }
@@ -2168,7 +2169,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(content.IsEqualTo(actualBytes));
                     }
                 }
@@ -2261,7 +2262,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(expectedBytes1.IsEqualTo(actualBytes));
                     }
 
@@ -2274,7 +2275,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(expectedBytes2.IsEqualTo(actualBytes));
                     }
 
@@ -2315,7 +2316,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(linesToWriteBytes.IsEqualTo(actualBytes));
                     }
                 }
@@ -2407,7 +2408,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(expectedBytes1.IsEqualTo(actualBytes));
                     }
 
@@ -2420,7 +2421,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(expectedBytes2.IsEqualTo(actualBytes));
                     }
 
@@ -2461,7 +2462,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(linesToWriteBytes.IsEqualTo(actualBytes));
                     }
                 }
@@ -2549,7 +2550,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(expectedBytes1.IsEqualTo(actualBytes));
                     }
 
@@ -2562,7 +2563,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(expectedBytes2.IsEqualTo(actualBytes));
                     }
 
@@ -2603,7 +2604,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(linesToWriteBytes.IsEqualTo(actualBytes));
                     }
                 }
@@ -2693,7 +2694,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(expectedBytes1.IsEqualTo(actualBytes));
                     }
 
@@ -2706,7 +2707,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(expectedBytes2.IsEqualTo(actualBytes));
                     }
 
@@ -2747,7 +2748,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(linesToWriteBytes.IsEqualTo(actualBytes));
                     }
                 }
@@ -2836,7 +2837,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(expectedBytes1.IsEqualTo(actualBytes));
                     }
 
@@ -2849,7 +2850,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(expectedBytes2.IsEqualTo(actualBytes));
                     }
 
@@ -2891,7 +2892,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(initialContentBytes.IsEqualTo(actualBytes));
                     }
                 }
@@ -2980,7 +2981,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(expectedBytes1.IsEqualTo(actualBytes));
                     }
 
@@ -2993,7 +2994,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(expectedBytes2.IsEqualTo(actualBytes));
                     }
 
@@ -3035,7 +3036,7 @@ namespace Renci.SshNet.IntegrationTests
                     using (var fs = client.OpenRead(remoteFile))
                     {
                         var actualBytes = new byte[fs.Length];
-                        fs.Read(actualBytes, offset: 0, actualBytes.Length);
+                        _ = fs.Read(actualBytes, offset: 0, actualBytes.Length);
                         Assert.IsTrue(initialContentBytes.IsEqualTo(actualBytes));
                     }
                 }

--- a/test/Renci.SshNet.Tests/Classes/Messages/Connection/ChannelDataMessageTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Messages/Connection/ChannelDataMessageTest.cs
@@ -123,7 +123,7 @@ namespace Renci.SshNet.Tests.Classes.Messages.Connection
             Assert.AreEqual((uint)size, sshDataStream.ReadUInt32());
 
             var actualData = new byte[size];
-            sshDataStream.Read(actualData, 0, size);
+            _ = sshDataStream.Read(actualData, 0, size);
             Assert.IsTrue(actualData.SequenceEqual(data.Take(offset, size)));
 
             Assert.IsTrue(sshDataStream.IsEndOfData);

--- a/test/Renci.SshNet.Tests/Classes/Messages/Connection/ChannelOpen/ChannelOpenMessageTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Messages/Connection/ChannelOpen/ChannelOpenMessageTest.cs
@@ -102,7 +102,7 @@ namespace Renci.SshNet.Tests.Classes.Messages.Connection
             Assert.AreEqual((uint)target.ChannelType.Length, actualChannelTypeLength);
 
             var actualChannelType = new byte[actualChannelTypeLength];
-            sshDataStream.Read(actualChannelType, 0, (int)actualChannelTypeLength);
+            _ = sshDataStream.Read(actualChannelType, 0, (int)actualChannelTypeLength);
             Assert.IsTrue(target.ChannelType.SequenceEqual(actualChannelType));
 
             Assert.AreEqual(localChannelNumber, sshDataStream.ReadUInt32());
@@ -110,7 +110,7 @@ namespace Renci.SshNet.Tests.Classes.Messages.Connection
             Assert.AreEqual(maximumPacketSize, sshDataStream.ReadUInt32());
 
             var actualInfo = new byte[infoBytes.Length];
-            sshDataStream.Read(actualInfo, 0, actualInfo.Length);
+            _ = sshDataStream.Read(actualInfo, 0, actualInfo.Length);
             Assert.IsTrue(infoBytes.SequenceEqual(actualInfo));
 
             Assert.IsTrue(sshDataStream.IsEndOfData);

--- a/test/Renci.SshNet.Tests/Classes/Messages/Transport/IgnoreMessageTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Messages/Transport/IgnoreMessageTest.cs
@@ -74,7 +74,7 @@ namespace Renci.SshNet.Tests.Classes.Messages.Transport
             Assert.AreEqual((uint)_data.Length, sshDataStream.ReadUInt32());
 
             var actualData = new byte[_data.Length];
-            sshDataStream.Read(actualData, 0, actualData.Length);
+            _ = sshDataStream.Read(actualData, 0, actualData.Length);
             Assert.IsTrue(_data.SequenceEqual(actualData));
 
             Assert.IsTrue(sshDataStream.IsEndOfData);

--- a/test/Renci.SshNet.Tests/Classes/Security/Cryptography/RsaKeyTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Security/Cryptography/RsaKeyTest.cs
@@ -24,7 +24,11 @@ namespace Renci.SshNet.Tests.Classes.Security.Cryptography
         // This is just to line up any differences in the assertion message.
         private static void AssertEqual(byte[] actualBytes, string expectedHex)
         {
+#if NET
+            string actualHex = Convert.ToHexString(actualBytes);
+#else
             string actualHex = BitConverter.ToString(actualBytes).Replace("-", "");
+#endif
 
             Assert.AreEqual(expectedHex, actualHex,
                 $"{Environment.NewLine}Expected: {expectedHex}{Environment.NewLine}  Actual: {actualHex}");

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/ExtendedRequests/FStatVfsRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/ExtendedRequests/FStatVfsRequestTest.cs
@@ -110,13 +110,13 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests.ExtendedRequests
             Assert.AreEqual((uint)_nameBytes.Length, sshDataStream.ReadUInt32());
 
             var actualNameBytes = new byte[_nameBytes.Length];
-            sshDataStream.Read(actualNameBytes, 0, actualNameBytes.Length);
+            _ = sshDataStream.Read(actualNameBytes, 0, actualNameBytes.Length);
             Assert.IsTrue(_nameBytes.SequenceEqual(actualNameBytes));
 
             Assert.AreEqual((uint)_handle.Length, sshDataStream.ReadUInt32());
 
             var actualHandle = new byte[_handle.Length];
-            sshDataStream.Read(actualHandle, 0, actualHandle.Length);
+            _ = sshDataStream.Read(actualHandle, 0, actualHandle.Length);
             Assert.IsTrue(_handle.SequenceEqual(actualHandle));
 
             Assert.IsTrue(sshDataStream.IsEndOfData);

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/ExtendedRequests/HardLinkRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/ExtendedRequests/HardLinkRequestTest.cs
@@ -97,19 +97,19 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests.ExtendedRequests
             Assert.AreEqual((uint)_nameBytes.Length, sshDataStream.ReadUInt32());
 
             var actualNameBytes = new byte[_nameBytes.Length];
-            sshDataStream.Read(actualNameBytes, 0, actualNameBytes.Length);
+            _ = sshDataStream.Read(actualNameBytes, 0, actualNameBytes.Length);
             Assert.IsTrue(_nameBytes.SequenceEqual(actualNameBytes));
 
             Assert.AreEqual((uint)_oldPathBytes.Length, sshDataStream.ReadUInt32());
 
             var actualOldPath = new byte[_oldPathBytes.Length];
-            sshDataStream.Read(actualOldPath, 0, actualOldPath.Length);
+            _ = sshDataStream.Read(actualOldPath, 0, actualOldPath.Length);
             Assert.IsTrue(_oldPathBytes.SequenceEqual(actualOldPath));
 
             Assert.AreEqual((uint)_newPathBytes.Length, sshDataStream.ReadUInt32());
 
             var actualNewPath = new byte[_newPathBytes.Length];
-            sshDataStream.Read(actualNewPath, 0, actualNewPath.Length);
+            _ = sshDataStream.Read(actualNewPath, 0, actualNewPath.Length);
             Assert.IsTrue(_newPathBytes.SequenceEqual(actualNewPath));
 
             Assert.IsTrue(sshDataStream.IsEndOfData);

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/ExtendedRequests/PosixRenameRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/ExtendedRequests/PosixRenameRequestTest.cs
@@ -101,19 +101,19 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests.ExtendedRequests
             Assert.AreEqual((uint)_nameBytes.Length, sshDataStream.ReadUInt32());
 
             var actualNameBytes = new byte[_nameBytes.Length];
-            sshDataStream.Read(actualNameBytes, 0, actualNameBytes.Length);
+            _ = sshDataStream.Read(actualNameBytes, 0, actualNameBytes.Length);
             Assert.IsTrue(_nameBytes.SequenceEqual(actualNameBytes));
 
             Assert.AreEqual((uint)_oldPathBytes.Length, sshDataStream.ReadUInt32());
 
             var actualOldPath = new byte[_oldPathBytes.Length];
-            sshDataStream.Read(actualOldPath, 0, actualOldPath.Length);
+            _ = sshDataStream.Read(actualOldPath, 0, actualOldPath.Length);
             Assert.IsTrue(_oldPathBytes.SequenceEqual(actualOldPath));
 
             Assert.AreEqual((uint)_newPathBytes.Length, sshDataStream.ReadUInt32());
 
             var actualNewPath = new byte[_newPathBytes.Length];
-            sshDataStream.Read(actualNewPath, 0, actualNewPath.Length);
+            _ = sshDataStream.Read(actualNewPath, 0, actualNewPath.Length);
             Assert.IsTrue(_newPathBytes.SequenceEqual(actualNewPath));
 
             Assert.IsTrue(sshDataStream.IsEndOfData);

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/ExtendedRequests/StatVfsRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/ExtendedRequests/StatVfsRequestTest.cs
@@ -116,13 +116,13 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests.ExtendedRequests
             Assert.AreEqual((uint)_nameBytes.Length, sshDataStream.ReadUInt32());
 
             var actualNameBytes = new byte[_nameBytes.Length];
-            sshDataStream.Read(actualNameBytes, 0, actualNameBytes.Length);
+            _ = sshDataStream.Read(actualNameBytes, 0, actualNameBytes.Length);
             Assert.IsTrue(_nameBytes.SequenceEqual(actualNameBytes));
 
             Assert.AreEqual((uint)_pathBytes.Length, sshDataStream.ReadUInt32());
 
             var actualPath = new byte[_pathBytes.Length];
-            sshDataStream.Read(actualPath, 0, actualPath.Length);
+            _ = sshDataStream.Read(actualPath, 0, actualPath.Length);
             Assert.IsTrue(_pathBytes.SequenceEqual(actualPath));
 
             Assert.IsTrue(sshDataStream.IsEndOfData);

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpBlockRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpBlockRequestTest.cs
@@ -92,7 +92,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             Assert.AreEqual((uint)_handle.Length, sshDataStream.ReadUInt32());
             var actualHandle = new byte[_handle.Length];
-            sshDataStream.Read(actualHandle, 0, actualHandle.Length);
+            _ = sshDataStream.Read(actualHandle, 0, actualHandle.Length);
             Assert.IsTrue(_handle.SequenceEqual(actualHandle));
 
             Assert.AreEqual(_offset, sshDataStream.ReadUInt64());

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpCloseRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpCloseRequestTest.cs
@@ -80,7 +80,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             Assert.AreEqual((uint)_handle.Length, sshDataStream.ReadUInt32());
             var actualHandle = new byte[_handle.Length];
-            sshDataStream.Read(actualHandle, 0, actualHandle.Length);
+            _ = sshDataStream.Read(actualHandle, 0, actualHandle.Length);
             Assert.IsTrue(_handle.SequenceEqual(actualHandle));
 
             Assert.IsTrue(sshDataStream.IsEndOfData);

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpFSetStatRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpFSetStatRequestTest.cs
@@ -85,11 +85,11 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             Assert.AreEqual((uint)_handle.Length, sshDataStream.ReadUInt32());
             var actualHandle = new byte[_handle.Length];
-            sshDataStream.Read(actualHandle, 0, actualHandle.Length);
+            _ = sshDataStream.Read(actualHandle, 0, actualHandle.Length);
             Assert.IsTrue(_handle.SequenceEqual(actualHandle));
 
             var actualAttributes = new byte[_attributesBytes.Length];
-            sshDataStream.Read(actualAttributes, 0, actualAttributes.Length);
+            _ = sshDataStream.Read(actualAttributes, 0, actualAttributes.Length);
             Assert.IsTrue(_attributesBytes.SequenceEqual(actualAttributes));
 
             Assert.IsTrue(sshDataStream.IsEndOfData);

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpFStatRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpFStatRequestTest.cs
@@ -102,7 +102,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             Assert.AreEqual((uint)_handle.Length, sshDataStream.ReadUInt32());
             var actualHandle = new byte[_handle.Length];
-            sshDataStream.Read(actualHandle, 0, actualHandle.Length);
+            _ = sshDataStream.Read(actualHandle, 0, actualHandle.Length);
             Assert.IsTrue(_handle.SequenceEqual(actualHandle));
 
             Assert.IsTrue(sshDataStream.IsEndOfData);

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpLStatRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpLStatRequestTest.cs
@@ -108,7 +108,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             Assert.AreEqual((uint)_pathBytes.Length, sshDataStream.ReadUInt32());
             var actualPath = new byte[_pathBytes.Length];
-            sshDataStream.Read(actualPath, 0, actualPath.Length);
+            _ = sshDataStream.Read(actualPath, 0, actualPath.Length);
             Assert.IsTrue(_pathBytes.SequenceEqual(actualPath));
 
             Assert.IsTrue(sshDataStream.IsEndOfData);

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpLinkRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpLinkRequestTest.cs
@@ -96,12 +96,12 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             Assert.AreEqual((uint)_newLinkPathBytes.Length, sshDataStream.ReadUInt32());
             var actualNewLinkPath = new byte[_newLinkPathBytes.Length];
-            sshDataStream.Read(actualNewLinkPath, 0, actualNewLinkPath.Length);
+            _ = sshDataStream.Read(actualNewLinkPath, 0, actualNewLinkPath.Length);
             Assert.IsTrue(_newLinkPathBytes.SequenceEqual(actualNewLinkPath));
 
             Assert.AreEqual((uint)_existingPathBytes.Length, sshDataStream.ReadUInt32());
             var actualExistingPath = new byte[_existingPathBytes.Length];
-            sshDataStream.Read(actualExistingPath, 0, actualExistingPath.Length);
+            _ = sshDataStream.Read(actualExistingPath, 0, actualExistingPath.Length);
             Assert.IsTrue(_existingPathBytes.SequenceEqual(actualExistingPath));
 
             Assert.AreEqual(1, sshDataStream.ReadByte());

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpMkDirRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpMkDirRequestTest.cs
@@ -91,11 +91,11 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             Assert.AreEqual((uint)_pathBytes.Length, sshDataStream.ReadUInt32());
             var actualPath = new byte[_pathBytes.Length];
-            sshDataStream.Read(actualPath, 0, actualPath.Length);
+            _ = sshDataStream.Read(actualPath, 0, actualPath.Length);
             Assert.IsTrue(_pathBytes.SequenceEqual(actualPath));
 
             var actualAttributes = new byte[_attributesBytes.Length];
-            sshDataStream.Read(actualAttributes, 0, actualAttributes.Length);
+            _ = sshDataStream.Read(actualAttributes, 0, actualAttributes.Length);
             Assert.IsTrue(_attributesBytes.SequenceEqual(actualAttributes));
 
             Assert.IsTrue(sshDataStream.IsEndOfData);

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpOpenDirRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpOpenDirRequestTest.cs
@@ -108,7 +108,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             Assert.AreEqual((uint)_pathBytes.Length, sshDataStream.ReadUInt32());
             var actualPath = new byte[_pathBytes.Length];
-            sshDataStream.Read(actualPath, 0, actualPath.Length);
+            _ = sshDataStream.Read(actualPath, 0, actualPath.Length);
             Assert.IsTrue(_pathBytes.SequenceEqual(actualPath));
 
             Assert.IsTrue(sshDataStream.IsEndOfData);

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpOpenRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpOpenRequestTest.cs
@@ -130,13 +130,13 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             Assert.AreEqual((uint)_filenameBytes.Length, sshDataStream.ReadUInt32());
             var actualPath = new byte[_filenameBytes.Length];
-            sshDataStream.Read(actualPath, 0, actualPath.Length);
+            _ = sshDataStream.Read(actualPath, 0, actualPath.Length);
             Assert.IsTrue(_filenameBytes.SequenceEqual(actualPath));
 
             Assert.AreEqual((uint)_flags, sshDataStream.ReadUInt32());
 
             var actualAttributes = new byte[_attributesBytes.Length];
-            sshDataStream.Read(actualAttributes, 0, actualAttributes.Length);
+            _ = sshDataStream.Read(actualAttributes, 0, actualAttributes.Length);
             Assert.IsTrue(_attributesBytes.SequenceEqual(actualAttributes));
 
             Assert.IsTrue(sshDataStream.IsEndOfData);

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpReadDirRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpReadDirRequestTest.cs
@@ -103,7 +103,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             Assert.AreEqual((uint)_handle.Length, sshDataStream.ReadUInt32());
             var actualHandle = new byte[_handle.Length];
-            sshDataStream.Read(actualHandle, 0, actualHandle.Length);
+            _ = sshDataStream.Read(actualHandle, 0, actualHandle.Length);
             Assert.IsTrue(_handle.SequenceEqual(actualHandle));
 
             Assert.IsTrue(sshDataStream.IsEndOfData);

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpReadLinkRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpReadLinkRequestTest.cs
@@ -120,7 +120,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             Assert.AreEqual((uint)_pathBytes.Length, sshDataStream.ReadUInt32());
             var actualPath = new byte[_pathBytes.Length];
-            sshDataStream.Read(actualPath, 0, actualPath.Length);
+            _ = sshDataStream.Read(actualPath, 0, actualPath.Length);
             Assert.IsTrue(_pathBytes.SequenceEqual(actualPath));
 
             Assert.IsTrue(sshDataStream.IsEndOfData);

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpReadRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpReadRequestTest.cs
@@ -124,7 +124,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             Assert.AreEqual((uint)_handle.Length, sshDataStream.ReadUInt32());
             var actualHandle = new byte[_handle.Length];
-            sshDataStream.Read(actualHandle, 0, actualHandle.Length);
+            _ = sshDataStream.Read(actualHandle, 0, actualHandle.Length);
             Assert.IsTrue(_handle.SequenceEqual(actualHandle));
 
             Assert.AreEqual(_offset, sshDataStream.ReadUInt64());

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpRealPathRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpRealPathRequestTest.cs
@@ -136,7 +136,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             Assert.AreEqual((uint)_pathBytes.Length, sshDataStream.ReadUInt32());
             var actualPath = new byte[_pathBytes.Length];
-            sshDataStream.Read(actualPath, 0, actualPath.Length);
+            _ = sshDataStream.Read(actualPath, 0, actualPath.Length);
             Assert.IsTrue(_pathBytes.SequenceEqual(actualPath));
 
             Assert.IsTrue(sshDataStream.IsEndOfData);

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpRemoveRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpRemoveRequestTest.cs
@@ -86,7 +86,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             Assert.AreEqual((uint)_filenameBytes.Length, sshDataStream.ReadUInt32());
             var actualFilename = new byte[_filenameBytes.Length];
-            sshDataStream.Read(actualFilename, 0, actualFilename.Length);
+            _ = sshDataStream.Read(actualFilename, 0, actualFilename.Length);
             Assert.IsTrue(_filenameBytes.SequenceEqual(actualFilename));
 
             Assert.IsTrue(sshDataStream.IsEndOfData);

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpRenameRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpRenameRequestTest.cs
@@ -93,12 +93,12 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             Assert.AreEqual((uint)_oldPathBytes.Length, sshDataStream.ReadUInt32());
             var actualOldPath = new byte[_oldPathBytes.Length];
-            sshDataStream.Read(actualOldPath, 0, actualOldPath.Length);
+            _ = sshDataStream.Read(actualOldPath, 0, actualOldPath.Length);
             Assert.IsTrue(_oldPathBytes.SequenceEqual(actualOldPath));
 
             Assert.AreEqual((uint)_newPathBytes.Length, sshDataStream.ReadUInt32());
             var actualNewPath = new byte[_newPathBytes.Length];
-            sshDataStream.Read(actualNewPath, 0, actualNewPath.Length);
+            _ = sshDataStream.Read(actualNewPath, 0, actualNewPath.Length);
             Assert.IsTrue(_newPathBytes.SequenceEqual(actualNewPath));
 
             Assert.IsTrue(sshDataStream.IsEndOfData);

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpSetStatRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpSetStatRequestTest.cs
@@ -96,11 +96,11 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             Assert.AreEqual((uint)_pathBytes.Length, sshDataStream.ReadUInt32());
             var actualPath = new byte[_pathBytes.Length];
-            sshDataStream.Read(actualPath, 0, actualPath.Length);
+            _ = sshDataStream.Read(actualPath, 0, actualPath.Length);
             Assert.IsTrue(_pathBytes.SequenceEqual(actualPath));
 
             var actualAttributes = new byte[_attributesBytes.Length];
-            sshDataStream.Read(actualAttributes, 0, actualAttributes.Length);
+            _ = sshDataStream.Read(actualAttributes, 0, actualAttributes.Length);
             Assert.IsTrue(_attributesBytes.SequenceEqual(actualAttributes));
 
             Assert.IsTrue(sshDataStream.IsEndOfData);

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpStatRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpStatRequestTest.cs
@@ -106,7 +106,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             Assert.AreEqual((uint)_pathBytes.Length, sshDataStream.ReadUInt32());
             var actualPath = new byte[_pathBytes.Length];
-            sshDataStream.Read(actualPath, 0, actualPath.Length);
+            _ = sshDataStream.Read(actualPath, 0, actualPath.Length);
             Assert.IsTrue(_pathBytes.SequenceEqual(actualPath));
 
             Assert.IsTrue(sshDataStream.IsEndOfData);

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpSymLinkRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpSymLinkRequestTest.cs
@@ -111,12 +111,12 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             Assert.AreEqual((uint)_newLinkPathBytes.Length, sshDataStream.ReadUInt32());
             var actualNewLinkPath = new byte[_newLinkPathBytes.Length];
-            sshDataStream.Read(actualNewLinkPath, 0, actualNewLinkPath.Length);
+            _ = sshDataStream.Read(actualNewLinkPath, 0, actualNewLinkPath.Length);
             Assert.IsTrue(_newLinkPathBytes.SequenceEqual(actualNewLinkPath));
 
             Assert.AreEqual((uint)_existingPathBytes.Length, sshDataStream.ReadUInt32());
             var actualExistingPath = new byte[_existingPathBytes.Length];
-            sshDataStream.Read(actualExistingPath, 0, actualExistingPath.Length);
+            _ = sshDataStream.Read(actualExistingPath, 0, actualExistingPath.Length);
             Assert.IsTrue(_existingPathBytes.SequenceEqual(actualExistingPath));
 
             Assert.IsTrue(sshDataStream.IsEndOfData);

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpWriteRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpWriteRequestTest.cs
@@ -103,14 +103,14 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             Assert.AreEqual((uint)_handle.Length, sshDataStream.ReadUInt32());
             var actualHandle = new byte[_handle.Length];
-            sshDataStream.Read(actualHandle, 0, actualHandle.Length);
+            _ = sshDataStream.Read(actualHandle, 0, actualHandle.Length);
             Assert.IsTrue(_handle.SequenceEqual(actualHandle));
 
             Assert.AreEqual(_serverFileOffset, sshDataStream.ReadUInt64());
 
             Assert.AreEqual((uint)_length, sshDataStream.ReadUInt32());
             var actualData = new byte[_length];
-            sshDataStream.Read(actualData, 0, actualData.Length);
+            _ = sshDataStream.Read(actualData, 0, actualData.Length);
             Assert.IsTrue(_data.Take(_offset, _length).SequenceEqual(actualData));
 
             Assert.IsTrue(sshDataStream.IsEndOfData);

--- a/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_Ctor_FileModeCreateNew_FileAccessWrite.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_Ctor_FileModeCreateNew_FileAccessWrite.cs
@@ -104,7 +104,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp
 
             try
             {
-                _target.Read(buffer, 0, buffer.Length);
+                _ = _target.Read(buffer, 0, buffer.Length);
                 Assert.Fail();
             }
             catch (NotSupportedException ex)

--- a/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_Ctor_FileModeCreate_FileAccessWrite_FileDoesNotExist.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_Ctor_FileModeCreate_FileAccessWrite_FileDoesNotExist.cs
@@ -107,7 +107,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp
 
             try
             {
-                _target.Read(buffer, 0, buffer.Length);
+                _ = _target.Read(buffer, 0, buffer.Length);
                 Assert.Fail();
             }
             catch (NotSupportedException ex)

--- a/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_Ctor_FileModeCreate_FileAccessWrite_FileExists.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_Ctor_FileModeCreate_FileAccessWrite_FileExists.cs
@@ -104,7 +104,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp
 
             try
             {
-                _target.Read(buffer, 0, buffer.Length);
+                _ = _target.Read(buffer, 0, buffer.Length);
                 Assert.Fail();
             }
             catch (NotSupportedException ex)

--- a/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_Ctor_FileModeOpenOrCreate_FileAccessWrite.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_Ctor_FileModeOpenOrCreate_FileAccessWrite.cs
@@ -104,7 +104,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp
 
             try
             {
-                _target.Read(buffer, 0, buffer.Length);
+                _ = _target.Read(buffer, 0, buffer.Length);
                 Assert.Fail();
             }
             catch (NotSupportedException ex)

--- a/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_Ctor_FileModeOpen_FileAccessWrite.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_Ctor_FileModeOpen_FileAccessWrite.cs
@@ -104,7 +104,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp
 
             try
             {
-                _target.Read(buffer, 0, buffer.Length);
+                _ = _target.Read(buffer, 0, buffer.Length);
                 Assert.Fail();
             }
             catch (NotSupportedException ex)

--- a/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_Ctor_FileModeTruncate_FileAccessWrite.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_Ctor_FileModeTruncate_FileAccessWrite.cs
@@ -104,7 +104,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp
 
             try
             {
-                _target.Read(buffer, 0, buffer.Length);
+                _ = _target.Read(buffer, 0, buffer.Length);
                 Assert.Fail();
             }
             catch (NotSupportedException ex)

--- a/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_OpenAsync_FileModeCreate_FileAccessWrite_FileDoesNotExist.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_OpenAsync_FileModeCreate_FileAccessWrite_FileDoesNotExist.cs
@@ -103,7 +103,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp
 
             try
             {
-                await _target.ReadAsync(buffer, 0, buffer.Length);
+                _ = await _target.ReadAsync(buffer, 0, buffer.Length);
                 Assert.Fail();
             }
             catch (NotSupportedException ex)

--- a/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_OpenAsync_FileModeOpenOrCreate_FileAccessWrite.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_OpenAsync_FileModeOpenOrCreate_FileAccessWrite.cs
@@ -103,7 +103,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp
 
             try
             {
-                await _target.ReadAsync(buffer, 0, buffer.Length);
+                _ = await _target.ReadAsync(buffer, 0, buffer.Length);
                 Assert.Fail();
             }
             catch (NotSupportedException ex)

--- a/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_OpenAsync_FileModeOpen_FileAccessWrite.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_OpenAsync_FileModeOpen_FileAccessWrite.cs
@@ -103,7 +103,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp
 
             try
             {
-                await _target.ReadAsync(buffer, 0, buffer.Length);
+                _ = await _target.ReadAsync(buffer, 0, buffer.Length);
                 Assert.Fail();
             }
             catch (NotSupportedException ex)

--- a/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_OpenAsync_FileModeTruncate_FileAccessWrite.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_OpenAsync_FileModeTruncate_FileAccessWrite.cs
@@ -103,7 +103,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp
 
             try
             {
-                await _target.ReadAsync(buffer, 0, buffer.Length);
+                _ = await _target.ReadAsync(buffer, 0, buffer.Length);
                 Assert.Fail();
             }
             catch (NotSupportedException ex)

--- a/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_ReadAsync_ReadMode_NoDataInReaderBufferAndReadLessBytesFromServerThanCountAndLessThanBufferSize.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_ReadAsync_ReadMode_NoDataInReaderBufferAndReadLessBytesFromServerThanCountAndLessThanBufferSize.cs
@@ -142,7 +142,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp
                 .ReturnsAsync(Array.Empty<byte>());
             SftpSessionMock.InSequence(MockSequence).Setup(p => p.IsOpen).Returns(true);
 
-            await _target.ReadAsync(new byte[10], 0, 10);
+            _ = await _target.ReadAsync(new byte[10], 0, 10);
 
             Assert.AreEqual(_actual, _target.Position);
 

--- a/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_Read_ReadMode_NoDataInReaderBufferAndReadLessBytesFromServerThanCountAndLessThanBufferSize.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_Read_ReadMode_NoDataInReaderBufferAndReadLessBytesFromServerThanCountAndLessThanBufferSize.cs
@@ -140,7 +140,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp
                 .Returns(Array.Empty<byte>());
             SftpSessionMock.InSequence(MockSequence).Setup(p => p.IsOpen).Returns(true);
 
-            _target.Read(new byte[10], 0, 10);
+            _ = _target.Read(new byte[10], 0, 10);
 
             Assert.AreEqual(_actual, _target.Position);
 

--- a/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_Seek_PositionedAtMiddleOfStream_OriginBeginAndOffsetZero_NoBuffering.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_Seek_PositionedAtMiddleOfStream_OriginBeginAndOffsetZero_NoBuffering.cs
@@ -68,7 +68,8 @@ namespace Renci.SshNet.Tests.Classes.Sftp
             base.Arrange();
 
             _target = new SftpFileStream(SftpSessionMock.Object, _path, _fileMode, _fileAccess, _bufferSize);
-            _target.Read(_buffer, 0, _buffer.Length);
+            int readBytesCount = _target.Read(_buffer, 0, _buffer.Length);
+            Assert.AreEqual(_buffer.Length, readBytesCount);
         }
 
         protected override void Act()

--- a/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_Seek_PositionedAtMiddleOfStream_OriginBeginAndOffsetZero_ReadBuffer.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_Seek_PositionedAtMiddleOfStream_OriginBeginAndOffsetZero_ReadBuffer.cs
@@ -71,7 +71,8 @@ namespace Renci.SshNet.Tests.Classes.Sftp
             base.Arrange();
 
             _target = new SftpFileStream(SftpSessionMock.Object, _path, _fileMode, _fileAccess, _bufferSize);
-            _target.Read(_buffer, 0, _buffer.Length);
+            int readBytesCount = _target.Read(_buffer, 0, _buffer.Length);
+            Assert.AreEqual(_buffer.Length, readBytesCount);
         }
 
         protected override void Act()

--- a/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_SetLength_DataInReadBuffer_NewLengthGreatherThanPosition.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_SetLength_DataInReadBuffer_NewLengthGreatherThanPosition.cs
@@ -107,8 +107,10 @@ namespace Renci.SshNet.Tests.Classes.Sftp
                                                  FileMode.Open,
                                                  FileAccess.ReadWrite,
                                                  (int)_bufferSize);
-            _sftpFileStream.Read(_readBytes1, 0, _readBytes1.Length);
-            _sftpFileStream.Read(_readBytes2, 0, _readBytes2.Length); // this will return bytes from the buffer
+            int readBytesCount1 = _sftpFileStream.Read(_readBytes1, 0, _readBytes1.Length);
+            Assert.AreEqual(_readBytes1.Length, readBytesCount1);
+            int readBytesCount2 = _sftpFileStream.Read(_readBytes2, 0, _readBytes2.Length); // this will return bytes from the buffer
+            Assert.AreEqual(_readBytes2.Length, readBytesCount2);
         }
 
         protected override void Act()

--- a/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_SetLength_DataInReadBuffer_NewLengthLessThanPosition.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_SetLength_DataInReadBuffer_NewLengthLessThanPosition.cs
@@ -97,7 +97,8 @@ namespace Renci.SshNet.Tests.Classes.Sftp
             base.Arrange();
 
             _sftpFileStream = new SftpFileStream(SftpSessionMock.Object, _path, FileMode.Open, FileAccess.ReadWrite, (int)_bufferSize);
-            _sftpFileStream.Read(_readBytes, 0, _readBytes.Length);
+            int readBytesCount = _sftpFileStream.Read(_readBytes, 0, _readBytes.Length);
+            Assert.AreEqual(_readBytes.Length, readBytesCount);
         }
 
         protected override void Act()

--- a/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_SetLength_DataInWriteBuffer_NewLengthGreatherThanPosition.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_SetLength_DataInWriteBuffer_NewLengthGreatherThanPosition.cs
@@ -112,7 +112,8 @@ namespace Renci.SshNet.Tests.Classes.Sftp
             base.Arrange();
 
             _sftpFileStream = new SftpFileStream(SftpSessionMock.Object, _path, FileMode.Open, FileAccess.ReadWrite, (int)_bufferSize);
-            _sftpFileStream.Read(_readBytes, 0, _readBytes.Length);
+            int readBytesCount = _sftpFileStream.Read(_readBytes, 0, _readBytes.Length);
+            Assert.AreEqual(_readBytes.Length, readBytesCount);
             _sftpFileStream.Write(new byte[] { 0x01, 0x02, 0x03, 0x04 }, 0, 4);
         }
 

--- a/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_SetLength_DataInWriteBuffer_NewLengthLessThanPosition.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest_SetLength_DataInWriteBuffer_NewLengthLessThanPosition.cs
@@ -112,7 +112,8 @@ namespace Renci.SshNet.Tests.Classes.Sftp
             base.Arrange();
 
             _sftpFileStream = new SftpFileStream(SftpSessionMock.Object, _path, FileMode.Open, FileAccess.ReadWrite, (int)_bufferSize);
-            _sftpFileStream.Read(_readBytes, 0, _readBytes.Length);
+            int readBytesCount = _sftpFileStream.Read(_readBytes, 0, _readBytes.Length);
+            Assert.AreEqual(_readBytes.Length, readBytesCount);
             _sftpFileStream.Write(new byte[] { 0x01, 0x02, 0x03, 0x04 }, 0, 4);
         }
 


### PR DESCRIPTION
SSH.NET is currently not buildable with .NET 9 because of newly introduced warnings CA1872 and CA2022, see separate commits.