### PR TITLE
Docs updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,36 +6,65 @@ SSH.NET is a Secure Shell (SSH-2) library for .NET, optimized for parallelism.
 [![NuGet download count](https://img.shields.io/nuget/dt/SSH.NET.svg)](https://www.nuget.org/packages/SSH.NET)
 [![Build status](https://ci.appveyor.com/api/projects/status/ih77qu6tap3o92gu/branch/develop?svg=true)](https://ci.appveyor.com/api/projects/status/ih77qu6tap3o92gu/branch/develop)
 
-## Introduction
-
-This project was inspired by **Sharp.SSH** library which was ported from java and it seems like was not supported
-for quite some time. This library is a complete rewrite, without any third party dependencies, using parallelism
-to achieve the best performance possible.
-
-## Documentation
-
-Documentation is hosted at https://sshnet.github.io/SSH.NET/. Currently (4/18/2020), the documentation is very sparse.
-Fortunately, there are a large number of [tests](https://github.com/sshnet/SSH.NET/tree/develop/test/) that demonstrate usage with working code.
-If the test for the functionality you would like to see documented is not complete, then you are cordially
-invited to read the source, Luke, and highly encouraged to generate a pull request for the implementation of
-the missing test once you figure things out.  🤓
-
-## Features
+## Key Features
 
 * Execution of SSH command using both synchronous and asynchronous methods
-* Return command execution exit status and other information 
-* Provide SFTP functionality for both synchronous and asynchronous operations
-* Provides SCP functionality
-* Provide status report for upload and download sftp operations to allow accurate progress bar implementation 
+* SFTP functionality for both synchronous and asynchronous operations
+* SCP functionality
 * Remote, dynamic and local port forwarding 
-* Shell/Terminal implementation
-* Specify key file pass phrase
-* Use multiple key files to authenticate
-* Supports publickey, password and keyboard-interactive authentication methods 
-* Supports two-factor or higher authentication
-* Supports SOCKS4, SOCKS5 and HTTP Proxy
+* Interactive shell/terminal implementation
+* Authentication via publickey, password and keyboard-interactive methods, including multi-factor
+* Connection via SOCKS4, SOCKS5 or HTTP proxy
 
-## Encryption Method
+## How to Use
+
+### Run a command
+
+```cs
+using (var client = new SshClient("sftp.foo.com", "guest", new PrivateKeyFile("path/to/my/key")))
+{
+    client.Connect();
+    using SshCommand cmd = client.RunCommand("echo 'Hello World!'");
+    Console.WriteLine(cmd.Result); // "Hello World!\n"
+}
+```
+
+### Upload and list files using SFTP
+
+```cs
+using (var client = new SftpClient("sftp.foo.com", "guest", "pwd"))
+{
+    client.Connect();
+
+    using (FileStream fs = File.OpenRead(@"C:\tmp\test-file.txt"))
+    {
+        client.UploadFile(fs, "/home/guest/test-file.txt");
+    }
+
+    foreach (ISftpFile file in client.ListDirectory("/home/guest/"))
+    {
+        Console.WriteLine($"{file.FullName} {file.LastWriteTime}");
+    }
+}
+```
+
+## Main Types
+
+The main types provided by this library are:
+
+* Renci.SshNet.SshClient
+* Renci.SshNet.SftpClient
+* Renci.SshNet.ScpClient
+* Renci.SshNet.PrivateKeyFile
+* Renci.SshNet.SshCommand
+* Renci.SshNet.ShellStream
+
+## Additional Documentation
+
+* [Further examples](https://sshnet.github.io/SSH.NET/examples.html)
+* [API browser](https://sshnet.github.io/SSH.NET/api/Renci.SshNet.html)
+
+## Encryption Methods
 
 **SSH.NET** supports the following encryption methods:
 * aes128-ctr
@@ -57,7 +86,7 @@ the missing test once you figure things out.  🤓
 * arcfour256
 * cast128-cbc
 
-## Key Exchange Method
+## Key Exchange Methods
 
 **SSH.NET** supports the following key exchange methods:
 * curve25519-sha256
@@ -130,41 +159,6 @@ Private keys can be encrypted using one of the following cipher methods:
 * .NETFramework 4.6.2 (and higher)
 * .NET Standard 2.0 and 2.1
 * .NET 6 (and higher)
-
-## Usage
-
-### Multi-factor authentication
-
-Establish a SFTP connection using both password and public-key authentication:
-
-```cs
-var connectionInfo = new ConnectionInfo("sftp.foo.com",
-                                        "guest",
-                                        new PasswordAuthenticationMethod("guest", "pwd"),
-                                        new PrivateKeyAuthenticationMethod("rsa.key"));
-using (var client = new SftpClient(connectionInfo))
-{
-    client.Connect();
-}
-
-```
-
-### Verify host identify
-
-Establish a SSH connection using user name and password, and reject the connection if the fingerprint of the server does not match the expected fingerprint:
-
-```cs
-string expectedFingerPrint = "LKOy5LvmtEe17S4lyxVXqvs7uPMy+yF79MQpHeCs/Qo";
-
-using (var client = new SshClient("sftp.foo.com", "guest", "pwd"))
-{
-    client.HostKeyReceived += (sender, e) =>
-        {
-            e.CanTrust = expectedFingerPrint.Equals(e.FingerPrintSHA256);
-        };
-    client.Connect();
-}
-```
 
 ## Building the library
 

--- a/docfx/examples.md
+++ b/docfx/examples.md
@@ -5,8 +5,6 @@ Getting Started
 
 ### Run a command
 
-Establish an SSH connection and run a command:
-
 ```cs
 using (var client = new SshClient("sftp.foo.com", "guest", new PrivateKeyFile("path/to/my/key")))
 {
@@ -16,9 +14,7 @@ using (var client = new SshClient("sftp.foo.com", "guest", new PrivateKeyFile("p
 }
 ```
 
-### Upload and list files
-
-SFTP Connection / Exchange 
+### Upload and list files using SFTP
 
 ```cs
 using (var client = new SftpClient("sftp.foo.com", "guest", "pwd"))
@@ -39,7 +35,7 @@ using (var client = new SftpClient("sftp.foo.com", "guest", "pwd"))
 
 ### Multi-factor authentication
 
-Establish an SFTP connection using both password and public-key authentication:
+Establish a connection using both password and public-key authentication:
 
 ```cs
 var connectionInfo = new ConnectionInfo("sftp.foo.com",
@@ -54,7 +50,7 @@ using (var client = new SftpClient(connectionInfo))
 
 ### Verify host identify
 
-Establish an SSH connection using user name and password, and reject the connection if the fingerprint of the server does not match the expected fingerprint:
+Establish a connection using user name and password, and reject the connection if the fingerprint of the server does not match the expected fingerprint:
 
 ```cs
 string expectedFingerPrint = "LKOy5LvmtEe17S4lyxVXqvs7uPMy+yF79MQpHeCs/Qo";

--- a/src/Renci.SshNet/Common/AsyncResult.cs
+++ b/src/Renci.SshNet/Common/AsyncResult.cs
@@ -92,9 +92,9 @@ namespace Renci.SshNet.Common
         /// <summary>
         /// Gets a user-defined object that qualifies or contains information about an asynchronous operation.
         /// </summary>
-        /// <returns>
+        /// <value>
         /// A user-defined object that qualifies or contains information about an asynchronous operation.
-        /// </returns>
+        /// </value>
         public object AsyncState
         {
             get { return _asyncState; }
@@ -103,9 +103,9 @@ namespace Renci.SshNet.Common
         /// <summary>
         /// Gets a value indicating whether the asynchronous operation completed synchronously.
         /// </summary>
-        /// <returns>
+        /// <value>
         /// <see langword="true"/> if the asynchronous operation completed synchronously; otherwise, <see langword="false"/>.
-        /// </returns>
+        /// </value>
         public bool CompletedSynchronously
         {
             get { return _completedState == StateCompletedSynchronously; }
@@ -114,9 +114,9 @@ namespace Renci.SshNet.Common
         /// <summary>
         /// Gets a <see cref="WaitHandle"/> that is used to wait for an asynchronous operation to complete.
         /// </summary>
-        /// <returns>
+        /// <value>
         /// A <see cref="WaitHandle"/> that is used to wait for an asynchronous operation to complete.
-        /// </returns>
+        /// </value>
         public WaitHandle AsyncWaitHandle
         {
             get
@@ -147,9 +147,9 @@ namespace Renci.SshNet.Common
         /// <summary>
         /// Gets a value indicating whether the asynchronous operation has completed.
         /// </summary>
-        /// <returns>
+        /// <value>
         /// <see langword="true"/> if the operation is complete; otherwise, <see langword="false"/>.
-        /// </returns>
+        /// </value>
         public bool IsCompleted
         {
             get { return _completedState != StatePending; }

--- a/src/Renci.SshNet/Common/ChannelInputStream.cs
+++ b/src/Renci.SshNet/Common/ChannelInputStream.cs
@@ -153,9 +153,9 @@ namespace Renci.SshNet.Common
         /// <summary>
         /// Gets a value indicating whether the current stream supports reading.
         /// </summary>
-        /// <returns>
-        /// true if the stream supports reading; otherwise, false.
-        /// </returns>
+        /// <value>
+        /// <see langword="true"/> if the stream supports reading; otherwise, <see langword="false"/>.
+        /// </value>
         public override bool CanRead
         {
             get { return false; }
@@ -164,9 +164,9 @@ namespace Renci.SshNet.Common
         /// <summary>
         /// Gets a value indicating whether the current stream supports seeking.
         /// </summary>
-        /// <returns>
-        /// <c>true</c> if the stream supports seeking; otherwise, <c>false</c>.
-        /// </returns>
+        /// <value>
+        /// <see langword="true"/> if the stream supports seeking; otherwise, <see langword="false"/>.
+        /// </value>
         public override bool CanSeek
         {
             get { return false; }
@@ -175,35 +175,35 @@ namespace Renci.SshNet.Common
         /// <summary>
         /// Gets a value indicating whether the current stream supports writing.
         /// </summary>
-        /// <returns>
-        /// <c>true</c> if the stream supports writing; otherwise, <c>false</c>.
-        /// </returns>
+        /// <value>
+        /// <see langword="true"/> if the stream supports writing; otherwise, <see langword="false"/>.
+        /// </value>
         public override bool CanWrite
         {
             get { return true; }
         }
 
         /// <summary>
-        /// Gets the length in bytes of the stream.
+        /// Throws <see cref="NotSupportedException"/>.
         /// </summary>
-        /// <returns>
-        /// A long value representing the length of the stream in bytes.
-        /// </returns>
-        /// <exception cref="NotSupportedException">A class derived from Stream does not support seeking.</exception>
-        /// <exception cref="ObjectDisposedException">Methods were called after the stream was closed.</exception>
+        /// <exception cref="NotSupportedException">Always.</exception>
+#pragma warning disable SA1623 // The property's documentation should begin with 'Gets or sets'
         public override long Length
+#pragma warning restore SA1623 // The property's documentation should begin with 'Gets or sets'
         {
             get { throw new NotSupportedException(); }
         }
 
         /// <summary>
-        /// Gets or sets the position within the current stream.
+        /// Gets the position within the current stream.
         /// </summary>
-        /// <returns>
+        /// <value>
         /// The current position within the stream.
-        /// </returns>
-        /// <exception cref="NotSupportedException">The stream does not support seeking.</exception>
+        /// </value>
+        /// <exception cref="NotSupportedException">The setter is called.</exception>
+#pragma warning disable SA1623 // The property's documentation should begin with 'Gets or sets'
         public override long Position
+#pragma warning restore SA1623 // The property's documentation should begin with 'Gets or sets'
         {
             get { return _totalPosition; }
             set { throw new NotSupportedException(); }

--- a/src/Renci.SshNet/Common/PipeStream.cs
+++ b/src/Renci.SshNet/Common/PipeStream.cs
@@ -163,9 +163,9 @@ namespace Renci.SshNet.Common
         /// <summary>
         /// Gets a value indicating whether the current stream supports reading.
         /// </summary>
-        /// <returns>
+        /// <value>
         /// <see langword="true"/>.
-        /// </returns>
+        /// </value>
         /// <remarks>
         /// It is safe to read from <see cref="PipeStream"/> even after disposal.
         /// </remarks>
@@ -177,9 +177,9 @@ namespace Renci.SshNet.Common
         /// <summary>
         /// Gets a value indicating whether the current stream supports seeking.
         /// </summary>
-        /// <returns>
+        /// <value>
         /// <see langword="false"/>.
-        /// </returns>
+        /// </value>
         public override bool CanSeek
         {
             get { return false; }
@@ -188,10 +188,10 @@ namespace Renci.SshNet.Common
         /// <summary>
         /// Gets a value indicating whether the current stream supports writing.
         /// </summary>
-        /// <returns>
+        /// <value>
         /// <see langword="true"/> if this stream has not been disposed and the underlying channel
         /// is still open, otherwise <see langword="false"/>.
-        /// </returns>
+        /// </value>
         /// <remarks>
         /// A value of <see langword="true"/> does not necessarily mean a write will succeed. It is possible
         /// that the stream is disposed by another thread between a call to <see cref="CanWrite"/> and the call to write.
@@ -204,7 +204,7 @@ namespace Renci.SshNet.Common
         /// <summary>
         /// Gets the number of bytes currently available for reading.
         /// </summary>
-        /// <returns>A long value representing the length of the stream in bytes.</returns>
+        /// <value>A long value representing the length of the stream in bytes.</value>
         public override long Length
         {
             get
@@ -221,9 +221,9 @@ namespace Renci.SshNet.Common
         /// This property always returns 0, and throws <see cref="NotSupportedException"/>
         /// when calling the setter.
         /// </summary>
-        /// <returns>
+        /// <value>
         /// 0.
-        /// </returns>
+        /// </value>
         /// <exception cref="NotSupportedException">The setter is called.</exception>
 #pragma warning disable SA1623 // The property's documentation should begin with 'Gets or sets'
         public override long Position

--- a/src/Renci.SshNet/Security/Cryptography/Cipher.cs
+++ b/src/Renci.SshNet/Security/Cryptography/Cipher.cs
@@ -16,10 +16,10 @@
         /// <summary>
         /// Gets the size of the authentication tag for ciphers which implement Authenticated Encryption (AE).
         /// </summary>
-        /// <returns>
+        /// <value>
         /// When this <see cref="Cipher"/> implements Authenticated Encryption, the size, in bytes,
         /// of the authentication tag included in the encrypted message.
-        /// </returns>
+        /// </value>
         public virtual int TagSize { get; }
 
         /// <summary>

--- a/src/Renci.SshNet/Security/Cryptography/RsaKey.cs
+++ b/src/Renci.SshNet/Security/Cryptography/RsaKey.cs
@@ -108,9 +108,9 @@ namespace Renci.SshNet.Security
         /// <summary>
         /// Gets the digital signature implementation for this key.
         /// </summary>
-        /// <returns>
+        /// <value>
         /// An implementation of an RSA digital signature using the SHA-1 hash algorithm.
-        /// </returns>
+        /// </value>
         protected internal override DigitalSignature DigitalSignature
         {
             get

--- a/src/Renci.SshNet/Sftp/SftpFileStream.cs
+++ b/src/Renci.SshNet/Sftp/SftpFileStream.cs
@@ -41,9 +41,9 @@ namespace Renci.SshNet.Sftp
         /// <summary>
         /// Gets a value indicating whether the current stream supports reading.
         /// </summary>
-        /// <returns>
+        /// <value>
         /// <see langword="true"/> if the stream supports reading; otherwise, <see langword="false"/>.
-        /// </returns>
+        /// </value>
         public override bool CanRead
         {
             get { return _canRead; }
@@ -52,9 +52,9 @@ namespace Renci.SshNet.Sftp
         /// <summary>
         /// Gets a value indicating whether the current stream supports seeking.
         /// </summary>
-        /// <returns>
+        /// <value>
         /// <see langword="true"/> if the stream supports seeking; otherwise, <see langword="false"/>.
-        /// </returns>
+        /// </value>
         public override bool CanSeek
         {
             get { return _canSeek; }
@@ -63,9 +63,9 @@ namespace Renci.SshNet.Sftp
         /// <summary>
         /// Gets a value indicating whether the current stream supports writing.
         /// </summary>
-        /// <returns>
+        /// <value>
         /// <see langword="true"/> if the stream supports writing; otherwise, <see langword="false"/>.
-        /// </returns>
+        /// </value>
         public override bool CanWrite
         {
             get { return _canWrite; }
@@ -85,7 +85,7 @@ namespace Renci.SshNet.Sftp
         /// <summary>
         /// Gets the length in bytes of the stream.
         /// </summary>
-        /// <returns>A long value representing the length of the stream in bytes.</returns>
+        /// <value>A long value representing the length of the stream in bytes.</value>
         /// <exception cref="NotSupportedException">A class derived from Stream does not support seeking. </exception>
         /// <exception cref="ObjectDisposedException">Methods were called after the stream was closed. </exception>
         /// <exception cref="IOException">IO operation failed. </exception>
@@ -125,7 +125,7 @@ namespace Renci.SshNet.Sftp
         /// <summary>
         /// Gets or sets the position within the current stream.
         /// </summary>
-        /// <returns>The current position within the stream.</returns>
+        /// <value>The current position within the stream.</value>
         /// <exception cref="IOException">An I/O error occurs. </exception>
         /// <exception cref="NotSupportedException">The stream does not support seeking. </exception>
         /// <exception cref="ObjectDisposedException">Methods were called after the stream was closed. </exception>

--- a/src/Renci.SshNet/ShellStream.cs
+++ b/src/Renci.SshNet/ShellStream.cs
@@ -189,9 +189,9 @@ namespace Renci.SshNet
         /// <summary>
         /// Gets a value indicating whether the current stream supports reading.
         /// </summary>
-        /// <returns>
+        /// <value>
         /// <see langword="true"/>.
-        /// </returns>
+        /// </value>
         /// <remarks>
         /// It is safe to read from <see cref="ShellStream"/> even after disposal.
         /// </remarks>
@@ -203,9 +203,9 @@ namespace Renci.SshNet
         /// <summary>
         /// Gets a value indicating whether the current stream supports seeking.
         /// </summary>
-        /// <returns>
+        /// <value>
         /// <see langword="false"/>.
-        /// </returns>
+        /// </value>
         public override bool CanSeek
         {
             get { return false; }
@@ -214,10 +214,10 @@ namespace Renci.SshNet
         /// <summary>
         /// Gets a value indicating whether the current stream supports writing.
         /// </summary>
-        /// <returns>
+        /// <value>
         /// <see langword="true"/> if this stream has not been disposed and the underlying channel
         /// is still open, otherwise <see langword="false"/>.
-        /// </returns>
+        /// </value>
         /// <remarks>
         /// A value of <see langword="true"/> does not necessarily mean a write will succeed. It is possible
         /// that the channel is closed and/or the stream is disposed by another thread between a call to
@@ -245,7 +245,7 @@ namespace Renci.SshNet
         /// <summary>
         /// Gets the number of bytes currently available for reading.
         /// </summary>
-        /// <returns>A long value representing the length of the stream in bytes.</returns>
+        /// <value>A value representing the length of the stream in bytes.</value>
         public override long Length
         {
             get
@@ -262,9 +262,9 @@ namespace Renci.SshNet
         /// This property always returns 0, and throws <see cref="NotSupportedException"/>
         /// when calling the setter.
         /// </summary>
-        /// <returns>
+        /// <value>
         /// 0.
-        /// </returns>
+        /// </value>
         /// <exception cref="NotSupportedException">The setter is called.</exception>
 #pragma warning disable SA1623 // The property's documentation should begin with 'Gets or sets'
         public override long Position

--- a/src/Renci.SshNet/SshCommand.cs
+++ b/src/Renci.SshNet/SshCommand.cs
@@ -14,7 +14,7 @@ using Renci.SshNet.Messages.Transport;
 namespace Renci.SshNet
 {
     /// <summary>
-    /// Represents SSH command that can be executed.
+    /// Represents an SSH command that can be executed.
     /// </summary>
     public class SshCommand : IDisposable
     {
@@ -404,7 +404,7 @@ namespace Renci.SshNet
         /// </summary>
         /// <param name="asyncResult">The reference to the pending asynchronous request to finish.</param>
         /// <returns><see cref="Result"/>.</returns>
-        /// <exception cref="ArgumentException">Either the IAsyncResult object did not come from the corresponding async method on this type, or EndExecute was called multiple times with the same IAsyncResult.</exception>
+        /// <exception cref="ArgumentException"><paramref name="asyncResult"/> does not correspond to the currently executing command.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="asyncResult"/> is <see langword="null"/>.</exception>
         public string EndExecute(IAsyncResult asyncResult)
         {
@@ -488,7 +488,7 @@ namespace Renci.SshNet
         }
 
         /// <summary>
-        /// Executes command specified by <see cref="CommandText"/> property.
+        /// Executes the command specified by <see cref="CommandText"/>.
         /// </summary>
         /// <returns><see cref="Result"/>.</returns>
         /// <exception cref="SshConnectionException">Client is not connected.</exception>
@@ -501,12 +501,10 @@ namespace Renci.SshNet
         }
 
         /// <summary>
-        /// Executes the specified command text.
+        /// Executes the specified command.
         /// </summary>
         /// <param name="commandText">The command text.</param>
-        /// <returns>
-        /// The result of the command execution.
-        /// </returns>
+        /// <returns><see cref="Result"/>.</returns>
         /// <exception cref="SshConnectionException">Client is not connected.</exception>
         /// <exception cref="SshOperationTimeoutException">Operation has timed out.</exception>
         public string Execute(string commandText)


### PR DESCRIPTION
* Use `/// <value>` instead of `/// <returns>` for properties (the latter is only meant for methods as it turns out - still works in VS but not in docfx)
* misc doc updates in SshCommand
* Update README - remove some fluff at the start and move the examples upfront. Base it somewhat on the template of MS packages as suggested in #1311 e.g. https://www.nuget.org/packages/System.Text.Json