### PR TITLE
.NET 9: don't treat NuGet audit Warnings as Errors and fix warning

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,6 +23,11 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
+  <!-- don't treat NuGet Audit warnings as errors -->
+  <PropertyGroup>
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+  </PropertyGroup>
+
   <!--
         Disable nullable warnings on old frameworks because of missing annotations.
   -->

--- a/test/Renci.SshNet.IntegrationTests/Renci.SshNet.IntegrationTests.csproj
+++ b/test/Renci.SshNet.IntegrationTests/Renci.SshNet.IntegrationTests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.2.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.2.1" />
-    <PackageReference Include="Testcontainers" Version="3.7.0" />
+    <PackageReference Include="Testcontainers" Version="3.9.0" />
     <!--
         Testcontainers has a dependency on SSH.NET which causes build warnings during assembly resolution:      
         


### PR DESCRIPTION
Since .NET 9 Preview 6, NuGet Audit also [scans transitive dependencies](https://github.com/dotnet/core/blob/main/release-notes/9.0/preview/preview6/sdk.md#nugetaudit-now-raises-warnings-for-vulnerabilities-in-transitive-dependencies), which causes a build failure in the test projects:

`warning NU1902: Package 'BouncyCastle.Cryptography' 2.2.1 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-8xfc-gm6g-vgpv`

Don't treat these as errors and update Testcontainers to fix the warning. See  [NuGet Audit docs](https://learn.microsoft.com/en-us/nuget/concepts/auditing-packages#warning-codes).