### PR TITLE
fix "client not connected" after SFTP reconnect

### DIFF
--- a/src/Renci.SshNet/BaseClient.cs
+++ b/src/Renci.SshNet/BaseClient.cs
@@ -240,6 +240,11 @@ namespace Renci.SshNet
             var session = Session;
             if (session is null || !session.IsConnected)
             {
+                if (session is not null)
+                {
+                    DisposeSession(session);
+                }
+
                 Session = CreateAndConnectSession();
             }
 
@@ -304,6 +309,11 @@ namespace Renci.SshNet
             var session = Session;
             if (session is null || !session.IsConnected)
             {
+                if (session is not null)
+                {
+                    DisposeSession(session);
+                }
+
                 Session = await CreateAndConnectSessionAsync(cancellationToken).ConfigureAwait(false);
             }
 

--- a/src/Renci.SshNet/SftpClient.cs
+++ b/src/Renci.SshNet/SftpClient.cs
@@ -2496,15 +2496,8 @@ namespace Renci.SshNet
         {
             base.OnConnected();
 
-            var sftpSession = _sftpSession;
-            if (sftpSession is null)
-            {
-                _sftpSession = CreateAndConnectToSftpSession();
-            }
-            else if (!sftpSession.IsOpen)
-            {
-                sftpSession.Connect();
-            }
+            _sftpSession?.Dispose();
+            _sftpSession = CreateAndConnectToSftpSession();
         }
 
         /// <summary>

--- a/test/Renci.SshNet.IntegrationTests/ConnectivityTests.cs
+++ b/test/Renci.SshNet.IntegrationTests/ConnectivityTests.cs
@@ -327,6 +327,54 @@ namespace Renci.SshNet.IntegrationTests
         }
 
         [TestMethod]
+        public void SftpClient_HandleSftpSessionAbortByServer()
+        {
+            using (var client = new SftpClient(_connectionInfoFactory.Create()))
+            {
+                client.Connect();
+                Assert.IsTrue(client.IsConnected);
+
+                _sshConnectionDisruptor.BreakConnections();
+                WaitForConnectionInterruption(client);
+                Assert.IsFalse(client.IsConnected);
+
+                client.Connect();
+                Assert.IsTrue(client.IsConnected);
+
+                foreach (var file in client.ListDirectory("."))
+                {
+                }
+
+                client.Disconnect();
+                Assert.IsFalse(client.IsConnected);
+            }
+        }
+
+        [TestMethod]
+        public async Task SftpClient_HandleSftpSessionAbortByServerAsync()
+        {
+            using (var client = new SftpClient(_connectionInfoFactory.Create()))
+            {
+                await client.ConnectAsync(CancellationToken.None);
+                Assert.IsTrue(client.IsConnected);
+
+                _sshConnectionDisruptor.BreakConnections();
+                WaitForConnectionInterruption(client);
+                Assert.IsFalse(client.IsConnected);
+
+                await client.ConnectAsync(CancellationToken.None);
+                Assert.IsTrue(client.IsConnected);
+
+                await foreach (var file in client.ListDirectoryAsync(".", CancellationToken.None))
+                {
+                }
+
+                client.Disconnect();
+                Assert.IsFalse(client.IsConnected);
+            }
+        }
+
+        [TestMethod]
         public void Common_DetectSessionKilledOnServer()
         {
             using (var client = new SftpClient(_connectionInfoFactory.Create()))


### PR DESCRIPTION
if the server closes the session and the client reconnects, this currently leads to a broken state because the session is re-created, but the SFTP subsession is not and still references the old session.

This causes all operations to fail with "client not connected" or even throwing the "An established connection was aborted by the server." exception of the old session.

Always re-create the SFTP subsession to fix this.

Also noticed another issue while looking into this: if the session already exists, but it not connected anymore, the old instance was never disposed.

fixes #1474