### PR TITLE
Fix sftp async methods not observing error conditions

### DIFF
--- a/src/Renci.SshNet/ISftpClient.cs
+++ b/src/Renci.SshNet/ISftpClient.cs
@@ -56,7 +56,6 @@ namespace Renci.SshNet
         /// The timeout to wait until an operation completes. The default value is negative
         /// one (-1) milliseconds, which indicates an infinite timeout period.
         /// </value>
-        /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="value"/> represents a value that is less than -1 or greater than <see cref="int.MaxValue"/> milliseconds.</exception>
         TimeSpan OperationTimeout { get; set; }
 

--- a/src/Renci.SshNet/ISubsystemSession.cs
+++ b/src/Renci.SshNet/ISubsystemSession.cs
@@ -11,12 +11,12 @@ namespace Renci.SshNet
     internal interface ISubsystemSession : IDisposable
     {
         /// <summary>
-        /// Gets or set the number of seconds to wait for an operation to complete.
+        /// Gets or sets the number of milliseconds to wait for an operation to complete.
         /// </summary>
         /// <value>
-        /// The number of seconds to wait for an operation to complete, or <c>-1</c> to wait indefinitely.
+        /// The number of milliseconds to wait for an operation to complete, or <c>-1</c> to wait indefinitely.
         /// </value>
-        int OperationTimeout { get; }
+        int OperationTimeout { get; set; }
 
         /// <summary>
         /// Gets a value indicating whether this session is open.

--- a/src/Renci.SshNet/SftpClient.cs
+++ b/src/Renci.SshNet/SftpClient.cs
@@ -46,21 +46,21 @@ namespace Renci.SshNet
         /// The timeout to wait until an operation completes. The default value is negative
         /// one (-1) milliseconds, which indicates an infinite timeout period.
         /// </value>
-        /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="value"/> represents a value that is less than -1 or greater than <see cref="int.MaxValue"/> milliseconds.</exception>
         public TimeSpan OperationTimeout
         {
             get
             {
-                CheckDisposed();
-
                 return TimeSpan.FromMilliseconds(_operationTimeout);
             }
             set
             {
-                CheckDisposed();
-
                 _operationTimeout = value.AsTimeout(nameof(OperationTimeout));
+
+                if (_sftpSession is { } sftpSession)
+                {
+                    sftpSession.OperationTimeout = _operationTimeout;
+                }
             }
         }
 

--- a/src/Renci.SshNet/SubsystemSession.cs
+++ b/src/Renci.SshNet/SubsystemSession.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Runtime.ExceptionServices;
 using System.Threading;
+using System.Threading.Tasks;
 
 using Renci.SshNet.Abstractions;
 using Renci.SshNet.Channels;
@@ -29,13 +30,8 @@ namespace Renci.SshNet
         private EventWaitHandle _channelClosedWaitHandle = new ManualResetEvent(initialState: false);
         private bool _isDisposed;
 
-        /// <summary>
-        /// Gets or set the number of seconds to wait for an operation to complete.
-        /// </summary>
-        /// <value>
-        /// The number of seconds to wait for an operation to complete, or -1 to wait indefinitely.
-        /// </value>
-        public int OperationTimeout { get; private set; }
+        /// <inheritdoc/>
+        public int OperationTimeout { get; set; }
 
         /// <summary>
         /// Occurs when an error occurred.
@@ -247,6 +243,59 @@ namespace Renci.SshNet
                     throw new SshOperationTimeoutException("Operation has timed out.");
                 default:
                     throw new NotImplementedException(string.Format(CultureInfo.InvariantCulture, "WaitAny return value '{0}' is not implemented.", result));
+            }
+        }
+
+        protected async Task<T> WaitOnHandleAsync<T>(TaskCompletionSource<T> tcs, int millisecondsTimeout, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var errorOccuredReg = ThreadPool.RegisterWaitForSingleObject(
+                _errorOccuredWaitHandle,
+                (tcs, _) => ((TaskCompletionSource<T>)tcs).TrySetException(_exception),
+                state: tcs,
+                millisecondsTimeOutInterval: -1,
+                executeOnlyOnce: true);
+
+            var sessionDisconnectedReg = ThreadPool.RegisterWaitForSingleObject(
+                _sessionDisconnectedWaitHandle,
+                static (tcs, _) => ((TaskCompletionSource<T>)tcs).TrySetException(new SshException("Connection was closed by the server.")),
+                state: tcs,
+                millisecondsTimeOutInterval: -1,
+                executeOnlyOnce: true);
+
+            var channelClosedReg = ThreadPool.RegisterWaitForSingleObject(
+                _channelClosedWaitHandle,
+                static (tcs, _) => ((TaskCompletionSource<T>)tcs).TrySetException(new SshException("Channel was closed.")),
+                state: tcs,
+                millisecondsTimeOutInterval: -1,
+                executeOnlyOnce: true);
+
+            using var timeoutCts = new CancellationTokenSource(millisecondsTimeout);
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+            using var tokenReg = linkedCts.Token.Register(
+                static s =>
+                {
+                    (var tcs, var cancellationToken) = ((TaskCompletionSource<T>, CancellationToken))s;
+                    _ = tcs.TrySetCanceled(cancellationToken);
+                },
+                state: (tcs, cancellationToken),
+                useSynchronizationContext: false);
+
+            try
+            {
+                return await tcs.Task.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException oce) when (timeoutCts.IsCancellationRequested)
+            {
+                throw new SshOperationTimeoutException("Operation has timed out.", oce);
+            }
+            finally
+            {
+                _ = errorOccuredReg.Unregister(waitObject: null);
+                _ = sessionDisconnectedReg.Unregister(waitObject: null);
+                _ = channelClosedReg.Unregister(waitObject: null);
             }
         }
 

--- a/test/Renci.SshNet.Tests/Classes/SftpClientTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/SftpClientTest.cs
@@ -115,37 +115,5 @@ namespace Renci.SshNet.Tests.Classes
                 Assert.AreEqual("OperationTimeout", ex.ParamName);
             }
         }
-
-        [TestMethod]
-        public void OperationTimeout_Disposed()
-        {
-            var connectionInfo = new PasswordConnectionInfo("host", 22, "admin", "pwd");
-            var target = new SftpClient(connectionInfo);
-            target.Dispose();
-
-            // getter
-            try
-            {
-                var actual = target.OperationTimeout;
-                Assert.Fail("Should have failed, but returned: " + actual);
-            }
-            catch (ObjectDisposedException ex)
-            {
-                Assert.IsNull(ex.InnerException);
-                Assert.AreEqual(typeof(SftpClient).FullName, ex.ObjectName);
-            }
-
-            // setter
-            try
-            {
-                target.OperationTimeout = TimeSpan.FromMilliseconds(5);
-                Assert.Fail();
-            }
-            catch (ObjectDisposedException ex)
-            {
-                Assert.IsNull(ex.InnerException);
-                Assert.AreEqual(typeof(SftpClient).FullName, ex.ObjectName);
-            }
-        }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/SftpClientTest_AsyncExceptions.cs
+++ b/test/Renci.SshNet.Tests/Classes/SftpClientTest_AsyncExceptions.cs
@@ -1,0 +1,268 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Moq;
+
+#if !NET8_0_OR_GREATER
+using Renci.SshNet.Abstractions;
+#endif
+using Renci.SshNet.Channels;
+using Renci.SshNet.Common;
+using Renci.SshNet.Connection;
+using Renci.SshNet.Messages;
+using Renci.SshNet.Messages.Authentication;
+using Renci.SshNet.Messages.Connection;
+using Renci.SshNet.Sftp;
+using Renci.SshNet.Sftp.Responses;
+
+namespace Renci.SshNet.Tests.Classes
+{
+    [TestClass]
+    public class SftpClientTest_AsyncExceptions
+    {
+        private MySession _session;
+        private SftpClient _client;
+
+        [TestInitialize]
+        public void Init()
+        {
+            var socketFactoryMock = new Mock<ISocketFactory>(MockBehavior.Strict);
+            var serviceFactoryMock = new Mock<IServiceFactory>(MockBehavior.Strict);
+
+            var connInfo = new PasswordConnectionInfo("host", "user", "pwd");
+
+            _session = new MySession(connInfo);
+
+            var concreteServiceFactory = new ServiceFactory();
+
+            serviceFactoryMock
+                .Setup(p => p.CreateSocketFactory())
+                .Returns(socketFactoryMock.Object);
+
+            serviceFactoryMock
+                .Setup(p => p.CreateSession(It.IsAny<ConnectionInfo>(), socketFactoryMock.Object))
+                .Returns(_session);
+
+            serviceFactoryMock
+                .Setup(p => p.CreateSftpResponseFactory())
+                .Returns(concreteServiceFactory.CreateSftpResponseFactory);
+
+            serviceFactoryMock
+                .Setup(p => p.CreateSftpSession(_session, It.IsAny<int>(), It.IsAny<Encoding>(), It.IsAny<ISftpResponseFactory>()))
+                .Returns(concreteServiceFactory.CreateSftpSession);
+
+            _client = new SftpClient(connInfo, false, serviceFactoryMock.Object);
+            _client.Connect();
+        }
+
+        [TestMethod]
+        public async Task Async_ObservesSessionDisconnected()
+        {
+            Task<SftpFileStream> openTask = _client.OpenAsync("path", FileMode.Create, FileAccess.Write, CancellationToken.None);
+
+            Assert.IsFalse(openTask.IsCompleted);
+
+            _session.InvokeDisconnected();
+
+            var ex = await Assert.ThrowsExceptionAsync<SshException>(() => openTask);
+            Assert.AreEqual("Connection was closed by the server.", ex.Message);
+        }
+
+        [TestMethod]
+        public async Task Async_ObservesChannelClosed()
+        {
+            Task<SftpFileStream> openTask = _client.OpenAsync("path", FileMode.Create, FileAccess.Write, CancellationToken.None);
+
+            Assert.IsFalse(openTask.IsCompleted);
+
+            _session.InvokeChannelCloseReceived();
+
+            var ex = await Assert.ThrowsExceptionAsync<SshException>(() => openTask);
+            Assert.AreEqual("Channel was closed.", ex.Message);
+        }
+
+        [TestMethod]
+        public async Task Async_ObservesCancellationToken()
+        {
+            using CancellationTokenSource cts = new();
+
+            Task<SftpFileStream> openTask = _client.OpenAsync("path", FileMode.Create, FileAccess.Write, cts.Token);
+
+            Assert.IsFalse(openTask.IsCompleted);
+
+            await cts.CancelAsync();
+
+            var ex = await Assert.ThrowsExceptionAsync<TaskCanceledException>(() => openTask);
+            Assert.AreEqual(cts.Token, ex.CancellationToken);
+        }
+
+        [TestMethod]
+        public async Task Async_ObservesOperationTimeout()
+        {
+            _client.OperationTimeout = TimeSpan.FromMilliseconds(250);
+
+            Task<SftpFileStream> openTask = _client.OpenAsync("path", FileMode.Create, FileAccess.Write, CancellationToken.None);
+
+            var ex = await Assert.ThrowsExceptionAsync<SshOperationTimeoutException>(() => openTask);
+        }
+
+        [TestMethod]
+        public async Task Async_ObservesErrorOccurred()
+        {
+            Task<SftpFileStream> openTask = _client.OpenAsync("path", FileMode.Create, FileAccess.Write, CancellationToken.None);
+
+            Assert.IsFalse(openTask.IsCompleted);
+
+            MyException ex = new("my exception");
+
+            _session.InvokeErrorOccurred(ex);
+
+            var ex2 = await Assert.ThrowsExceptionAsync<MyException>(() => openTask);
+            Assert.AreEqual(ex.Message, ex2.Message);
+        }
+
+#pragma warning disable IDE0022 // Use block body for method
+#pragma warning disable IDE0025 // Use block body for property
+#pragma warning disable CS0067 // event is unused
+        private class MySession(ConnectionInfo connectionInfo) : ISession
+        {
+            public IConnectionInfo ConnectionInfo => connectionInfo;
+
+            public event EventHandler<MessageEventArgs<ChannelCloseMessage>> ChannelCloseReceived;
+            public event EventHandler<MessageEventArgs<ChannelDataMessage>> ChannelDataReceived;
+            public event EventHandler<MessageEventArgs<ChannelEofMessage>> ChannelEofReceived;
+            public event EventHandler<MessageEventArgs<ChannelExtendedDataMessage>> ChannelExtendedDataReceived;
+            public event EventHandler<MessageEventArgs<ChannelFailureMessage>> ChannelFailureReceived;
+            public event EventHandler<MessageEventArgs<ChannelOpenConfirmationMessage>> ChannelOpenConfirmationReceived;
+            public event EventHandler<MessageEventArgs<ChannelOpenFailureMessage>> ChannelOpenFailureReceived;
+            public event EventHandler<MessageEventArgs<ChannelOpenMessage>> ChannelOpenReceived;
+            public event EventHandler<MessageEventArgs<ChannelRequestMessage>> ChannelRequestReceived;
+            public event EventHandler<MessageEventArgs<ChannelSuccessMessage>> ChannelSuccessReceived;
+            public event EventHandler<MessageEventArgs<ChannelWindowAdjustMessage>> ChannelWindowAdjustReceived;
+            public event EventHandler<EventArgs> Disconnected;
+            public event EventHandler<ExceptionEventArgs> ErrorOccured;
+            public event EventHandler<SshIdentificationEventArgs> ServerIdentificationReceived;
+            public event EventHandler<HostKeyEventArgs> HostKeyReceived;
+            public event EventHandler<MessageEventArgs<RequestSuccessMessage>> RequestSuccessReceived;
+            public event EventHandler<MessageEventArgs<RequestFailureMessage>> RequestFailureReceived;
+            public event EventHandler<MessageEventArgs<BannerMessage>> UserAuthenticationBannerReceived;
+
+            public void InvokeDisconnected()
+            {
+                Disconnected?.Invoke(this, new EventArgs());
+            }
+
+            public void InvokeChannelCloseReceived()
+            {
+                ChannelCloseReceived?.Invoke(
+                    this,
+                    new MessageEventArgs<ChannelCloseMessage>(new ChannelCloseMessage(0)));
+            }
+
+            public void InvokeErrorOccurred(Exception ex)
+            {
+                ErrorOccured?.Invoke(this, new ExceptionEventArgs(ex));
+            }
+
+            public void SendMessage(Message message)
+            {
+                if (message is ChannelOpenMessage)
+                {
+                    ChannelOpenConfirmationReceived?.Invoke(
+                        this,
+                        new MessageEventArgs<ChannelOpenConfirmationMessage>(
+                            new ChannelOpenConfirmationMessage(0, int.MaxValue, int.MaxValue, 0)));
+                }
+                else if (message is ChannelRequestMessage)
+                {
+                    ChannelSuccessReceived?.Invoke(
+                        this,
+                        new MessageEventArgs<ChannelSuccessMessage>(new ChannelSuccessMessage(0)));
+                }
+                else if (message is ChannelDataMessage dataMsg)
+                {
+                    if (dataMsg.Data[sizeof(uint)] == (byte)SftpMessageTypes.Init)
+                    {
+                        ChannelDataReceived?.Invoke(
+                            this,
+                            new MessageEventArgs<ChannelDataMessage>(
+                                new ChannelDataMessage(0, new SftpVersionResponse() { Version = 3 }.GetBytes())));
+                    }
+                    else if (dataMsg.Data[sizeof(uint)] == (byte)SftpMessageTypes.RealPath)
+                    {
+                        ChannelDataReceived?.Invoke(
+                            this,
+                            new MessageEventArgs<ChannelDataMessage>(
+                                new ChannelDataMessage(0,
+                                    new SftpNameResponse(3, Encoding.UTF8)
+                                    {
+                                        ResponseId = 1,
+                                        Files = [new("thepath", new SftpFileAttributes(default, default, default, default, default, default, default))]
+                                    }.GetBytes())));
+                    }
+                }
+            }
+
+            public bool IsConnected => false;
+
+            public SemaphoreSlim SessionSemaphore { get; } = new(1);
+
+            public IChannelSession CreateChannelSession() => new ChannelSession(this, 0, int.MaxValue, int.MaxValue);
+
+            public WaitHandle MessageListenerCompleted => throw new NotImplementedException();
+
+            public void Connect()
+            {
+            }
+
+            public Task ConnectAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
+
+            public IChannelDirectTcpip CreateChannelDirectTcpip() => throw new NotImplementedException();
+
+            public IChannelForwardedTcpip CreateChannelForwardedTcpip(uint remoteChannelNumber, uint remoteWindowSize, uint remoteChannelDataPacketSize)
+                => throw new NotImplementedException();
+
+            public void Dispose()
+            {
+            }
+
+            public void OnDisconnecting()
+            {
+            }
+
+            public void Disconnect() => throw new NotImplementedException();
+
+            public void RegisterMessage(string messageName) => throw new NotImplementedException();
+
+            public bool TrySendMessage(Message message) => throw new NotImplementedException();
+
+            public WaitResult TryWait(WaitHandle waitHandle, TimeSpan timeout, out Exception exception) => throw new NotImplementedException();
+
+            public WaitResult TryWait(WaitHandle waitHandle, TimeSpan timeout) => throw new NotImplementedException();
+
+            public void UnRegisterMessage(string messageName) => throw new NotImplementedException();
+
+            public void WaitOnHandle(WaitHandle waitHandle)
+            {
+            }
+
+            public void WaitOnHandle(WaitHandle waitHandle, TimeSpan timeout) => throw new NotImplementedException();
+        }
+
+        [TestCleanup]
+        public void Cleanup() => _client?.Dispose();
+
+#pragma warning disable
+        private class MyException : Exception
+        {
+            public MyException(string message) : base(message)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
The async methods on SftpClient (as implemented in SftpSession) were only completing on receiving a response in the sftp layer, or via cancellation. They were not paying any attention to the ErrorOccured, SessionDisconnected or ChannelClosed events, which would result in an infinite wait when one of these occured.

This fix waits asynchronously on the wait handles using ThreadPool.RegisterWaitForSingleObject. It also adds missing plumbing of OperationTimeout.

closes #1497