### PR TITLE
fix shellStream bug

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "version": "8.0.100",
-    "rollForward": "latestMajor"
-  }
-}


### PR DESCRIPTION
* Added SendWindowChangeRequest to ShellStream

* Resolve the bug where data may be lost when creating ShellStream

When creating ShellStream, the channel will be immediately opened in the constructor of ShellStream. At this time, the calling module may not have subscribed to ShellStream's DataReceived event, which may result in the loss of a small piece of data immediately after connection. Manually call the Open method to solve this problem.