### PR TITLE
Improve ShellStream

### DIFF
--- a/src/Renci.SshNet/IServiceFactory.cs
+++ b/src/Renci.SshNet/IServiceFactory.cs
@@ -138,6 +138,44 @@ namespace Renci.SshNet
                                       int bufferSize);
 
         /// <summary>
+        /// Creates a shell stream.
+        /// </summary>
+        /// <param name="session">The SSH session.</param>
+        /// <param name="terminalName">The <c>TERM</c> environment variable.</param>
+        /// <param name="columns">The terminal width in columns.</param>
+        /// <param name="rows">The terminal width in rows.</param>
+        /// <param name="width">The terminal width in pixels.</param>
+        /// <param name="height">The terminal height in pixels.</param>
+        /// <param name="terminalModeValues">The terminal mode values.</param>
+        /// <param name="bufferSize">The size of the buffer.</param>
+        /// <param name="dataReceived">The DataReceived Handler.</param>
+        /// <param name="errorOccurred">The ErrorOccurred Handler.</param>
+        /// <returns>
+        /// The created <see cref="ShellStream"/> instance.
+        /// </returns>
+        /// <exception cref="SshConnectionException">Client is not connected.</exception>
+        /// <remarks>
+        /// <para>
+        /// The <c>TERM</c> environment variable contains an identifier for the text window's capabilities.
+        /// You can get a detailed list of these capabilities by using the ‘infocmp’ command.
+        /// </para>
+        /// <para>
+        /// The column/row dimensions override the pixel dimensions(when non-zero). Pixel dimensions refer
+        /// to the drawable area of the window.
+        /// </para>
+        /// </remarks>
+        ShellStream CreateShellStream(ISession session,
+                                      string terminalName,
+                                      uint columns,
+                                      uint rows,
+                                      uint width,
+                                      uint height,
+                                      IDictionary<TerminalModes, uint> terminalModeValues,
+                                      int bufferSize,
+                                      EventHandler<ShellDataEventArgs> dataReceived,
+                                      EventHandler<ExceptionEventArgs> errorOccurred);
+
+        /// <summary>
         /// Creates a shell stream without allocating a pseudo terminal.
         /// </summary>
         /// <param name="session">The SSH session.</param>

--- a/src/Renci.SshNet/ServiceFactory.cs
+++ b/src/Renci.SshNet/ServiceFactory.cs
@@ -199,6 +199,38 @@ namespace Renci.SshNet
             return new ShellStream(session, terminalName, columns, rows, width, height, terminalModeValues, bufferSize);
         }
 
+        /// <summary>
+        /// Creates a shell stream.
+        /// </summary>
+        /// <param name="session">The SSH session.</param>
+        /// <param name="terminalName">The <c>TERM</c> environment variable.</param>
+        /// <param name="columns">The terminal width in columns.</param>
+        /// <param name="rows">The terminal width in rows.</param>
+        /// <param name="width">The terminal width in pixels.</param>
+        /// <param name="height">The terminal height in pixels.</param>
+        /// <param name="terminalModeValues">The terminal mode values.</param>
+        /// <param name="bufferSize">The size of the buffer.</param>
+        /// <param name="dataReceived">The DataReceived Handler.</param>
+        /// <param name="errorOccurred">The ErrorOccurred Handler.</param>
+        /// <returns>
+        /// The created <see cref="ShellStream"/> instance.
+        /// </returns>
+        /// <exception cref="SshConnectionException">Client is not connected.</exception>
+        /// <remarks>
+        /// <para>
+        /// The <c>TERM</c> environment variable contains an identifier for the text window's capabilities.
+        /// You can get a detailed list of these capabilities by using the ‘infocmp’ command.
+        /// </para>
+        /// <para>
+        /// The column/row dimensions override the pixel dimensions(when non-zero). Pixel dimensions refer
+        /// to the drawable area of the window.
+        /// </para>
+        /// </remarks>
+        public ShellStream CreateShellStream(ISession session, string terminalName, uint columns, uint rows, uint width, uint height, IDictionary<TerminalModes, uint> terminalModeValues, int bufferSize, EventHandler<ShellDataEventArgs> dataReceived, EventHandler<ExceptionEventArgs> errorOccurred)
+        {
+            return new ShellStream(session, terminalName, columns, rows, width, height, terminalModeValues, bufferSize, dataReceived, errorOccurred);
+        }
+
         /// <inheritdoc/>
         public ShellStream CreateShellStreamNoTerminal(ISession session, int bufferSize)
         {

--- a/src/Renci.SshNet/ShellStream.cs
+++ b/src/Renci.SshNet/ShellStream.cs
@@ -94,6 +94,29 @@ namespace Renci.SshNet
         /// <param name="height">The terminal height in pixels.</param>
         /// <param name="terminalModeValues">The terminal mode values.</param>
         /// <param name="bufferSize">The size of the buffer.</param>
+        /// <param name="dataReceived">The DataReceived Handler.</param>
+        /// <param name="errorOccurred">The ErrorOccurred Handler.</param>
+        /// <exception cref="SshException">The channel could not be opened.</exception>
+        /// <exception cref="SshException">The pseudo-terminal request was not accepted by the server.</exception>
+        /// <exception cref="SshException">The request to start a shell was not accepted by the server.</exception>
+        internal ShellStream(ISession session, string terminalName, uint columns, uint rows, uint width, uint height, IDictionary<TerminalModes, uint> terminalModeValues, int bufferSize, EventHandler<ShellDataEventArgs> dataReceived, EventHandler<ExceptionEventArgs> errorOccurred)
+               : this(session, terminalName, columns, rows, width, height, terminalModeValues, bufferSize)
+        {
+            DataReceived = dataReceived;
+            ErrorOccurred = errorOccurred;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ShellStream"/> class.
+        /// </summary>
+        /// <param name="session">The SSH session.</param>
+        /// <param name="terminalName">The <c>TERM</c> environment variable.</param>
+        /// <param name="columns">The terminal width in columns.</param>
+        /// <param name="rows">The terminal width in rows.</param>
+        /// <param name="width">The terminal width in pixels.</param>
+        /// <param name="height">The terminal height in pixels.</param>
+        /// <param name="terminalModeValues">The terminal mode values.</param>
+        /// <param name="bufferSize">The size of the buffer.</param>
         /// <exception cref="SshException">The channel could not be opened.</exception>
         /// <exception cref="SshException">The pseudo-terminal request was not accepted by the server.</exception>
         /// <exception cref="SshException">The request to start a shell was not accepted by the server.</exception>
@@ -870,6 +893,21 @@ namespace Renci.SshNet
             // By default, the terminal driver translates carriage return to line feed on input.
             // See option ICRLF at https://www.man7.org/linux/man-pages/man3/termios.3.html.
             Write(line + (_noTerminal ? "\n" : "\r"));
+        }
+
+        /// <summary>
+        /// Change the terminal size.
+        /// </summary>
+        /// <param name="columns">new columns of the terminal.</param>
+        /// <param name="rows">new rows of the terminal.</param>
+        /// <param name="width">new width of the terminal.</param>
+        /// <param name="height">new height of the terminal.</param>
+        /// <returns>
+        /// <see langword="true"/> if request was successful; otherwise <see langword="false"/>.
+        /// </returns>
+        public bool SendWindowChangeRequest(uint columns, uint rows, uint width, uint height)
+        {
+            return _channel.SendWindowChangeRequest(columns, rows, width, height);
         }
 
         /// <inheritdoc/>

--- a/src/Renci.SshNet/ShellStream.cs
+++ b/src/Renci.SshNet/ShellStream.cs
@@ -94,16 +94,16 @@ namespace Renci.SshNet
         /// <param name="height">The terminal height in pixels.</param>
         /// <param name="terminalModeValues">The terminal mode values.</param>
         /// <param name="bufferSize">The size of the buffer.</param>
-        /// <param name="dataReceived">The DataReceived Handler.</param>
-        /// <param name="errorOccurred">The ErrorOccurred Handler.</param>
+        /// <param name="dataReceived">The DataReceived Handler.Please note that this event needs to be manually unsubscribed.</param>
+        /// <param name="errorOccurred">The ErrorOccurred Handler.Please note that this event needs to be manually unsubscribed.</param>
         /// <exception cref="SshException">The channel could not be opened.</exception>
         /// <exception cref="SshException">The pseudo-terminal request was not accepted by the server.</exception>
         /// <exception cref="SshException">The request to start a shell was not accepted by the server.</exception>
         internal ShellStream(ISession session, string terminalName, uint columns, uint rows, uint width, uint height, IDictionary<TerminalModes, uint> terminalModeValues, int bufferSize, EventHandler<ShellDataEventArgs> dataReceived, EventHandler<ExceptionEventArgs> errorOccurred)
                : this(session, terminalName, columns, rows, width, height, terminalModeValues, bufferSize)
         {
-            DataReceived = dataReceived;
-            ErrorOccurred = errorOccurred;
+            DataReceived += dataReceived;
+            ErrorOccurred += errorOccurred;
         }
 
         /// <summary>

--- a/src/Renci.SshNet/SshClient.cs
+++ b/src/Renci.SshNet/SshClient.cs
@@ -287,6 +287,39 @@ namespace Renci.SshNet
             return ServiceFactory.CreateShellStream(Session, terminalName, columns, rows, width, height, terminalModeValues, bufferSize);
         }
 
+        /// <summary>
+        /// Creates a shell stream.
+        /// </summary>
+        /// <param name="terminalName">The <c>TERM</c> environment variable.</param>
+        /// <param name="columns">The terminal width in columns.</param>
+        /// <param name="rows">The terminal width in rows.</param>
+        /// <param name="width">The terminal width in pixels.</param>
+        /// <param name="height">The terminal height in pixels.</param>
+        /// <param name="bufferSize">The size of the buffer.</param>
+        /// <param name="terminalModeValues">The terminal mode values.</param>
+        /// <param name="dataReceived">The DataReceived Handler.</param>
+        /// <param name="errorOccurred">The ErrorOccurred Handler.</param>
+        /// <returns>
+        /// The created <see cref="ShellStream"/> instance.
+        /// </returns>
+        /// <exception cref="SshConnectionException">Client is not connected.</exception>
+        /// <remarks>
+        /// <para>
+        /// The <c>TERM</c> environment variable contains an identifier for the text window's capabilities.
+        /// You can get a detailed list of these capabilities by using the ‘infocmp’ command.
+        /// </para>
+        /// <para>
+        /// The column/row dimensions override the pixel dimensions(when non-zero). Pixel dimensions refer
+        /// to the drawable area of the window.
+        /// </para>
+        /// </remarks>
+        public ShellStream CreateShellStream(string terminalName, uint columns, uint rows, uint width, uint height, int bufferSize, IDictionary<TerminalModes, uint>? terminalModeValues, EventHandler<ShellDataEventArgs> dataReceived, EventHandler<ExceptionEventArgs> errorOccurred)
+        {
+            EnsureSessionIsOpen();
+
+            return ServiceFactory.CreateShellStream(Session, terminalName, columns, rows, width, height, terminalModeValues, bufferSize, dataReceived, errorOccurred);
+        }
+
         /// <inheritdoc />
         public ShellStream CreateShellStreamNoTerminal(int bufferSize = -1)
         {


### PR DESCRIPTION
* Added SendWindowChangeRequest to ShellStream

* Added a new constructor to ShellStream

When creating ShellStream, the channel will be immediately opened in the constructor of ShellStream. At this time, the calling module may not have subscribed to ShellStream's DataReceived event, which may result in the loss of a small piece of data immediately after connection.   
You can use ShellStream's new constructor to solve this problem