### PR TITLE
fix Package Downgrade Warning with .NET 9 SDK

### DIFF
--- a/test/Renci.SshNet.IntegrationTests/Renci.SshNet.IntegrationTests.csproj
+++ b/test/Renci.SshNet.IntegrationTests/Renci.SshNet.IntegrationTests.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
   
   <ItemGroup>
+    <PackageReference Include="BouncyCastle.Cryptography" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MSTest.TestAdapter" />
     <PackageReference Include="MSTest.TestFramework" />


### PR DESCRIPTION
Cherry-picked from #1480. Build with .NET 9 SDK currently fails with the following error:

/home/mus/git/SSH.NET/test/Renci.SshNet.IntegrationTests/Renci.SshNet.IntegrationTests.csproj : error NU1605:
      Warning As Error: Detected package downgrade: BouncyCastle.Cryptography from 2.4.0 to 2.3.1. Reference the package directly from the project to select a different version.
       Renci.SshNet.IntegrationTests -> SSH.NET 1.0.0 -> BouncyCastle.Cryptography (>= 2.4.0)
       Renci.SshNet.IntegrationTests -> Testcontainers 3.10.0 -> BouncyCastle.Cryptography (>= 2.3.1)