### PR TITLE
Pin Alpine Linux image to 3.20

### DIFF
--- a/test/Renci.SshNet.IntegrationTests/Dockerfile
+++ b/test/Renci.SshNet.IntegrationTests/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.20
 
 COPY --chown=root:root server/ssh /etc/ssh/
 COPY --chown=root:root server/script /opt/sshnet

--- a/test/Renci.SshNet.IntegrationTests/TestsFixtures/InfrastructureFixture.cs
+++ b/test/Renci.SshNet.IntegrationTests/TestsFixtures/InfrastructureFixture.cs
@@ -43,7 +43,7 @@ namespace Renci.SshNet.IntegrationTests.TestsFixtures
             _sshServerImage = new ImageFromDockerfileBuilder()
                 .WithName("renci-ssh-tests-server-image")
                 .WithDockerfileDirectory(CommonDirectoryPath.GetSolutionDirectory(), Path.Combine("test", "Renci.SshNet.IntegrationTests"))
-                .WithDockerfile("Dockerfile.TestServer")
+                .WithDockerfile("Dockerfile")
                 .WithDeleteIfExists(true)
                 .WithLogger(containerLogger)
                 .Build();


### PR DESCRIPTION
Until failures are fixed with latest: #1553

(also renamed Dockerfile so that it does not need to be specified in `docker build`)