### PR TITLE
Fix hang/unhandled exception in SshCommand upon disconnect

### DIFF
--- a/test/Renci.SshNet.IntegrationTests/OldIntegrationTests/SshCommandTest.cs
+++ b/test/Renci.SshNet.IntegrationTests/OldIntegrationTests/SshCommandTest.cs
@@ -195,6 +195,25 @@ namespace Renci.SshNet.IntegrationTests.OldIntegrationTests
         }
 
         [TestMethod]
+        [Timeout(15000)]
+        public async Task Test_ExecuteAsync_Disconnect()
+        {
+            using (var client = new SshClient(SshServerHostName, SshServerPort, User.UserName, User.Password))
+            {
+                client.Connect();
+                using var cmd = client.CreateCommand("sleep 10s");
+                cmd.CommandTimeout = TimeSpan.FromSeconds(2);
+
+                Task executeTask = cmd.ExecuteAsync();
+
+                client.Disconnect();
+
+                // Waiting for timeout is not optimal here, but better than hanging indefinitely.
+                await Assert.ThrowsExceptionAsync<SshOperationTimeoutException>(() => executeTask);
+            }
+        }
+
+        [TestMethod]
         public void Test_Execute_InvalidCommand()
         {
             using (var client = new SshClient(SshServerHostName, SshServerPort, User.UserName, User.Password))


### PR DESCRIPTION
* Swallow exceptions occurring in the cancellation/timeout callback (due to disconnect) which would result in crash due to UnhandledException
* Always complete the Task when cancelling, even when such an exception occurs, in order to avoid the Task never completing. In the case of client disconnect, it would still wait until timeout. This is not ideal since we should be able to complete right away, but at least it's no longer an indefinite hang

contributes to #1561 