### PR TITLE
Update bound port on ForwardedPortDynamic after connection (in case original was passed as zero)

### DIFF
--- a/src/Renci.SshNet/ForwardedPortDynamic.cs
+++ b/src/Renci.SshNet/ForwardedPortDynamic.cs
@@ -40,7 +40,7 @@ namespace Renci.SshNet
         /// <summary>
         /// Gets the bound port.
         /// </summary>
-        public uint BoundPort { get; }
+        public uint BoundPort { get; private set; }
 
         private Socket _listener;
         private CountdownEvent _pendingChannelCountdown;

--- a/src/Renci.SshNet/ForwardedPortDynamic.cs
+++ b/src/Renci.SshNet/ForwardedPortDynamic.cs
@@ -168,6 +168,9 @@ namespace Renci.SshNet
             _listener.Bind(ep);
             _listener.Listen(5);
 
+            // update bound port (in case original was passed as zero)
+            BoundPort = (uint)((IPEndPoint)_listener.LocalEndPoint).Port;
+
             Session.ErrorOccured += Session_ErrorOccured;
             Session.Disconnected += Session_Disconnected;
 


### PR DESCRIPTION
Update the bound port after connection (in case original was passed as zero).
The logic was copied from ForwardedPortLocal into ForwardedPortDynamic.