### PR TITLE
Reply to global requests when want_reply is true

### DIFF
--- a/src/Renci.SshNet/Session.cs
+++ b/src/Renci.SshNet/Session.cs
@@ -473,11 +473,6 @@ namespace Renci.SshNet
         internal event EventHandler<MessageEventArgs<SuccessMessage>> UserAuthenticationSuccessReceived;
 
         /// <summary>
-        /// Occurs when <see cref="GlobalRequestMessage"/> message received
-        /// </summary>
-        internal event EventHandler<MessageEventArgs<GlobalRequestMessage>> GlobalRequestReceived;
-
-        /// <summary>
         /// Occurs when <see cref="RequestSuccessMessage"/> message received
         /// </summary>
         public event EventHandler<MessageEventArgs<RequestSuccessMessage>> RequestSuccessReceived;
@@ -1681,7 +1676,10 @@ namespace Renci.SshNet
         /// <param name="message"><see cref="GlobalRequestMessage"/> message.</param>
         internal void OnGlobalRequestReceived(GlobalRequestMessage message)
         {
-            GlobalRequestReceived?.Invoke(this, new MessageEventArgs<GlobalRequestMessage>(message));
+            if (message.WantReply)
+            {
+                SendMessage(new RequestFailureMessage());
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
We currently don't recognise any global requests from the server, but if one is sent, then per [RFC 4253 section 4](https://datatracker.ietf.org/doc/html/rfc4254#section-4) we still need to reply when the server expects one. So send SSH_MSG_REQUEST_FAILURE in this case.

closes #709