### PR TITLE
Fix API break on KeyExchange

### DIFF
--- a/src/Renci.SshNet/Security/KeyExchange.cs
+++ b/src/Renci.SshNet/Security/KeyExchange.cs
@@ -63,7 +63,10 @@ namespace Renci.SshNet.Security
         /// </summary>
         public event EventHandler<HostKeyEventArgs> HostKeyReceived;
 
-        private protected KeyExchange()
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeyExchange"/> class.
+        /// </summary>
+        protected KeyExchange()
         {
             _logger = SshNetLoggingConfiguration.LoggerFactory.CreateLogger(GetType());
         }


### PR DESCRIPTION
This type is public and a `private protected` ctor breaks subclassing outside the assembly