### PR TITLE
Use native AesGcm for .NET Framework from nuget

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,6 +11,7 @@
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageVersion Include="Meziantou.Analyzer" Version="2.0.220" />
     <!-- Should stay on LTS .NET releases. -->
+    <PackageVersion Include="Microsoft.Bcl.Cryptography" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.9" />
     <PackageVersion Include="MSTest" Version="3.9.3" />

--- a/src/Renci.SshNet/Renci.SshNet.csproj
+++ b/src/Renci.SshNet/Renci.SshNet.csproj
@@ -49,7 +49,11 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition=" !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')) ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+    <PackageReference Include="Microsoft.Bcl.Cryptography" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Formats.Asn1" />
   </ItemGroup>
 

--- a/src/Renci.SshNet/Security/Cryptography/Ciphers/AesGcmCipher.BclImpl.cs
+++ b/src/Renci.SshNet/Security/Cryptography/Ciphers/AesGcmCipher.BclImpl.cs
@@ -1,4 +1,4 @@
-#if NET
+#if !NETSTANDARD
 using System;
 using System.Security.Cryptography;
 

--- a/src/Renci.SshNet/Security/Cryptography/Ciphers/AesGcmCipher.cs
+++ b/src/Renci.SshNet/Security/Cryptography/Ciphers/AesGcmCipher.cs
@@ -65,15 +65,7 @@ namespace Renci.SshNet.Security.Cryptography.Ciphers
 #if !NETSTANDARD
             if (System.Security.Cryptography.AesGcm.IsSupported)
             {
-                try
-                {
-                    _impl = new BclImpl(key, _iv);
-                }
-                catch (DllNotFoundException)
-                {
-                    // Mono doesn't have BCrypt.dll
-                    _impl = new BouncyCastleImpl(key, _iv);
-                }
+                _impl = new BclImpl(key, _iv);
             }
             else
 #endif

--- a/src/Renci.SshNet/Security/Cryptography/Ciphers/AesGcmCipher.cs
+++ b/src/Renci.SshNet/Security/Cryptography/Ciphers/AesGcmCipher.cs
@@ -15,7 +15,7 @@ namespace Renci.SshNet.Security.Cryptography.Ciphers
         private const int TagSizeInBytes = 16;
         private readonly byte[] _iv;
         private readonly int _aadLength;
-#if NET
+#if !NETSTANDARD
         private readonly Impl _impl;
 #else
         private readonly BouncyCastleImpl _impl;
@@ -62,10 +62,18 @@ namespace Renci.SshNet.Security.Cryptography.Ciphers
             // SSH AES-GCM requires a 12-octet Initial IV
             _iv = iv.Take(12);
             _aadLength = aadLength;
-#if NET
+#if !NETSTANDARD
             if (System.Security.Cryptography.AesGcm.IsSupported)
             {
-                _impl = new BclImpl(key, _iv);
+                try
+                {
+                    _impl = new BclImpl(key, _iv);
+                }
+                catch (DllNotFoundException)
+                {
+                    // Mono doesn't have BCrypt.dll
+                    _impl = new BouncyCastleImpl(key, _iv);
+                }
             }
             else
 #endif


### PR DESCRIPTION
Based on https://github.com/dotnet/runtime/issues/89718, we can use native `AesGcm` for .NET Framework from [Microsoft.Bcl.Cryptography](https://www.nuget.org/packages/Microsoft.Bcl.Cryptography/) nuget package