### PR TITLE
lock SendData to fix random connection failures

### DIFF
--- a/test/Renci.SshNet.IntegrationTests/OldIntegrationTests/SftpClientTest.Upload.cs
+++ b/test/Renci.SshNet.IntegrationTests/OldIntegrationTests/SftpClientTest.Upload.cs
@@ -77,11 +77,6 @@ namespace Renci.SshNet.IntegrationTests.OldIntegrationTests
         [TestCategory("Sftp")]
         public void Test_Sftp_Multiple_Async_Upload_And_Download_10Files_5MB_Each()
         {
-            if (Environment.GetEnvironmentVariable("CI") == "true")
-            {
-                Assert.Inconclusive("Skipping because of failures in CI, see #1253");
-            }
-
             var maxFiles = 10;
             var maxSize = 5;
 


### PR DESCRIPTION
Fixes #1253 and probably #1493 .

This adds a lock to SendData to avoid the loop to interleave between multiple messages, causing a "bad message" error in the server (see https://github.com/sshnet/SSH.NET/issues/1253#issuecomment-2353988482).

This may totally be the wrong fix since I'm not really familiar with the protocol and I couldn't find anything specifically about this in the RFCs. But it seems sensible to me that the server doesn't expect this to happen.

By adding some logging I confirmed that in the failure cases of the test, the loop did indeed interleave between different messages. In the success cases, there simply were never more than 1 iteration, so it couldn't interleave.

Without this fix, I had the test fail about every third run. With this fix, I have run the test for about 500 times without a failure.