### PR TITLE
Only enable TreatWarningsAsErrors in Release

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -456,22 +456,22 @@ dotnet_diagnostic.SA1601.severity = none
 # SA1648: <inheritdoc> must be used with inheriting class
 #
 # This rule is disabled by default, hence we need to explicitly enable it.
-dotnet_diagnostic.SA1648.severity = error
+dotnet_diagnostic.SA1648.severity = warning
 
 # SX1101: Do not prefix local members with 'this.'
 #
 # This rule is disabled by default, hence we need to explicitly enable it.
-dotnet_diagnostic.SX1101.severity = error
+dotnet_diagnostic.SX1101.severity = warning
 
 # SX1309: Field names must begin with underscore
 #
 # This rule is disabled by default, hence we need to explicitly enable it.
-dotnet_diagnostic.SX1309.severity = error
+dotnet_diagnostic.SX1309.severity = warning
 
 # SX1309S: Static field names must begin with underscore
 #
 # This rule is disabled by default, hence we need to explicitly enable it.
-dotnet_diagnostic.SX1309S.severity = error
+dotnet_diagnostic.SX1309S.severity = warning
 
 #### Meziantou.Analyzer rules ####
 
@@ -608,7 +608,7 @@ MA0053.class_with_virtual_member_shoud_be_sealed = true
 # MA0112: Use 'Count > 0' instead of 'Any()'
 #
 # This rule is disabled by default, hence we need to explicitly enable it.
-dotnet_diagnostic.MA0112.severity = error
+dotnet_diagnostic.MA0112.severity = warning
 
 # MA0165: Make interpolated string
 dotnet_diagnostic.MA0165.severity = none
@@ -646,7 +646,7 @@ dotnet_diagnostic.CA1008.severity = none
 #
 # Even when enabled, this diagnostic does not appear to be reported for assemblies without CLSCompliantAttribute.
 # We reported this issue as https://github.com/dotnet/roslyn-analyzers/issues/6563.
-dotnet_diagnostic.CA1014.severity = error
+dotnet_diagnostic.CA1014.severity = warning
 
 # CA1051: Do not declare visible instance fields
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1051
@@ -1003,19 +1003,19 @@ dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
 
 dotnet_naming_rule.private_fields_camel_case_begins_with_underscore.symbols = private_fields
 dotnet_naming_rule.private_fields_camel_case_begins_with_underscore.style = camel_case_begins_with_underscore
-dotnet_naming_rule.private_fields_camel_case_begins_with_underscore.severity = error
+dotnet_naming_rule.private_fields_camel_case_begins_with_underscore.severity = warning
 
 dotnet_naming_rule.private_static_fields_camel_case_begins_with_underscore.symbols = private_static_fields
 dotnet_naming_rule.private_static_fields_camel_case_begins_with_underscore.style = camel_case_begins_with_underscore
-dotnet_naming_rule.private_static_fields_camel_case_begins_with_underscore.severity = error
+dotnet_naming_rule.private_static_fields_camel_case_begins_with_underscore.severity = warning
 
 dotnet_naming_rule.private_static_readonly_fields_pascal_case.symbols = private_static_readonly_fields
 dotnet_naming_rule.private_static_readonly_fields_pascal_case.style = pascal_case
-dotnet_naming_rule.private_static_readonly_fields_pascal_case.severity = error
+dotnet_naming_rule.private_static_readonly_fields_pascal_case.severity = warning
 
 dotnet_naming_rule.private_const_fields_pascal_case.symbols = private_const_fields
 dotnet_naming_rule.private_const_fields_pascal_case.style = pascal_case
-dotnet_naming_rule.private_const_fields_pascal_case.severity = error
+dotnet_naming_rule.private_const_fields_pascal_case.severity = warning
 
 # Symbol specifications
 
@@ -1067,7 +1067,7 @@ dotnet_naming_style.camel_case_begins_with_underscore.capitalization = camel_cas
 #### .NET Compiler Platform general options ####
 
 # Change the default rule severity for all analyzer rules that are enabled by default
-dotnet_analyzer_diagnostic.severity = error
+dotnet_analyzer_diagnostic.severity = warning
 
 #### .NET Compiler Platform code refactoring rules ####
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <WarningLevel>9999</WarningLevel>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+  <PropertyGroup Condition="'$(Configuration)' == 'Release' Or '$(CI)' != ''">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,6 +11,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>latest</LangVersion>
     <WarningLevel>9999</WarningLevel>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "version": "9.0.100",
-    "rollForward": "latestMajor"
-  }
-}


### PR DESCRIPTION
Having this enabled in Debug is imho annoying for multiple reasons:

- sometimes you just want to temporarily add code for debugging and don't want to deal with the errors.
- when a .NET SDK major version introduces new analyzers, you can't build anymore. I e.g. currently can't build just because I have .NET 10 Preview installed.
- In other projects I haven seen even minor SDK versions introduce new warnings because there were bugfixes in existing analyzers. So you suddenly can't build because of a .NET SDK minor update.