### PR TITLE
Add a debug helper for reading traffic with Wireshark

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,3 +41,11 @@ The tests always log to the console. See the [Logging documentation](https://ssh
 ### Wireshark
 
 Wireshark is able to dissect initial connection packets, such as key exchange, before encryption happens. Enter "ssh" as the display filter. See https://wiki.wireshark.org/SSH.md for more information.
+
+The Debug build of SSH.NET has helpers to also allow dissection of the encrypted traffic by dumping the session keys in a format that Wireshark understands. Set a value for `SshNetLoggingConfiguration.WiresharkKeyLogFilePath` before connecting, and supply the same value to Wireshark in Edit -> Preferences -> Protocols -> SSH -> "Key log filename".
+
+```c#
+using Renci.SshNet;
+
+SshNetLoggingConfiguration.WiresharkKeyLogFilePath = @"C:\tmp\sshkeylogfile.txt";
+```

--- a/src/Renci.SshNet/Session.cs
+++ b/src/Renci.SshNet/Session.cs
@@ -320,7 +320,7 @@ namespace Renci.SshNet
         /// Gets the client init message.
         /// </summary>
         /// <value>The client init message.</value>
-        public Message ClientInitMessage { get; private set; }
+        public KeyExchangeInitMessage ClientInitMessage { get; private set; }
 
         /// <summary>
         /// Gets the server version string.
@@ -1581,6 +1581,16 @@ namespace Renci.SshNet
 
             _clientCompression = _keyExchange.CreateCompressor();
             _serverDecompression = _keyExchange.CreateDecompressor();
+
+#if DEBUG
+            if (SshNetLoggingConfiguration.WiresharkKeyLogFilePath is string path
+                && _keyExchange is KeyExchange kex)
+            {
+                System.IO.File.AppendAllText(
+                    path,
+                    $"{ToHex(ClientInitMessage.Cookie)} SHARED_SECRET {ToHex(kex.SharedKey)}{Environment.NewLine}");
+            }
+#endif
 
             // Dispose of old KeyExchange object as it is no longer needed.
             _keyExchange.HostKeyReceived -= KeyExchange_HostKeyReceived;

--- a/src/Renci.SshNet/SshNetLoggingConfiguration.cs
+++ b/src/Renci.SshNet/SshNetLoggingConfiguration.cs
@@ -22,5 +22,17 @@ namespace Renci.SshNet
             ThrowHelper.ThrowIfNull(loggerFactory);
             LoggerFactory = loggerFactory;
         }
+
+#if DEBUG
+        /// <summary>
+        /// Gets or sets the path to which to write session secrets which
+        /// Wireshark can read and use to inspect encrypted traffic.
+        /// </summary>
+        /// <remarks>
+        /// To configure in Wireshark, go to Edit -> Preferences -> Protocols
+        /// -> SSH and set the same value for "Key log filename".
+        /// </remarks>
+        public static string? WiresharkKeyLogFilePath { get; set; }
+#endif
     }
 }


### PR DESCRIPTION
Wireshark can already helpfully dissect the initial SSH handshake. When given the session keys, it can also dissect the encrypted traffic for inspection/debugging. This adds a helper in Debug mode to write out that information in the format Wireshark requires.

Usage is to set `SshNetLoggingConfiguration.WiresharkKeyLogFilePath` before connecting, and supply the same value to Wireshark in Edit -> Preferences -> Protocols -> SSH -> "Key log filename".

Description of the format is at https://wiki.wireshark.org/SSH#key-log-format and https://gitlab.com/wireshark/wireshark/-/blob/82d6f8631aad39f1f10db77a62ebae01e3be881f/epan/dissectors/packet-ssh.c#L2071

I've had this branch around for a while and had the impression that it didn't always work, but seems OK testing recently

![image](https://github.com/user-attachments/assets/902746a7-fcb0-4de3-a9a5-5873507c70d9)
