### PR TITLE
Check host key algorithms before continuing key exchange

### DIFF
--- a/src/Renci.SshNet/ServiceFactory.cs
+++ b/src/Renci.SshNet/ServiceFactory.cs
@@ -101,7 +101,7 @@ namespace Renci.SshNet
 
             if (keyExchangeAlgorithmFactory is null)
             {
-                throw new SshConnectionException("Failed to negotiate key exchange algorithm.", DisconnectReason.KeyExchangeFailed);
+                throw new SshConnectionException($"No matching key exchange algorithm (server offers {serverAlgorithms.Join(",")})", DisconnectReason.KeyExchangeFailed);
             }
 
             return keyExchangeAlgorithmFactory();


### PR DESCRIPTION
The library currently does not check for matching host key algorithms until needed at the end of the key exchange, in contrast to other algorithm types which are checked beforehand. This leads to confusing or uninformative errors, normally from the server (correctly) closing the connection.

This change moves that check alongside the rest of them, and also improves the error messages that arise from no matching algorithms. For example, the error in #1641 (and probably #1636) is now

```
Renci.SshNet.Common.SshConnectionException: No matching host key algorithm (server offers ssh-dss)
```