### PR TITLE
fix IDE0350 warnings with .NET SDK 9.0.300

### DIFF
--- a/test/Renci.SshNet.IntegrationTests/OldIntegrationTests/SshCommandTest.cs
+++ b/test/Renci.SshNet.IntegrationTests/OldIntegrationTests/SshCommandTest.cs
@@ -457,14 +457,14 @@ namespace Renci.SshNet.IntegrationTests.OldIntegrationTests
                         client.Connect();
                         return client;
                     },
-                    (int counter, ParallelLoopState pls, SshClient client) =>
+                    (counter, pls, client) =>
                     {
                         var result = ExecuteTestCommand(client);
                         Debug.WriteLine(string.Format("TestMultipleThreadMultipleConnections #{0}", counter));
                         Assert.IsTrue(result);
                         return client;
                     },
-                    (SshClient client) =>
+                    client =>
                     {
                         client.Disconnect();
                         client.Dispose();


### PR DESCRIPTION
These warnings started appearing with .NET SDK 9.0.300 .


```
test\Renci.SshNet.IntegrationTests\OldIntegrationTests\SshCommandTest.cs(460,21,460,22): warning IDE0350: Lambda expression can be simplified (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0350)
```