### PR TITLE
Drop netstandard2.1 target

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ OpenSSH certificate authentication is supported for all of the above, e.g. ssh-e
 
 **SSH.NET** supports the following target frameworks:
 * .NETFramework 4.6.2 (and higher)
-* .NET Standard 2.0 and 2.1
+* .NET Standard 2.0
 * .NET 8 (and higher)
 
 ## Building the library

--- a/src/Renci.SshNet/Abstractions/SocketExtensions.cs
+++ b/src/Renci.SshNet/Abstractions/SocketExtensions.cs
@@ -93,11 +93,7 @@ namespace Renci.SshNet.Abstractions
             {
                 args.RemoteEndPoint = remoteEndpoint;
 
-#if NETSTANDARD2_1
-                await using (cancellationToken.Register(o => ((AwaitableSocketAsyncEventArgs)o).SetCancelled(), args, useSynchronizationContext: false).ConfigureAwait(continueOnCapturedContext: false))
-#else
                 using (cancellationToken.Register(o => ((AwaitableSocketAsyncEventArgs)o).SetCancelled(), args, useSynchronizationContext: false))
-#endif
                 {
                     await args.ExecuteAsync(socket.ConnectAsync);
                 }
@@ -112,11 +108,7 @@ namespace Renci.SshNet.Abstractions
             {
                 args.SetBuffer(buffer, offset, length);
 
-#if NETSTANDARD2_1
-                await using (cancellationToken.Register(o => ((AwaitableSocketAsyncEventArgs)o).SetCancelled(), args, useSynchronizationContext: false).ConfigureAwait(continueOnCapturedContext: false))
-#else
                 using (cancellationToken.Register(o => ((AwaitableSocketAsyncEventArgs)o).SetCancelled(), args, useSynchronizationContext: false))
-#endif
                 {
                     await args.ExecuteAsync(socket.ReceiveAsync);
                 }

--- a/src/Renci.SshNet/Abstractions/StreamExtensions.cs
+++ b/src/Renci.SshNet/Abstractions/StreamExtensions.cs
@@ -1,4 +1,4 @@
-#if NETFRAMEWORK || NETSTANDARD2_0
+#if !NET
 using System;
 using System.IO;
 using System.Threading.Tasks;

--- a/src/Renci.SshNet/ClientAuthentication.cs
+++ b/src/Renci.SshNet/ClientAuthentication.cs
@@ -105,7 +105,7 @@ namespace Renci.SshNet
             {
                 authenticationException = new SshAuthenticationException(string.Format(CultureInfo.InvariantCulture,
                                                                                        "No suitable authentication method found to complete authentication ({0}).",
-#if NET || NETSTANDARD2_1
+#if NET
                                                                                        string.Join(',', allowedAuthenticationMethods)))
 #else
                                                                                        string.Join(",", allowedAuthenticationMethods)))

--- a/src/Renci.SshNet/Common/Extensions.cs
+++ b/src/Renci.SshNet/Common/Extensions.cs
@@ -50,7 +50,7 @@ namespace Renci.SshNet.Common
 
         internal static BigInteger ToBigInteger(this ReadOnlySpan<byte> data)
         {
-#if NETSTANDARD2_1 || NET
+#if NET
             return new BigInteger(data, isBigEndian: true);
 #else
             var reversed = data.ToArray();
@@ -61,7 +61,7 @@ namespace Renci.SshNet.Common
 
         internal static BigInteger ToBigInteger(this byte[] data)
         {
-#if NETSTANDARD2_1 || NET
+#if NET
             return new BigInteger(data, isBigEndian: true);
 #else
             var reversed = new byte[data.Length];
@@ -76,7 +76,7 @@ namespace Renci.SshNet.Common
         /// </summary>
         public static BigInteger ToBigInteger2(this byte[] data)
         {
-#if NETSTANDARD2_1 || NET
+#if NET
             return new BigInteger(data, isBigEndian: true, isUnsigned: true);
 #else
             if ((data[0] & (1 << 7)) != 0)
@@ -91,7 +91,7 @@ namespace Renci.SshNet.Common
 #endif
         }
 
-#if NETFRAMEWORK || NETSTANDARD2_0
+#if !NET
         public static byte[] ToByteArray(this BigInteger bigInt, bool isUnsigned = false, bool isBigEndian = false)
         {
             var data = bigInt.ToByteArray();
@@ -361,7 +361,7 @@ namespace Renci.SshNet.Common
             return string.Join(separator, values);
         }
 
-#if NETFRAMEWORK || NETSTANDARD2_0
+#if !NET
         internal static bool TryAdd<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, TValue value)
         {
             if (!dictionary.ContainsKey(key))

--- a/src/Renci.SshNet/Common/PipeStream.cs
+++ b/src/Renci.SshNet/Common/PipeStream.cs
@@ -51,7 +51,7 @@ namespace Renci.SshNet.Common
             return Read(buffer.AsSpan(offset, count));
         }
 
-#if NETSTANDARD2_1 || NET
+#if NET
         /// <inheritdoc/>
         public override int Read(Span<byte> buffer)
 #else
@@ -99,7 +99,7 @@ namespace Renci.SshNet.Common
             }
         }
 
-#if NETSTANDARD2_1 || NET
+#if NET
         /// <inheritdoc/>
         public override void Write(ReadOnlySpan<byte> buffer)
         {
@@ -157,7 +157,7 @@ namespace Renci.SshNet.Common
             return WriteAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
         }
 
-#if NETSTANDARD2_1 || NET
+#if NET
         /// <inheritdoc/>
         public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
 #else

--- a/src/Renci.SshNet/Common/SshData.cs
+++ b/src/Renci.SshNet/Common/SshData.cs
@@ -372,7 +372,7 @@ namespace Renci.SshNet.Common
         /// <param name="data">name-list data to write.</param>
         protected void Write(string[] data)
         {
-#if NET || NETSTANDARD2_1
+#if NET
             Write(string.Join(',', data), Ascii);
 #else
             Write(string.Join(",", data), Ascii);

--- a/src/Renci.SshNet/Common/SshDataStream.cs
+++ b/src/Renci.SshNet/Common/SshDataStream.cs
@@ -59,7 +59,7 @@ namespace Renci.SshNet.Common
             }
         }
 
-#if NETFRAMEWORK || NETSTANDARD2_0
+#if !NET
         private void Write(ReadOnlySpan<byte> buffer)
         {
             var sharedBuffer = System.Buffers.ArrayPool<byte>.Shared.Rent(buffer.Length);
@@ -129,7 +129,7 @@ namespace Renci.SshNet.Common
             ThrowHelper.ThrowIfNull(s);
             ThrowHelper.ThrowIfNull(encoding);
 
-#if NETSTANDARD2_1 || NET
+#if NET
             ReadOnlySpan<char> value = s;
             var count = encoding.GetByteCount(value);
             var bytes = count <= 256 ? stackalloc byte[count] : new byte[count];
@@ -220,7 +220,7 @@ namespace Renci.SshNet.Common
         /// </returns>
         public BigInteger ReadBigInt()
         {
-#if NETSTANDARD2_1 || NET
+#if NET
             var data = ReadBinarySegment();
             return new BigInteger(data, isBigEndian: true);
 #else

--- a/src/Renci.SshNet/Connection/ProxyConnector.cs
+++ b/src/Renci.SshNet/Connection/ProxyConnector.cs
@@ -21,14 +21,14 @@ namespace Renci.SshNet.Connection
 
         // ToDo: Performs async/sync fallback, true async version should be implemented in derived classes
         protected virtual
-#if NET || NETSTANDARD2_1
+#if NET
         async
 #endif
         Task HandleProxyConnectAsync(IConnectionInfo connectionInfo, Socket socket, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-#if NET || NETSTANDARD2_1
+#if NET
             await using (cancellationToken.Register(o => ((Socket)o).Dispose(), socket, useSynchronizationContext: false).ConfigureAwait(continueOnCapturedContext: false))
 #else
             using (cancellationToken.Register(o => ((Socket)o).Dispose(), socket, useSynchronizationContext: false))
@@ -39,7 +39,7 @@ namespace Renci.SshNet.Connection
 #pragma warning restore MA0042 // Do not use blocking calls in an async method
             }
 
-#if !NET && !NETSTANDARD2_1
+#if !NET
             return Task.CompletedTask;
 #endif
         }

--- a/src/Renci.SshNet/Messages/Authentication/FailureMessage.cs
+++ b/src/Renci.SshNet/Messages/Authentication/FailureMessage.cs
@@ -55,7 +55,7 @@ namespace Renci.SshNet.Messages.Authentication
             PartialSuccess = ReadBoolean();
             if (PartialSuccess)
             {
-#if NET || NETSTANDARD2_1
+#if NET
                 Message = string.Join(',', AllowedAuthentications);
 #else
                 Message = string.Join(",", AllowedAuthentications);

--- a/src/Renci.SshNet/Renci.SshNet.csproj
+++ b/src/Renci.SshNet/Renci.SshNet.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>Renci.SshNet</AssemblyName>
     <Product>SSH.NET</Product>
     <AssemblyTitle>SSH.NET</AssemblyTitle>
-    <TargetFrameworks>net462;netstandard2.0;netstandard2.1;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Renci.SshNet/ScpClient.cs
+++ b/src/Renci.SshNet/ScpClient.cs
@@ -670,7 +670,7 @@ namespace Renci.SshNet
         /// <param name="fileOrDirectory">The file or directory to upload.</param>
         private void UploadTimes(IChannelSession channel, Stream input, FileSystemInfo fileOrDirectory)
         {
-#if NET || NETSTANDARD2_1
+#if NET
             var zeroTime = DateTime.UnixEpoch;
 #else
             var zeroTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
@@ -851,7 +851,7 @@ namespace Renci.SshNet
                     var mtime = long.Parse(match.Result("${mtime}"), CultureInfo.InvariantCulture);
                     var atime = long.Parse(match.Result("${atime}"), CultureInfo.InvariantCulture);
 
-#if NET || NETSTANDARD2_1
+#if NET
                     var zeroTime = DateTime.UnixEpoch;
 #else
                     var zeroTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);

--- a/src/Renci.SshNet/Security/Cryptography/EcdsaKey.cs
+++ b/src/Renci.SshNet/Security/Cryptography/EcdsaKey.cs
@@ -147,7 +147,7 @@ namespace Renci.SshNet.Security
                 Buffer.BlockCopy(qy, 0, q, qx.Length + 1, qy.Length);
 
                 // returns Curve-Name and x/y as ECPoint
-#if NETSTANDARD2_1 || NET
+#if NET
                 return new[] { curve, new BigInteger(q, isBigEndian: true) };
 #else
                 Array.Reverse(q);

--- a/src/Renci.SshNet/Session.cs
+++ b/src/Renci.SshNet/Session.cs
@@ -1326,7 +1326,7 @@ namespace Renci.SshNet
             if (_serverMac != null && _serverEtm)
             {
                 var clientHash = _serverMac.ComputeHash(data, 0, data.Length - serverMacLength);
-#if NETSTANDARD2_1 || NET
+#if NET
                 if (!CryptographicOperations.FixedTimeEquals(clientHash, new ReadOnlySpan<byte>(data, data.Length - serverMacLength, serverMacLength)))
 #else
                 if (!Org.BouncyCastle.Utilities.Arrays.FixedTimeEquals(serverMacLength, clientHash, 0, data, data.Length - serverMacLength))
@@ -1354,7 +1354,7 @@ namespace Renci.SshNet
             if (_serverMac != null && !_serverEtm)
             {
                 var clientHash = _serverMac.ComputeHash(data, 0, data.Length - serverMacLength);
-#if NETSTANDARD2_1 || NET
+#if NET
                 if (!CryptographicOperations.FixedTimeEquals(clientHash, new ReadOnlySpan<byte>(data, data.Length - serverMacLength, serverMacLength)))
 #else
                 if (!Org.BouncyCastle.Utilities.Arrays.FixedTimeEquals(serverMacLength, clientHash, 0, data, data.Length - serverMacLength))

--- a/src/Renci.SshNet/Sftp/SftpSession.cs
+++ b/src/Renci.SshNet/Sftp/SftpSession.cs
@@ -135,7 +135,7 @@ namespace Renci.SshNet.Sftp
             if (fullPath.EndsWith("/.", StringComparison.OrdinalIgnoreCase) ||
                 fullPath.EndsWith("/..", StringComparison.OrdinalIgnoreCase) ||
                 fullPath.Equals("/", StringComparison.OrdinalIgnoreCase) ||
-#if NET || NETSTANDARD2_1
+#if NET
                 fullPath.IndexOf('/', StringComparison.OrdinalIgnoreCase) < 0)
 #else
                 fullPath.IndexOf('/') < 0)
@@ -146,7 +146,7 @@ namespace Renci.SshNet.Sftp
 
             var pathParts = fullPath.Split('/');
 
-#if NET || NETSTANDARD2_1
+#if NET
             var partialFullPath = string.Join('/', pathParts, 0, pathParts.Length - 1);
 #else
             var partialFullPath = string.Join("/", pathParts, 0, pathParts.Length - 1);
@@ -206,7 +206,7 @@ namespace Renci.SshNet.Sftp
             if (fullPath.EndsWith("/.", StringComparison.Ordinal) ||
                 fullPath.EndsWith("/..", StringComparison.Ordinal) ||
                 fullPath.Equals("/", StringComparison.Ordinal) ||
-#if NET || NETSTANDARD2_1
+#if NET
                 fullPath.IndexOf('/', StringComparison.Ordinal) < 0)
 #else
                 fullPath.IndexOf('/') < 0)
@@ -217,7 +217,7 @@ namespace Renci.SshNet.Sftp
 
             var pathParts = fullPath.Split('/');
 
-#if NET || NETSTANDARD2_1
+#if NET
             var partialFullPath = string.Join('/', pathParts);
 #else
             var partialFullPath = string.Join("/", pathParts);

--- a/src/Renci.SshNet/SftpClient.cs
+++ b/src/Renci.SshNet/SftpClient.cs
@@ -2308,7 +2308,7 @@ namespace Renci.SshNet
 
             var basePath = fullPath;
 
-#if NET || NETSTANDARD2_1
+#if NET
             if (!basePath.EndsWith('/'))
 #else
             if (!basePath.EndsWith("/", StringComparison.Ordinal))

--- a/src/Renci.SshNet/ShellStream.cs
+++ b/src/Renci.SshNet/ShellStream.cs
@@ -762,7 +762,7 @@ namespace Renci.SshNet
             return Read(buffer.AsSpan(offset, count));
         }
 
-#if NETSTANDARD2_1 || NET
+#if NET
         /// <inheritdoc/>
         public override int Read(Span<byte> buffer)
 #else
@@ -838,7 +838,7 @@ namespace Renci.SshNet
             Write(buffer.AsSpan(offset, count));
         }
 
-#if NETSTANDARD2_1 || NET
+#if NET
         /// <inheritdoc/>
         public override void Write(ReadOnlySpan<byte> buffer)
 #else


### PR DESCRIPTION
This is imho not worth targeting. The only non-EOL frameworks that actually benefit from this are Mono 6.4 and Unity 2021.2 (see https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-1).

Even if people use SSH.NET with any of these, they will still work fine with the netstandard2.0 target and only miss very minor optimizations.

Simplified `#if NETFRAMEWORK || NETSTANDARD2_0` to `#if !NET` in the process.