### PR TITLE
Use ArraySegment for channel data

### DIFF
--- a/src/Renci.SshNet/Channels/Channel.cs
+++ b/src/Renci.SshNet/Channels/Channel.cs
@@ -378,9 +378,9 @@ namespace Renci.SshNet.Channels
         /// Called when channel data is received.
         /// </summary>
         /// <param name="data">The data.</param>
-        protected virtual void OnData(byte[] data)
+        protected virtual void OnData(ArraySegment<byte> data)
         {
-            AdjustDataWindow(data);
+            AdjustDataWindow(data.Count);
 
             DataReceived?.Invoke(this, new ChannelDataEventArgs(LocalChannelNumber, data));
         }
@@ -392,7 +392,7 @@ namespace Renci.SshNet.Channels
         /// <param name="dataTypeCode">The data type code.</param>
         protected virtual void OnExtendedData(byte[] data, uint dataTypeCode)
         {
-            AdjustDataWindow(data);
+            AdjustDataWindow(data.Length);
 
             ExtendedDataReceived?.Invoke(this, new ChannelExtendedDataEventArgs(LocalChannelNumber, data, dataTypeCode));
         }
@@ -651,7 +651,7 @@ namespace Renci.SshNet.Channels
             {
                 try
                 {
-                    OnData(e.Message.Data);
+                    OnData(new ArraySegment<byte>(e.Message.Data, e.Message.Offset, e.Message.Size));
                 }
                 catch (Exception ex)
                 {
@@ -768,9 +768,9 @@ namespace Renci.SshNet.Channels
             }
         }
 
-        private void AdjustDataWindow(byte[] messageData)
+        private void AdjustDataWindow(int count)
         {
-            LocalWindowSize -= (uint)messageData.Length;
+            LocalWindowSize -= (uint)count;
 
             // Adjust window if window size is too low
             if (LocalWindowSize < LocalPacketSize)

--- a/src/Renci.SshNet/Channels/ChannelDirectTcpip.cs
+++ b/src/Renci.SshNet/Channels/ChannelDirectTcpip.cs
@@ -194,7 +194,7 @@ namespace Renci.SshNet.Channels
         /// Called when channel data is received.
         /// </summary>
         /// <param name="data">The data.</param>
-        protected override void OnData(byte[] data)
+        protected override void OnData(ArraySegment<byte> data)
         {
             base.OnData(data);
 
@@ -204,7 +204,7 @@ namespace Renci.SshNet.Channels
                 {
                     if (_socket.IsConnected())
                     {
-                        SocketAbstraction.Send(_socket, data, 0, data.Length);
+                        SocketAbstraction.Send(_socket, data.Array, data.Offset, data.Count);
                     }
                 }
             }

--- a/src/Renci.SshNet/Channels/ChannelForwardedTcpip.cs
+++ b/src/Renci.SshNet/Channels/ChannelForwardedTcpip.cs
@@ -201,14 +201,14 @@ namespace Renci.SshNet.Channels
         /// Called when channel data is received.
         /// </summary>
         /// <param name="data">The data.</param>
-        protected override void OnData(byte[] data)
+        protected override void OnData(ArraySegment<byte> data)
         {
             base.OnData(data);
 
             var socket = _socket;
             if (socket.IsConnected())
             {
-                SocketAbstraction.Send(socket, data, 0, data.Length);
+                SocketAbstraction.Send(socket, data.Array, data.Offset, data.Count);
             }
         }
     }

--- a/src/Renci.SshNet/Common/ChannelDataEventArgs.cs
+++ b/src/Renci.SshNet/Common/ChannelDataEventArgs.cs
@@ -13,17 +13,22 @@ namespace Renci.SshNet.Common
         /// <param name="channelNumber">Channel number.</param>
         /// <param name="data">Channel data.</param>
         /// <exception cref="ArgumentNullException"><paramref name="data"/> is <see langword="null"/>.</exception>
-        public ChannelDataEventArgs(uint channelNumber, byte[] data)
+        public ChannelDataEventArgs(uint channelNumber, ArraySegment<byte> data)
             : base(channelNumber)
         {
-            ThrowHelper.ThrowIfNull(data);
+            ThrowHelper.ThrowIfNull(data.Array);
 
             Data = data;
+        }
+
+        internal ChannelDataEventArgs(uint channelNumber, byte[] data)
+            : this(channelNumber, new ArraySegment<byte>(data))
+        {
         }
 
         /// <summary>
         /// Gets channel data.
         /// </summary>
-        public byte[] Data { get; }
+        public ArraySegment<byte> Data { get; }
     }
 }

--- a/src/Renci.SshNet/Common/ChannelExtendedDataEventArgs.cs
+++ b/src/Renci.SshNet/Common/ChannelExtendedDataEventArgs.cs
@@ -1,4 +1,6 @@
-﻿namespace Renci.SshNet.Common
+﻿using System;
+
+namespace Renci.SshNet.Common
 {
     /// <summary>
     /// Provides data for <see cref="Channels.Channel.ExtendedDataReceived"/> events.
@@ -12,7 +14,7 @@
         /// <param name="data">Channel data.</param>
         /// <param name="dataTypeCode">Channel data type code.</param>
         public ChannelExtendedDataEventArgs(uint channelNumber, byte[] data, uint dataTypeCode)
-            : base(channelNumber, data)
+            : base(channelNumber, new ArraySegment<byte>(data))
         {
             DataTypeCode = dataTypeCode;
         }

--- a/src/Renci.SshNet/Common/SshData.cs
+++ b/src/Renci.SshNet/Common/SshData.cs
@@ -232,7 +232,7 @@ namespace Renci.SshNet.Common
         }
 
         /// <summary>
-        /// Reads next data type as byte array from internal buffer.
+        /// Reads a length-prefixed byte array from the internal buffer.
         /// </summary>
         /// <returns>
         /// The bytes read.
@@ -240,6 +240,20 @@ namespace Renci.SshNet.Common
         protected byte[] ReadBinary()
         {
             return _stream.ReadBinary();
+        }
+
+        /// <summary>
+        /// Reads a length-prefixed byte array from the internal buffer,
+        /// returned as a view over the buffer.
+        /// </summary>
+        /// <remarks>
+        /// When using this method, consider whether the underlying buffer is shared
+        /// or reused, and whether the returned <see cref="ArraySegment{T}"/> may
+        /// exist beyond the lifetime for which it is valid to be used.
+        /// </remarks>
+        private protected ArraySegment<byte> ReadBinarySegment()
+        {
+            return _stream.ReadBinarySegment();
         }
 
         /// <summary>

--- a/src/Renci.SshNet/Messages/Connection/ChannelDataMessage.cs
+++ b/src/Renci.SshNet/Messages/Connection/ChannelDataMessage.cs
@@ -120,9 +120,11 @@ namespace Renci.SshNet.Messages.Connection
         {
             base.LoadData();
 
-            Data = ReadBinary();
-            Offset = 0;
-            Size = Data.Length;
+            var data = ReadBinarySegment();
+
+            Data = data.Array;
+            Offset = data.Offset;
+            Size = data.Count;
         }
 
         /// <summary>

--- a/src/Renci.SshNet/Netconf/NetConfSession.cs
+++ b/src/Renci.SshNet/Netconf/NetConfSession.cs
@@ -121,9 +121,9 @@ namespace Renci.SshNet.NetConf
             WaitOnHandle(_serverCapabilitiesConfirmed, OperationTimeout);
         }
 
-        protected override void OnDataReceived(byte[] data)
+        protected override void OnDataReceived(ArraySegment<byte> data)
         {
-            var chunk = Encoding.UTF8.GetString(data);
+            var chunk = Encoding.UTF8.GetString(data.Array, data.Offset, data.Count);
 
             if (ServerCapabilities is null)
             {

--- a/src/Renci.SshNet/ScpClient.cs
+++ b/src/Renci.SshNet/ScpClient.cs
@@ -257,7 +257,7 @@ namespace Renci.SshNet
             using (var input = ServiceFactory.CreatePipeStream())
             using (var channel = Session.CreateChannelSession())
             {
-                channel.DataReceived += (sender, e) => input.Write(e.Data, 0, e.Data.Length);
+                channel.DataReceived += (sender, e) => input.Write(e.Data.Array!, e.Data.Offset, e.Data.Count);
                 channel.Closed += (sender, e) => input.Dispose();
                 channel.Open();
 
@@ -300,7 +300,7 @@ namespace Renci.SshNet
             using (var input = ServiceFactory.CreatePipeStream())
             using (var channel = Session.CreateChannelSession())
             {
-                channel.DataReceived += (sender, e) => input.Write(e.Data, 0, e.Data.Length);
+                channel.DataReceived += (sender, e) => input.Write(e.Data.Array!, e.Data.Offset, e.Data.Count);
                 channel.Closed += (sender, e) => input.Dispose();
                 channel.Open();
 
@@ -346,7 +346,7 @@ namespace Renci.SshNet
             using (var input = ServiceFactory.CreatePipeStream())
             using (var channel = Session.CreateChannelSession())
             {
-                channel.DataReceived += (sender, e) => input.Write(e.Data, 0, e.Data.Length);
+                channel.DataReceived += (sender, e) => input.Write(e.Data.Array!, e.Data.Offset, e.Data.Count);
                 channel.Closed += (sender, e) => input.Dispose();
                 channel.Open();
 
@@ -389,7 +389,7 @@ namespace Renci.SshNet
             using (var input = ServiceFactory.CreatePipeStream())
             using (var channel = Session.CreateChannelSession())
             {
-                channel.DataReceived += (sender, e) => input.Write(e.Data, 0, e.Data.Length);
+                channel.DataReceived += (sender, e) => input.Write(e.Data.Array!, e.Data.Offset, e.Data.Count);
                 channel.Closed += (sender, e) => input.Dispose();
                 channel.Open();
 
@@ -429,7 +429,7 @@ namespace Renci.SshNet
             using (var input = ServiceFactory.CreatePipeStream())
             using (var channel = Session.CreateChannelSession())
             {
-                channel.DataReceived += (sender, e) => input.Write(e.Data, 0, e.Data.Length);
+                channel.DataReceived += (sender, e) => input.Write(e.Data.Array!, e.Data.Offset, e.Data.Count);
                 channel.Closed += (sender, e) => input.Dispose();
                 channel.Open();
 
@@ -469,7 +469,7 @@ namespace Renci.SshNet
             using (var input = ServiceFactory.CreatePipeStream())
             using (var channel = Session.CreateChannelSession())
             {
-                channel.DataReceived += (sender, e) => input.Write(e.Data, 0, e.Data.Length);
+                channel.DataReceived += (sender, e) => input.Write(e.Data.Array!, e.Data.Offset, e.Data.Count);
                 channel.Closed += (sender, e) => input.Dispose();
                 channel.Open();
 

--- a/src/Renci.SshNet/Shell.cs
+++ b/src/Renci.SshNet/Shell.cs
@@ -241,12 +241,12 @@ namespace Renci.SshNet
 
         private void Channel_ExtendedDataReceived(object sender, ChannelExtendedDataEventArgs e)
         {
-            _extendedOutputStream?.Write(e.Data, 0, e.Data.Length);
+            _extendedOutputStream?.Write(e.Data.Array, e.Data.Offset, e.Data.Count);
         }
 
         private void Channel_DataReceived(object sender, ChannelDataEventArgs e)
         {
-            _outputStream?.Write(e.Data, 0, e.Data.Length);
+            _outputStream?.Write(e.Data.Array, e.Data.Offset, e.Data.Count);
         }
 
         private void Channel_Closed(object sender, ChannelEventArgs e)

--- a/src/Renci.SshNet/ShellStream.cs
+++ b/src/Renci.SshNet/ShellStream.cs
@@ -965,16 +965,16 @@ namespace Renci.SshNet
         {
             lock (_sync)
             {
-                _readBuffer.EnsureAvailableSpace(e.Data.Length);
+                _readBuffer.EnsureAvailableSpace(e.Data.Count);
 
                 e.Data.AsSpan().CopyTo(_readBuffer.AvailableSpan);
 
-                _readBuffer.Commit(e.Data.Length);
+                _readBuffer.Commit(e.Data.Count);
 
                 Monitor.PulseAll(_sync);
             }
 
-            DataReceived?.Invoke(this, new ShellDataEventArgs(e.Data));
+            DataReceived?.Invoke(this, new ShellDataEventArgs(e.Data.ToArray()));
         }
     }
 }

--- a/src/Renci.SshNet/SshCommand.cs
+++ b/src/Renci.SshNet/SshCommand.cs
@@ -583,7 +583,7 @@ namespace Renci.SshNet
 
         private void Channel_ExtendedDataReceived(object? sender, ChannelExtendedDataEventArgs e)
         {
-            ExtendedOutputStream.Write(e.Data, 0, e.Data.Length);
+            ExtendedOutputStream.Write(e.Data.Array!, e.Data.Offset, e.Data.Count);
 
             if (e.DataTypeCode == 1)
             {
@@ -593,7 +593,7 @@ namespace Renci.SshNet
 
         private void Channel_DataReceived(object? sender, ChannelDataEventArgs e)
         {
-            OutputStream.Write(e.Data, 0, e.Data.Length);
+            OutputStream.Write(e.Data.Array!, e.Data.Offset, e.Data.Count);
         }
 
         /// <summary>

--- a/src/Renci.SshNet/SubsystemSession.cs
+++ b/src/Renci.SshNet/SubsystemSession.cs
@@ -173,7 +173,7 @@ namespace Renci.SshNet
         /// Called when data is received.
         /// </summary>
         /// <param name="data">The data.</param>
-        protected abstract void OnDataReceived(byte[] data);
+        protected abstract void OnDataReceived(ArraySegment<byte> data);
 
         /// <summary>
         /// Raises the error.

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelStub.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelStub.cs
@@ -68,7 +68,7 @@ namespace Renci.SshNet.Tests.Classes.Channels
             }
         }
 
-        protected override void OnData(byte[] data)
+        protected override void OnData(ArraySegment<byte> data)
         {
             base.OnData(data);
 

--- a/test/Renci.SshNet.Tests/Classes/Channels/ClientChannelStub.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ClientChannelStub.cs
@@ -72,7 +72,7 @@ namespace Renci.SshNet.Tests.Classes.Channels
             }
         }
 
-        protected override void OnData(byte[] data)
+        protected override void OnData(ArraySegment<byte> data)
         {
             base.OnData(data);
 

--- a/test/Renci.SshNet.Tests/Classes/Messages/Connection/ChannelDataMessageTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Messages/Connection/ChannelDataMessageTest.cs
@@ -145,9 +145,7 @@ namespace Renci.SshNet.Tests.Classes.Messages.Connection
 
             target.Load(bytes, 1, bytes.Length - 1); // skip message type
 
-            Assert.IsTrue(target.Data.SequenceEqual(data.Take(offset, size)));
-            Assert.AreEqual(0, target.Offset);
-            Assert.AreEqual(size, target.Size);
+            CollectionAssert.AreEqual(data.Take(offset, size), target.Data.Take(target.Offset, target.Size));
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSessionStub.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSessionStub.cs
@@ -37,7 +37,7 @@ namespace Renci.SshNet.Tests.Classes
             }
         }
 
-        protected override void OnDataReceived(byte[] data)
+        protected override void OnDataReceived(ArraySegment<byte> data)
         {
             OnDataReceivedInvocations.Add(new ChannelDataEventArgs(0, data));
 


### PR DESCRIPTION
~~currently based on #1649. this change is the second commit~~

The library currently allocates 4 bytes (and some) for every 1 byte of file downloaded(*). It could be 0. This takes it to 3.

(*)
1. Array allocated for read of encrypted packet from socket
2. Array for decrypted packet
3. Array for channel data (removed in this change)
4. Array for sftp data packet