### PR TITLE
scp: add flag to notify for uploading finished when uploaded an empty file

### DIFF
--- a/src/Renci.SshNet/ScpClient.cs
+++ b/src/Renci.SshNet/ScpClient.cs
@@ -240,12 +240,13 @@ namespace Renci.SshNet
         /// </summary>
         /// <param name="source">The <see cref="Stream"/> to upload.</param>
         /// <param name="path">A relative or absolute path for the remote file.</param>
+        /// <param name="notifyOnEmptyFile">Should the <see cref="Uploading"/> event be raised when the file is empty?</param>
         /// <exception cref="ArgumentNullException"><paramref name="path" /> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="path"/> is a zero-length <see cref="string"/>.</exception>
         /// <exception cref="ScpException">A directory with the specified path exists on the remote host.</exception>
         /// <exception cref="SshException">The secure copy execution request was rejected by the server.</exception>
         /// <exception cref="SshConnectionException">Client is not connected.</exception>
-        public void Upload(Stream source, string path)
+        public void Upload(Stream source, string path, bool notifyOnEmptyFile=false)
         {
             if (Session is null)
             {
@@ -271,7 +272,7 @@ namespace Renci.SshNet
                 CheckReturnCode(input);
 
                 UploadFileModeAndName(channel, input, source.Length, posixPath.File);
-                UploadFileContent(channel, input, source, posixPath.File);
+                UploadFileContent(channel, input, source, posixPath.File, notifyOnEmptyFile);
             }
         }
 
@@ -280,13 +281,14 @@ namespace Renci.SshNet
         /// </summary>
         /// <param name="fileInfo">The file system info.</param>
         /// <param name="path">A relative or absolute path for the remote file.</param>
+        /// <param name="notifyOnEmptyFile">Should the <see cref="Uploading"/> event be raised when the file is empty?</param>
         /// <exception cref="ArgumentNullException"><paramref name="fileInfo" /> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="path" /> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="path"/> is a zero-length <see cref="string"/>.</exception>
         /// <exception cref="ScpException">A directory with the specified path exists on the remote host.</exception>
         /// <exception cref="SshException">The secure copy execution request was rejected by the server.</exception>
         /// <exception cref="SshConnectionException">Client is not connected.</exception>
-        public void Upload(FileInfo fileInfo, string path)
+        public void Upload(FileInfo fileInfo, string path, bool notifyOnEmptyFile=false)
         {
             ThrowHelper.ThrowIfNull(fileInfo);
 
@@ -317,7 +319,7 @@ namespace Renci.SshNet
                 {
                     UploadTimes(channel, input, fileInfo);
                     UploadFileModeAndName(channel, input, source.Length, posixPath.File);
-                    UploadFileContent(channel, input, source, fileInfo.Name);
+                    UploadFileContent(channel, input, source, fileInfo.Name, notifyOnEmptyFile);
                 }
             }
         }
@@ -327,13 +329,14 @@ namespace Renci.SshNet
         /// </summary>
         /// <param name="directoryInfo">The directory info.</param>
         /// <param name="path">A relative or absolute path for the remote directory.</param>
+        /// <param name="notifyOnEmptyFile">Should the <see cref="Uploading"/> event be raised when the file is empty?</param>
         /// <exception cref="ArgumentNullException"><paramref name="directoryInfo"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="path"/> is a zero-length string.</exception>
         /// <exception cref="ScpException"><paramref name="path"/> does not exist on the remote host, is not a directory or the user does not have the required permission.</exception>
         /// <exception cref="SshException">The secure copy execution request was rejected by the server.</exception>
         /// <exception cref="SshConnectionException">Client is not connected.</exception>
-        public void Upload(DirectoryInfo directoryInfo, string path)
+        public void Upload(DirectoryInfo directoryInfo, string path, bool notifyOnEmptyFile=false)
         {
             ThrowHelper.ThrowIfNull(directoryInfo);
             ThrowHelper.ThrowIfNullOrEmpty(path);
@@ -362,7 +365,7 @@ namespace Renci.SshNet
 
                 CheckReturnCode(input);
 
-                UploadDirectoryContent(channel, input, directoryInfo);
+                UploadDirectoryContent(channel, input, directoryInfo, notifyOnEmptyFile);
             }
         }
 
@@ -556,10 +559,11 @@ namespace Renci.SshNet
         /// <param name="input">A <see cref="Stream"/> from which any feedback from the server can be read.</param>
         /// <param name="source">The content to upload.</param>
         /// <param name="remoteFileName">The name of the remote file, without path, to which the content is uploaded.</param>
+        /// <param name="notifyOnEmptyFile">Should the <see cref="Uploading"/> event be raised when the file is empty?</param>
         /// <remarks>
         /// <paramref name="remoteFileName"/> is only used for raising the <see cref="Uploading"/> event.
         /// </remarks>
-        private void UploadFileContent(IChannelSession channel, Stream input, Stream source, string remoteFileName)
+        private void UploadFileContent(IChannelSession channel, Stream input, Stream source, string remoteFileName, bool notifyOnEmptyFile)
         {
             var totalLength = source.Length;
             var buffer = new byte[BufferSize];
@@ -577,6 +581,11 @@ namespace Renci.SshNet
                 RaiseUploadingEvent(remoteFileName, totalLength, totalRead);
 
                 read = source.Read(buffer, 0, buffer.Length);
+            }
+
+            if (totalLength == 0 && totalRead == 0 && notifyOnEmptyFile)
+            {
+                RaiseUploadingEvent(remoteFileName, totalLength, totalRead);
             }
 
             SendSuccessConfirmation(channel);
@@ -687,7 +696,8 @@ namespace Renci.SshNet
         /// <param name="channel">The channel to perform the upload in.</param>
         /// <param name="input">A <see cref="Stream"/> from which any feedback from the server can be read.</param>
         /// <param name="directoryInfo">The directory to upload.</param>
-        private void UploadDirectoryContent(IChannelSession channel, Stream input, DirectoryInfo directoryInfo)
+        /// <param name="notifyOnEmptyFile">Should the <see cref="Uploading"/> event be raised when the file is empty?</param>
+        private void UploadDirectoryContent(IChannelSession channel, Stream input, DirectoryInfo directoryInfo, bool notifyOnEmptyFile=false)
         {
             // Upload files
             var files = directoryInfo.GetFiles();
@@ -697,7 +707,7 @@ namespace Renci.SshNet
                 {
                     UploadTimes(channel, input, file);
                     UploadFileModeAndName(channel, input, source.Length, file.Name);
-                    UploadFileContent(channel, input, source, file.Name);
+                    UploadFileContent(channel, input, source, file.Name, notifyOnEmptyFile);
                 }
             }
 
@@ -707,7 +717,7 @@ namespace Renci.SshNet
             {
                 UploadTimes(channel, input, directory);
                 UploadDirectoryModeAndName(channel, input, directory.Name);
-                UploadDirectoryContent(channel, input, directory);
+                UploadDirectoryContent(channel, input, directory, notifyOnEmptyFile);
             }
 
             // Mark upload of current directory complete

--- a/src/Renci.SshNet/ScpClient.cs
+++ b/src/Renci.SshNet/ScpClient.cs
@@ -240,13 +240,12 @@ namespace Renci.SshNet
         /// </summary>
         /// <param name="source">The <see cref="Stream"/> to upload.</param>
         /// <param name="path">A relative or absolute path for the remote file.</param>
-        /// <param name="notifyOnEmptyFile">Should the <see cref="Uploading"/> event be raised when the file is empty?</param>
         /// <exception cref="ArgumentNullException"><paramref name="path" /> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="path"/> is a zero-length <see cref="string"/>.</exception>
         /// <exception cref="ScpException">A directory with the specified path exists on the remote host.</exception>
         /// <exception cref="SshException">The secure copy execution request was rejected by the server.</exception>
         /// <exception cref="SshConnectionException">Client is not connected.</exception>
-        public void Upload(Stream source, string path, bool notifyOnEmptyFile=false)
+        public void Upload(Stream source, string path)
         {
             if (Session is null)
             {
@@ -272,7 +271,7 @@ namespace Renci.SshNet
                 CheckReturnCode(input);
 
                 UploadFileModeAndName(channel, input, source.Length, posixPath.File);
-                UploadFileContent(channel, input, source, posixPath.File, notifyOnEmptyFile);
+                UploadFileContent(channel, input, source, posixPath.File);
             }
         }
 
@@ -281,14 +280,13 @@ namespace Renci.SshNet
         /// </summary>
         /// <param name="fileInfo">The file system info.</param>
         /// <param name="path">A relative or absolute path for the remote file.</param>
-        /// <param name="notifyOnEmptyFile">Should the <see cref="Uploading"/> event be raised when the file is empty?</param>
         /// <exception cref="ArgumentNullException"><paramref name="fileInfo" /> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="path" /> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="path"/> is a zero-length <see cref="string"/>.</exception>
         /// <exception cref="ScpException">A directory with the specified path exists on the remote host.</exception>
         /// <exception cref="SshException">The secure copy execution request was rejected by the server.</exception>
         /// <exception cref="SshConnectionException">Client is not connected.</exception>
-        public void Upload(FileInfo fileInfo, string path, bool notifyOnEmptyFile=false)
+        public void Upload(FileInfo fileInfo, string path)
         {
             ThrowHelper.ThrowIfNull(fileInfo);
 
@@ -319,7 +317,7 @@ namespace Renci.SshNet
                 {
                     UploadTimes(channel, input, fileInfo);
                     UploadFileModeAndName(channel, input, source.Length, posixPath.File);
-                    UploadFileContent(channel, input, source, fileInfo.Name, notifyOnEmptyFile);
+                    UploadFileContent(channel, input, source, fileInfo.Name);
                 }
             }
         }
@@ -329,14 +327,13 @@ namespace Renci.SshNet
         /// </summary>
         /// <param name="directoryInfo">The directory info.</param>
         /// <param name="path">A relative or absolute path for the remote directory.</param>
-        /// <param name="notifyOnEmptyFile">Should the <see cref="Uploading"/> event be raised when the file is empty?</param>
         /// <exception cref="ArgumentNullException"><paramref name="directoryInfo"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="path"/> is a zero-length string.</exception>
         /// <exception cref="ScpException"><paramref name="path"/> does not exist on the remote host, is not a directory or the user does not have the required permission.</exception>
         /// <exception cref="SshException">The secure copy execution request was rejected by the server.</exception>
         /// <exception cref="SshConnectionException">Client is not connected.</exception>
-        public void Upload(DirectoryInfo directoryInfo, string path, bool notifyOnEmptyFile=false)
+        public void Upload(DirectoryInfo directoryInfo, string path)
         {
             ThrowHelper.ThrowIfNull(directoryInfo);
             ThrowHelper.ThrowIfNullOrEmpty(path);
@@ -365,7 +362,7 @@ namespace Renci.SshNet
 
                 CheckReturnCode(input);
 
-                UploadDirectoryContent(channel, input, directoryInfo, notifyOnEmptyFile);
+                UploadDirectoryContent(channel, input, directoryInfo);
             }
         }
 
@@ -559,11 +556,10 @@ namespace Renci.SshNet
         /// <param name="input">A <see cref="Stream"/> from which any feedback from the server can be read.</param>
         /// <param name="source">The content to upload.</param>
         /// <param name="remoteFileName">The name of the remote file, without path, to which the content is uploaded.</param>
-        /// <param name="notifyOnEmptyFile">Should the <see cref="Uploading"/> event be raised when the file is empty?</param>
         /// <remarks>
         /// <paramref name="remoteFileName"/> is only used for raising the <see cref="Uploading"/> event.
         /// </remarks>
-        private void UploadFileContent(IChannelSession channel, Stream input, Stream source, string remoteFileName, bool notifyOnEmptyFile)
+        private void UploadFileContent(IChannelSession channel, Stream input, Stream source, string remoteFileName)
         {
             var totalLength = source.Length;
             var buffer = new byte[BufferSize];
@@ -583,7 +579,7 @@ namespace Renci.SshNet
                 read = source.Read(buffer, 0, buffer.Length);
             }
 
-            if (totalLength == 0 && totalRead == 0 && notifyOnEmptyFile)
+            if (totalLength == 0 && totalRead == 0)
             {
                 RaiseUploadingEvent(remoteFileName, totalLength, totalRead);
             }
@@ -696,8 +692,7 @@ namespace Renci.SshNet
         /// <param name="channel">The channel to perform the upload in.</param>
         /// <param name="input">A <see cref="Stream"/> from which any feedback from the server can be read.</param>
         /// <param name="directoryInfo">The directory to upload.</param>
-        /// <param name="notifyOnEmptyFile">Should the <see cref="Uploading"/> event be raised when the file is empty?</param>
-        private void UploadDirectoryContent(IChannelSession channel, Stream input, DirectoryInfo directoryInfo, bool notifyOnEmptyFile=false)
+        private void UploadDirectoryContent(IChannelSession channel, Stream input, DirectoryInfo directoryInfo)
         {
             // Upload files
             var files = directoryInfo.GetFiles();
@@ -707,7 +702,7 @@ namespace Renci.SshNet
                 {
                     UploadTimes(channel, input, file);
                     UploadFileModeAndName(channel, input, source.Length, file.Name);
-                    UploadFileContent(channel, input, source, file.Name, notifyOnEmptyFile);
+                    UploadFileContent(channel, input, source, file.Name);
                 }
             }
 
@@ -717,7 +712,7 @@ namespace Renci.SshNet
             {
                 UploadTimes(channel, input, directory);
                 UploadDirectoryModeAndName(channel, input, directory.Name);
-                UploadDirectoryContent(channel, input, directory, notifyOnEmptyFile);
+                UploadDirectoryContent(channel, input, directory);
             }
 
             // Mark upload of current directory complete


### PR DESCRIPTION
Added a new flag: `notifyOnEmptyFile` (default: `false`).

Details
    * This flag controls whether the `Uploading` event should be triggered when an uploaded file is empty (`totalLength` == 0).
    * When enabled and the uploaded file is empty, the `Uploading` event will still be raised.
    * This behavior is currently implemented only for **SCP** uploads.

Use Case
I’m building a simple .NET Framework application that uploads configuration files to an SSH server. Each upload triggers a log entry via the Uploading event. However, empty files were previously ignored, and no log was written. With this change, the log will accurately reflect all upload attempts — including empty files — when the flag is enabled.