### PR TITLE
Refactor logging to allow a loggerfactory per session

### DIFF
--- a/docfx/logging.md
+++ b/docfx/logging.md
@@ -1,7 +1,31 @@
 Logging
 =================
 
-SSH.NET uses the [Microsoft.Extensions.Logging](https://learn.microsoft.com/dotnet/core/extensions/logging) API to log diagnostic messages. In order to access the log messages of SSH.NET in your own application for diagnosis, register your own `ILoggerFactory` before using the SSH.NET APIs, for example:
+SSH.NET uses the [Microsoft.Extensions.Logging](https://learn.microsoft.com/dotnet/core/extensions/logging) API to log diagnostic messages. 
+
+It is possible to specify a logger in the `ConnectionInfo`, for example:
+
+```cs
+using Microsoft.Extensions.Logging;
+
+ILoggerFactory loggerFactory = LoggerFactory.Create(builder =>
+{
+    builder.SetMinimumLevel(LogLevel.Debug);
+    builder.AddConsole();
+});
+
+var connectionInfo = new ConnectionInfo("sftp.foo.com",
+                                        "guest",
+                                        new PasswordAuthenticationMethod("guest", "pwd"));
+										
+connectionInfo.LoggerFactory = loggerFactory;
+using (var client = new SftpClient(connectionInfo))
+{
+    client.Connect();
+}
+```
+
+You can also register an application-wide `ILoggerFactory` before using the SSH.NET APIs, this will be used as a fallback if the `ConnectionInfo` is not set, for example:
 
 ```cs
 using Microsoft.Extensions.Logging;

--- a/src/Renci.SshNet/BaseClient.cs
+++ b/src/Renci.SshNet/BaseClient.cs
@@ -20,6 +20,8 @@ namespace Renci.SshNet
         /// Holds value indicating whether the connection info is owned by this client.
         /// </summary>
         private readonly bool _ownsConnectionInfo;
+
+        private readonly ILogger _logger;
         private readonly IServiceFactory _serviceFactory;
         private readonly object _keepAliveLock = new object();
         private TimeSpan _keepAliveInterval;
@@ -34,14 +36,6 @@ namespace Renci.SshNet
         /// The current session.
         /// </value>
         internal ISession? Session { get; private set; }
-
-        internal ILogger? Logger
-        {
-            get
-            {
-                return Session?.SessionLoggerFactory?.CreateLogger(GetType());
-            }
-        }
 
         /// <summary>
         /// Gets the factory for creating new services.
@@ -198,6 +192,7 @@ namespace Renci.SshNet
             _connectionInfo = connectionInfo;
             _ownsConnectionInfo = ownsConnectionInfo;
             _serviceFactory = serviceFactory;
+            _logger = (connectionInfo.LoggerFactory ?? SshNetLoggingConfiguration.LoggerFactory).CreateLogger(GetType());
             _keepAliveInterval = Timeout.InfiniteTimeSpan;
         }
 
@@ -351,7 +346,7 @@ namespace Renci.SshNet
         /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
         public void Disconnect()
         {
-            Logger?.LogInformation("Disconnecting client.");
+            _logger.LogInformation("Disconnecting client.");
 
             CheckDisposed();
 
@@ -450,7 +445,7 @@ namespace Renci.SshNet
 
             if (disposing)
             {
-                Logger?.LogDebug("Disposing client.");
+                _logger.LogDebug("Disposing client.");
 
                 Disconnect();
 
@@ -513,7 +508,7 @@ namespace Renci.SshNet
                 }
                 catch (Exception ex)
                 {
-                    Logger?.LogError(ex, "Error sending keepalive message");
+                    _logger.LogError(ex, "Error sending keepalive message");
                 }
                 finally
                 {

--- a/src/Renci.SshNet/BaseClient.cs
+++ b/src/Renci.SshNet/BaseClient.cs
@@ -20,8 +20,6 @@ namespace Renci.SshNet
         /// Holds value indicating whether the connection info is owned by this client.
         /// </summary>
         private readonly bool _ownsConnectionInfo;
-
-        private readonly ILogger _logger;
         private readonly IServiceFactory _serviceFactory;
         private readonly object _keepAliveLock = new object();
         private TimeSpan _keepAliveInterval;
@@ -36,6 +34,14 @@ namespace Renci.SshNet
         /// The current session.
         /// </value>
         internal ISession? Session { get; private set; }
+
+        internal ILogger? Logger
+        {
+            get
+            {
+                return Session?.SessionLoggerFactory?.CreateLogger(GetType());
+            }
+        }
 
         /// <summary>
         /// Gets the factory for creating new services.
@@ -192,7 +198,6 @@ namespace Renci.SshNet
             _connectionInfo = connectionInfo;
             _ownsConnectionInfo = ownsConnectionInfo;
             _serviceFactory = serviceFactory;
-            _logger = SshNetLoggingConfiguration.LoggerFactory.CreateLogger(GetType());
             _keepAliveInterval = Timeout.InfiniteTimeSpan;
         }
 
@@ -346,7 +351,7 @@ namespace Renci.SshNet
         /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
         public void Disconnect()
         {
-            _logger.LogInformation("Disconnecting client.");
+            Logger?.LogInformation("Disconnecting client.");
 
             CheckDisposed();
 
@@ -445,7 +450,7 @@ namespace Renci.SshNet
 
             if (disposing)
             {
-                _logger.LogDebug("Disposing client.");
+                Logger?.LogDebug("Disposing client.");
 
                 Disconnect();
 
@@ -508,7 +513,7 @@ namespace Renci.SshNet
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Error sending keepalive message");
+                    Logger?.LogError(ex, "Error sending keepalive message");
                 }
                 finally
                 {

--- a/src/Renci.SshNet/Channels/Channel.cs
+++ b/src/Renci.SshNet/Channels/Channel.cs
@@ -84,7 +84,7 @@ namespace Renci.SshNet.Channels
             LocalChannelNumber = localChannelNumber;
             LocalPacketSize = localPacketSize;
             LocalWindowSize = localWindowSize;
-            _logger = SshNetLoggingConfiguration.LoggerFactory.CreateLogger(GetType());
+            _logger = session.SessionLoggerFactory.CreateLogger(GetType());
 
             session.ChannelWindowAdjustReceived += OnChannelWindowAdjust;
             session.ChannelDataReceived += OnChannelData;

--- a/src/Renci.SshNet/Channels/ChannelDirectTcpip.cs
+++ b/src/Renci.SshNet/Channels/ChannelDirectTcpip.cs
@@ -33,7 +33,7 @@ namespace Renci.SshNet.Channels
         public ChannelDirectTcpip(ISession session, uint localChannelNumber, uint localWindowSize, uint localPacketSize)
             : base(session, localChannelNumber, localWindowSize, localPacketSize)
         {
-            _logger = SshNetLoggingConfiguration.LoggerFactory.CreateLogger<ChannelDirectTcpip>();
+            _logger = session.SessionLoggerFactory.CreateLogger<ChannelDirectTcpip>();
         }
 
         /// <summary>

--- a/src/Renci.SshNet/Channels/ChannelForwardedTcpip.cs
+++ b/src/Renci.SshNet/Channels/ChannelForwardedTcpip.cs
@@ -48,7 +48,7 @@ namespace Renci.SshNet.Channels
                    remoteWindowSize,
                    remotePacketSize)
         {
-            _logger = SshNetLoggingConfiguration.LoggerFactory.CreateLogger<ChannelForwardedTcpip>();
+            _logger = session.SessionLoggerFactory.CreateLogger<ChannelForwardedTcpip>();
         }
 
         /// <summary>

--- a/src/Renci.SshNet/Connection/ConnectorBase.cs
+++ b/src/Renci.SshNet/Connection/ConnectorBase.cs
@@ -15,13 +15,15 @@ namespace Renci.SshNet.Connection
     internal abstract class ConnectorBase : IConnector
     {
         private readonly ILogger _logger;
+        private readonly ILoggerFactory _loggerFactory;
 
-        protected ConnectorBase(ISocketFactory socketFactory)
+        protected ConnectorBase(ISocketFactory socketFactory, ILoggerFactory loggerFactory)
         {
             ThrowHelper.ThrowIfNull(socketFactory);
 
             SocketFactory = socketFactory;
-            _logger = SshNetLoggingConfiguration.LoggerFactory.CreateLogger(GetType());
+            _loggerFactory = loggerFactory;
+            _logger = _loggerFactory.CreateLogger(GetType());
         }
 
         internal ISocketFactory SocketFactory { get; private set; }

--- a/src/Renci.SshNet/Connection/ConnectorBase.cs
+++ b/src/Renci.SshNet/Connection/ConnectorBase.cs
@@ -15,15 +15,13 @@ namespace Renci.SshNet.Connection
     internal abstract class ConnectorBase : IConnector
     {
         private readonly ILogger _logger;
-        private readonly ILoggerFactory _loggerFactory;
 
         protected ConnectorBase(ISocketFactory socketFactory, ILoggerFactory loggerFactory)
         {
             ThrowHelper.ThrowIfNull(socketFactory);
 
             SocketFactory = socketFactory;
-            _loggerFactory = loggerFactory;
-            _logger = _loggerFactory.CreateLogger(GetType());
+            _logger = loggerFactory.CreateLogger(GetType());
         }
 
         internal ISocketFactory SocketFactory { get; private set; }

--- a/src/Renci.SshNet/Connection/DirectConnector.cs
+++ b/src/Renci.SshNet/Connection/DirectConnector.cs
@@ -2,12 +2,14 @@
 using System.Net.Sockets;
 using System.Threading;
 
+using Microsoft.Extensions.Logging;
+
 namespace Renci.SshNet.Connection
 {
     internal sealed class DirectConnector : ConnectorBase
     {
-        public DirectConnector(ISocketFactory socketFactory)
-            : base(socketFactory)
+        public DirectConnector(ISocketFactory socketFactory, ILoggerFactory loggerFactory)
+            : base(socketFactory, loggerFactory)
         {
         }
 

--- a/src/Renci.SshNet/Connection/HttpConnector.cs
+++ b/src/Renci.SshNet/Connection/HttpConnector.cs
@@ -5,6 +5,8 @@ using System.Net;
 using System.Net.Sockets;
 using System.Text.RegularExpressions;
 
+using Microsoft.Extensions.Logging;
+
 using Renci.SshNet.Abstractions;
 using Renci.SshNet.Common;
 
@@ -48,8 +50,8 @@ namespace Renci.SshNet.Connection
         private static readonly Regex HttpHeaderRegex = new Regex(HttpHeaderPattern, RegexOptions.Compiled);
 #endif
 
-        public HttpConnector(ISocketFactory socketFactory)
-            : base(socketFactory)
+        public HttpConnector(ISocketFactory socketFactory, ILoggerFactory loggerFactory)
+            : base(socketFactory, loggerFactory)
         {
         }
 

--- a/src/Renci.SshNet/Connection/ProxyConnector.cs
+++ b/src/Renci.SshNet/Connection/ProxyConnector.cs
@@ -4,6 +4,8 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Microsoft.Extensions.Logging;
+
 namespace Renci.SshNet.Connection
 {
     /// <summary>
@@ -12,8 +14,8 @@ namespace Renci.SshNet.Connection
     /// </summary>
     internal abstract class ProxyConnector : ConnectorBase
     {
-        protected ProxyConnector(ISocketFactory socketFactory)
-            : base(socketFactory)
+        protected ProxyConnector(ISocketFactory socketFactory, ILoggerFactory loggerFactory)
+            : base(socketFactory, loggerFactory)
         {
         }
 

--- a/src/Renci.SshNet/Connection/Socks4Connector.cs
+++ b/src/Renci.SshNet/Connection/Socks4Connector.cs
@@ -4,6 +4,8 @@ using System.Net;
 using System.Net.Sockets;
 using System.Text;
 
+using Microsoft.Extensions.Logging;
+
 using Renci.SshNet.Abstractions;
 using Renci.SshNet.Common;
 
@@ -17,8 +19,8 @@ namespace Renci.SshNet.Connection
     /// </remarks>
     internal sealed class Socks4Connector : ProxyConnector
     {
-        public Socks4Connector(ISocketFactory socketFactory)
-            : base(socketFactory)
+        public Socks4Connector(ISocketFactory socketFactory, ILoggerFactory loggerFactory)
+            : base(socketFactory, loggerFactory)
         {
         }
 

--- a/src/Renci.SshNet/Connection/Socks5Connector.cs
+++ b/src/Renci.SshNet/Connection/Socks5Connector.cs
@@ -5,6 +5,8 @@ using System.Net;
 using System.Net.Sockets;
 using System.Text;
 
+using Microsoft.Extensions.Logging;
+
 using Renci.SshNet.Abstractions;
 using Renci.SshNet.Common;
 
@@ -18,8 +20,8 @@ namespace Renci.SshNet.Connection
     /// </remarks>
     internal sealed class Socks5Connector : ProxyConnector
     {
-        public Socks5Connector(ISocketFactory socketFactory)
-            : base(socketFactory)
+        public Socks5Connector(ISocketFactory socketFactory, ILoggerFactory loggerFactory)
+            : base(socketFactory, loggerFactory)
         {
         }
 

--- a/src/Renci.SshNet/ConnectionInfo.cs
+++ b/src/Renci.SshNet/ConnectionInfo.cs
@@ -5,6 +5,8 @@ using System.Net;
 using System.Security.Cryptography;
 using System.Text;
 
+using Microsoft.Extensions.Logging;
+
 using Renci.SshNet.Common;
 using Renci.SshNet.Compression;
 using Renci.SshNet.Messages.Authentication;
@@ -495,5 +497,13 @@ namespace Renci.SshNet
             get { return AuthenticationMethods.Cast<IAuthenticationMethod>().ToList(); }
 #pragma warning restore S2365 // Properties should not make collection or array copies
         }
+
+        /// <summary>
+        /// Gets or sets logger factory for this connection.
+        /// </summary>
+        /// <value>
+        /// The logger factory for this connection. If <see langword="null"/> then <see cref="SshNetLoggingConfiguration.LoggerFactory"/> should be used.
+        /// </value>
+        public ILoggerFactory LoggerFactory { get; set; }
     }
 }

--- a/src/Renci.SshNet/ConnectionInfo.cs
+++ b/src/Renci.SshNet/ConnectionInfo.cs
@@ -502,7 +502,7 @@ namespace Renci.SshNet
         /// Gets or sets logger factory for this connection.
         /// </summary>
         /// <value>
-        /// The logger factory for this connection. If <see langword="null"/> then <see cref="SshNetLoggingConfiguration.LoggerFactory"/> should be used.
+        /// The logger factory for this connection. If <see langword="null"/> then <see cref="SshNetLoggingConfiguration.LoggerFactory"/> is used.
         /// </value>
         public ILoggerFactory LoggerFactory { get; set; }
     }

--- a/src/Renci.SshNet/ForwardedPortDynamic.cs
+++ b/src/Renci.SshNet/ForwardedPortDynamic.cs
@@ -75,7 +75,7 @@ namespace Renci.SshNet
             BoundHost = host;
             BoundPort = port;
             _status = ForwardedPortStatus.Stopped;
-            _logger = SshNetLoggingConfiguration.LoggerFactory.CreateLogger<ForwardedPortDynamic>();
+            _logger = Session.SessionLoggerFactory.CreateLogger<ForwardedPortDynamic>();
         }
 
         /// <summary>

--- a/src/Renci.SshNet/ForwardedPortDynamic.cs
+++ b/src/Renci.SshNet/ForwardedPortDynamic.cs
@@ -21,7 +21,6 @@ namespace Renci.SshNet
     /// </summary>
     public class ForwardedPortDynamic : ForwardedPort
     {
-        private readonly ILogger _logger;
         private ForwardedPortStatus _status;
 
         /// <summary>
@@ -75,7 +74,6 @@ namespace Renci.SshNet
             BoundHost = host;
             BoundPort = port;
             _status = ForwardedPortStatus.Stopped;
-            _logger = Session.SessionLoggerFactory.CreateLogger<ForwardedPortDynamic>();
         }
 
         /// <summary>
@@ -416,7 +414,12 @@ namespace Renci.SshNet
 
             if (!_pendingChannelCountdown.Wait(timeout))
             {
-                _logger.LogInformation("Timeout waiting for pending channels in dynamic forwarded port to close.");
+                var session = Session;
+                if (session != null)
+                {
+                    var logger = session.SessionLoggerFactory.CreateLogger<ForwardedPortDynamic>();
+                    logger.LogInformation("Timeout waiting for pending channels in dynamic forwarded port to close.");
+                }
             }
         }
 

--- a/src/Renci.SshNet/ForwardedPortLocal.cs
+++ b/src/Renci.SshNet/ForwardedPortLocal.cs
@@ -14,7 +14,6 @@ namespace Renci.SshNet
     /// </summary>
     public partial class ForwardedPortLocal : ForwardedPort
     {
-        private readonly ILogger _logger;
         private ForwardedPortStatus _status;
         private bool _isDisposed;
         private Socket _listener;
@@ -103,7 +102,6 @@ namespace Renci.SshNet
             Host = host;
             Port = port;
             _status = ForwardedPortStatus.Stopped;
-            _logger = Session.SessionLoggerFactory.CreateLogger<ForwardedPortLocal>();
         }
 
         /// <summary>
@@ -390,7 +388,12 @@ namespace Renci.SshNet
 
             if (!_pendingChannelCountdown.Wait(timeout))
             {
-                _logger.LogInformation("Timeout waiting for pending channels in local forwarded port to close.");
+                var session = Session;
+                if (session != null)
+                {
+                    var logger = session.SessionLoggerFactory.CreateLogger<ForwardedPortLocal>();
+                    logger.LogInformation("Timeout waiting for pending channels in local forwarded port to close.");
+                }
             }
         }
 

--- a/src/Renci.SshNet/ForwardedPortLocal.cs
+++ b/src/Renci.SshNet/ForwardedPortLocal.cs
@@ -103,7 +103,7 @@ namespace Renci.SshNet
             Host = host;
             Port = port;
             _status = ForwardedPortStatus.Stopped;
-            _logger = SshNetLoggingConfiguration.LoggerFactory.CreateLogger<ForwardedPortLocal>();
+            _logger = Session.SessionLoggerFactory.CreateLogger<ForwardedPortLocal>();
         }
 
         /// <summary>

--- a/src/Renci.SshNet/ForwardedPortRemote.cs
+++ b/src/Renci.SshNet/ForwardedPortRemote.cs
@@ -16,7 +16,6 @@ namespace Renci.SshNet
     /// </summary>
     public class ForwardedPortRemote : ForwardedPort
     {
-        private readonly ILogger _logger;
         private ForwardedPortStatus _status;
         private bool _requestStatus;
         private EventWaitHandle _globalRequestResponse = new AutoResetEvent(initialState: false);
@@ -100,7 +99,6 @@ namespace Renci.SshNet
             HostAddress = hostAddress;
             Port = port;
             _status = ForwardedPortStatus.Stopped;
-            _logger = Session.SessionLoggerFactory.CreateLogger<ForwardedPortRemote>();
         }
 
         /// <summary>
@@ -212,7 +210,12 @@ namespace Renci.SshNet
 
             if (!_pendingChannelCountdown.Wait(timeout))
             {
-                _logger.LogInformation("Timeout waiting for pending channels in remote forwarded port to close.");
+                var session = Session;
+                if (session != null)
+                {
+                    var logger = session.SessionLoggerFactory.CreateLogger<ForwardedPortRemote>();
+                    logger.LogInformation("Timeout waiting for pending channels in remote forwarded port to close.");
+                }
             }
 
             _status = ForwardedPortStatus.Stopped;

--- a/src/Renci.SshNet/ForwardedPortRemote.cs
+++ b/src/Renci.SshNet/ForwardedPortRemote.cs
@@ -100,7 +100,7 @@ namespace Renci.SshNet
             HostAddress = hostAddress;
             Port = port;
             _status = ForwardedPortStatus.Stopped;
-            _logger = SshNetLoggingConfiguration.LoggerFactory.CreateLogger<ForwardedPortRemote>();
+            _logger = Session.SessionLoggerFactory.CreateLogger<ForwardedPortRemote>();
         }
 
         /// <summary>

--- a/src/Renci.SshNet/IConnectionInfo.cs
+++ b/src/Renci.SshNet/IConnectionInfo.cs
@@ -18,7 +18,7 @@ namespace Renci.SshNet
         /// Gets the logger factory for this connection.
         /// </summary>
         /// <value>
-        /// The logger factory for this connection. If <see langword="null"/> then <see cref="SshNetLoggingConfiguration.LoggerFactory"/> should be used.
+        /// The logger factory for this connection. If <see langword="null"/> then <see cref="SshNetLoggingConfiguration.LoggerFactory"/> is used.
         /// </value>
         public ILoggerFactory LoggerFactory { get; }
 

--- a/src/Renci.SshNet/IConnectionInfo.cs
+++ b/src/Renci.SshNet/IConnectionInfo.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Text;
 
+using Microsoft.Extensions.Logging;
+
 using Renci.SshNet.Common;
 using Renci.SshNet.Messages.Connection;
 
@@ -12,6 +14,14 @@ namespace Renci.SshNet
     /// </summary>
     internal interface IConnectionInfo
     {
+        /// <summary>
+        /// Gets the logger factory for this connection.
+        /// </summary>
+        /// <value>
+        /// The logger factory for this connection. If <see langword="null"/> then <see cref="SshNetLoggingConfiguration.LoggerFactory"/> should be used.
+        /// </value>
+        public ILoggerFactory LoggerFactory { get; }
+
         /// <summary>
         /// Gets the timeout to used when waiting for a server to acknowledge closing a channel.
         /// </summary>

--- a/src/Renci.SshNet/ISession.cs
+++ b/src/Renci.SshNet/ISession.cs
@@ -28,7 +28,7 @@ namespace Renci.SshNet
         /// Gets the logger factory for this session.
         /// </summary>
         /// <value>
-        /// The logger factory for this session.
+        /// The logger factory for this session. Will never return <see langword="null"/>.
         /// </value>
         public ILoggerFactory SessionLoggerFactory { get; }
 

--- a/src/Renci.SshNet/ISession.cs
+++ b/src/Renci.SshNet/ISession.cs
@@ -3,6 +3,8 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Microsoft.Extensions.Logging;
+
 using Renci.SshNet.Channels;
 using Renci.SshNet.Common;
 using Renci.SshNet.Messages;
@@ -21,6 +23,14 @@ namespace Renci.SshNet
         /// </summary>
         /// <value>The connection info.</value>
         IConnectionInfo ConnectionInfo { get; }
+
+        /// <summary>
+        /// Gets the logger factory for this session.
+        /// </summary>
+        /// <value>
+        /// The logger factory for this session.
+        /// </value>
+        public ILoggerFactory SessionLoggerFactory { get; }
 
         /// <summary>
         /// Gets a value indicating whether the session is connected.

--- a/src/Renci.SshNet/ISubsystemSession.cs
+++ b/src/Renci.SshNet/ISubsystemSession.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Threading;
 
+using Microsoft.Extensions.Logging;
+
 using Renci.SshNet.Common;
 
 namespace Renci.SshNet
@@ -10,6 +12,14 @@ namespace Renci.SshNet
     /// </summary>
     internal interface ISubsystemSession : IDisposable
     {
+        /// <summary>
+        /// Gets the logger factory for this subsystem session.
+        /// </summary>
+        /// <value>
+        /// The logger factory for this connection.
+        /// </value>
+        public ILoggerFactory SessionLoggerFactory { get; }
+
         /// <summary>
         /// Gets or sets the number of milliseconds to wait for an operation to complete.
         /// </summary>

--- a/src/Renci.SshNet/ISubsystemSession.cs
+++ b/src/Renci.SshNet/ISubsystemSession.cs
@@ -16,7 +16,7 @@ namespace Renci.SshNet
         /// Gets the logger factory for this subsystem session.
         /// </summary>
         /// <value>
-        /// The logger factory for this connection.
+        /// The logger factory for this connection. Will never return <see langword="null"/>.
         /// </value>
         public ILoggerFactory SessionLoggerFactory { get; }
 

--- a/src/Renci.SshNet/Security/KeyExchange.cs
+++ b/src/Renci.SshNet/Security/KeyExchange.cs
@@ -69,7 +69,7 @@ namespace Renci.SshNet.Security
         /// </summary>
         protected KeyExchange()
         {
-            _logger = SshNetLoggingConfiguration.LoggerFactory.CreateLogger(GetType());
+            _logger = Session.SessionLoggerFactory.CreateLogger(GetType());
         }
 
         /// <inheritdoc/>

--- a/src/Renci.SshNet/Security/KeyExchange.cs
+++ b/src/Renci.SshNet/Security/KeyExchange.cs
@@ -18,7 +18,7 @@ namespace Renci.SshNet.Security
     /// </summary>
     public abstract class KeyExchange : Algorithm, IKeyExchange
     {
-        private readonly ILogger _logger;
+        private ILogger _logger;
         private Func<byte[], KeyHostAlgorithm> _hostKeyAlgorithmFactory;
         private CipherInfo _clientCipherInfo;
         private CipherInfo _serverCipherInfo;
@@ -69,13 +69,13 @@ namespace Renci.SshNet.Security
         /// </summary>
         protected KeyExchange()
         {
-            _logger = Session.SessionLoggerFactory.CreateLogger(GetType());
         }
 
         /// <inheritdoc/>
         public virtual void Start(Session session, KeyExchangeInitMessage message, bool sendClientInitMessage)
         {
             Session = session;
+            _logger = Session.SessionLoggerFactory.CreateLogger(GetType());
 
             if (sendClientInitMessage)
             {

--- a/src/Renci.SshNet/ServiceFactory.cs
+++ b/src/Renci.SshNet/ServiceFactory.cs
@@ -26,11 +26,8 @@ namespace Renci.SshNet
         /// </summary>
         private const int PartialSuccessLimit = 5;
 
-        private readonly ILogger _logger;
-
         internal ServiceFactory()
         {
-            _logger = SshNetLoggingConfiguration.LoggerFactory.CreateLogger<ServiceFactory>();
         }
 
         /// <summary>
@@ -160,7 +157,7 @@ namespace Renci.SshNet
                 fileSize = null;
                 maxPendingReads = defaultMaxPendingReads;
 
-                _logger.LogInformation(ex, "Failed to obtain size of file. Allowing maximum {MaxPendingReads} pending reads", maxPendingReads);
+                sftpSession.SessionLoggerFactory.CreateLogger<ServiceFactory>().LogInformation(ex, "Failed to obtain size of file. Allowing maximum {MaxPendingReads} pending reads", maxPendingReads);
             }
 
             return sftpSession.CreateFileReader(handle, sftpSession, chunkSize, maxPendingReads, fileSize);
@@ -221,16 +218,18 @@ namespace Renci.SshNet
             ThrowHelper.ThrowIfNull(connectionInfo);
             ThrowHelper.ThrowIfNull(socketFactory);
 
+            var loggerFactory = connectionInfo.LoggerFactory ?? SshNetLoggingConfiguration.LoggerFactory;
+
             switch (connectionInfo.ProxyType)
             {
                 case ProxyTypes.None:
-                    return new DirectConnector(socketFactory);
+                    return new DirectConnector(socketFactory, loggerFactory);
                 case ProxyTypes.Socks4:
-                    return new Socks4Connector(socketFactory);
+                    return new Socks4Connector(socketFactory, loggerFactory);
                 case ProxyTypes.Socks5:
-                    return new Socks5Connector(socketFactory);
+                    return new Socks5Connector(socketFactory, loggerFactory);
                 case ProxyTypes.Http:
-                    return new HttpConnector(socketFactory);
+                    return new HttpConnector(socketFactory, loggerFactory);
                 default:
                     throw new NotSupportedException(string.Format("ProxyTypes '{0}' is not supported.", connectionInfo.ProxyType));
             }

--- a/src/Renci.SshNet/Session.cs
+++ b/src/Renci.SshNet/Session.cs
@@ -358,7 +358,7 @@ namespace Renci.SshNet
         /// <value>
         /// The logger factory for this session.
         /// </value>
-        public ILoggerFactory SessionLoggerFactory { get; private set; }
+        public ILoggerFactory SessionLoggerFactory { get; }
 
         /// <summary>
         /// Occurs when an error occurred.

--- a/src/Renci.SshNet/Session.cs
+++ b/src/Renci.SshNet/Session.cs
@@ -353,6 +353,14 @@ namespace Renci.SshNet
         public ConnectionInfo ConnectionInfo { get; private set; }
 
         /// <summary>
+        /// Gets the logger factory for this session.
+        /// </summary>
+        /// <value>
+        /// The logger factory for this session.
+        /// </value>
+        public ILoggerFactory SessionLoggerFactory { get; private set; }
+
+        /// <summary>
         /// Occurs when an error occurred.
         /// </summary>
         /// <remarks>A known misspelling of "occurred" preserved for backward compatibility.</remarks>
@@ -554,9 +562,10 @@ namespace Renci.SshNet
             ThrowHelper.ThrowIfNull(socketFactory);
 
             ConnectionInfo = connectionInfo;
+            SessionLoggerFactory = connectionInfo.LoggerFactory ?? SshNetLoggingConfiguration.LoggerFactory;
             _serviceFactory = serviceFactory;
             _socketFactory = socketFactory;
-            _logger = SshNetLoggingConfiguration.LoggerFactory.CreateLogger<Session>();
+            _logger = SessionLoggerFactory.CreateLogger<Session>();
             _messageListenerCompleted = new ManualResetEvent(initialState: true);
         }
 

--- a/src/Renci.SshNet/Sftp/SftpFileReader.cs
+++ b/src/Renci.SshNet/Sftp/SftpFileReader.cs
@@ -71,7 +71,7 @@ namespace Renci.SshNet.Sftp
             _readAheadCompleted = new ManualResetEvent(initialState: false);
             _disposingWaitHandle = new ManualResetEvent(initialState: false);
             _waitHandles = _sftpSession.CreateWaitHandleArray(_disposingWaitHandle, _semaphore.AvailableWaitHandle);
-            _logger = SshNetLoggingConfiguration.LoggerFactory.CreateLogger<SftpFileReader>();
+            _logger = sftpSession.SessionLoggerFactory.CreateLogger<SftpFileReader>();
 
             StartReadAhead();
         }

--- a/src/Renci.SshNet/SubsystemSession.cs
+++ b/src/Renci.SshNet/SubsystemSession.cs
@@ -24,7 +24,7 @@ namespace Renci.SshNet
 
         private readonly string _subsystemName;
         private readonly ILogger _logger;
-        private ISession _session;
+        private readonly ISession _session;
         private IChannelSession _channel;
         private Exception _exception;
         private EventWaitHandle _errorOccurredWaitHandle = new ManualResetEvent(initialState: false);
@@ -530,11 +530,6 @@ namespace Renci.SshNet
         /// </remarks>
         private void UnsubscribeFromSessionEvents(ISession session)
         {
-            if (session is null)
-            {
-                return;
-            }
-
             session.Disconnected -= Session_Disconnected;
             session.ErrorOccured -= Session_ErrorOccurred;
         }
@@ -562,8 +557,6 @@ namespace Renci.SshNet
             if (disposing)
             {
                 Disconnect();
-
-                _session = null;
 
                 var errorOccurredWaitHandle = _errorOccurredWaitHandle;
                 if (errorOccurredWaitHandle != null)

--- a/src/Renci.SshNet/SubsystemSession.cs
+++ b/src/Renci.SshNet/SubsystemSession.cs
@@ -72,6 +72,14 @@ namespace Renci.SshNet
             get { return _channel is not null && _channel.IsOpen; }
         }
 
+        public ILoggerFactory SessionLoggerFactory
+        {
+            get
+            {
+                return _session.SessionLoggerFactory;
+            }
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="SubsystemSession"/> class.
         /// </summary>
@@ -86,7 +94,7 @@ namespace Renci.SshNet
 
             _session = session;
             _subsystemName = subsystemName;
-            _logger = SshNetLoggingConfiguration.LoggerFactory.CreateLogger(GetType());
+            _logger = SessionLoggerFactory.CreateLogger(GetType());
             OperationTimeout = operationTimeout;
         }
 

--- a/test/Renci.SshNet.Tests/Classes/BaseClientTestBase.cs
+++ b/test/Renci.SshNet.Tests/Classes/BaseClientTestBase.cs
@@ -1,4 +1,6 @@
-﻿using Moq;
+﻿using Microsoft.Extensions.Logging.Abstractions;
+
+using Moq;
 
 using Renci.SshNet.Connection;
 using Renci.SshNet.Tests.Common;
@@ -16,6 +18,7 @@ namespace Renci.SshNet.Tests.Classes
             ServiceFactoryMock = new Mock<IServiceFactory>(MockBehavior.Strict);
             SocketFactoryMock = new Mock<ISocketFactory>(MockBehavior.Strict);
             SessionMock = new Mock<ISession>(MockBehavior.Strict);
+            SessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
         }
 
         protected virtual void SetupData()

--- a/test/Renci.SshNet.Tests/Classes/BaseClientTest_ConnectAsync_Timeout.cs
+++ b/test/Renci.SshNet.Tests/Classes/BaseClientTest_ConnectAsync_Timeout.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -23,6 +24,7 @@ namespace Renci.SshNet.Tests.Classes
         public void Init()
         {
             var sessionMock = new Mock<ISession>();
+            sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             var serviceFactoryMock = new Mock<IServiceFactory>();
             var socketFactoryMock = new Mock<ISocketFactory>();
 

--- a/test/Renci.SshNet.Tests/Classes/BaseClientTest_Disconnected_Connect.cs
+++ b/test/Renci.SshNet.Tests/Classes/BaseClientTest_Disconnected_Connect.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
 
@@ -25,6 +26,7 @@ namespace Renci.SshNet.Tests.Classes
 
             _socketFactory2Mock = new Mock<ISocketFactory>(MockBehavior.Strict);
             _session2Mock = new Mock<ISession>(MockBehavior.Strict);
+            _session2Mock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
         }
 
         protected override void SetupMocks()

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelDirectTcpipTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelDirectTcpipTest.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -49,6 +50,7 @@ namespace Renci.SshNet.Tests.Classes.Channels
             _channelCloseTimeout = TimeSpan.FromSeconds(random.Next(10, 20));
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _forwardedPortMock = new Mock<IForwardedPort>(MockBehavior.Strict);
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
         }

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelDirectTcpipTest_Dispose_SessionIsConnectedAndChannelIsOpen.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelDirectTcpipTest_Dispose_SessionIsConnectedAndChannelIsOpen.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -78,6 +79,7 @@ namespace Renci.SshNet.Tests.Classes.Channels
             _remotePacketSize = (uint)random.Next(100, 200);
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _forwardedPortMock = new Mock<IForwardedPort>(MockBehavior.Strict);
 

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelForwardedTcpipTest_Dispose_SessionIsConnectedAndChannelIsOpen.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelForwardedTcpipTest_Dispose_SessionIsConnectedAndChannelIsOpen.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -83,6 +84,7 @@ namespace Renci.SshNet.Tests.Classes.Channels
             _remoteEndpoint = new IPEndPoint(IPAddress.Loopback, 8122);
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _forwardedPortMock = new Mock<IForwardedPort>(MockBehavior.Strict);
 

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTestBase.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTestBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
 
@@ -21,6 +22,7 @@ namespace Renci.SshNet.Tests.Classes.Channels
         protected void CreateMocks()
         {
             SessionMock = new Mock<ISession>(MockBehavior.Strict);
+            SessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             ConnectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
         }
 

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelTestBase.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelTestBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
 
@@ -21,6 +22,7 @@ namespace Renci.SshNet.Tests.Classes.Channels
         protected void CreateMocks()
         {
             SessionMock = new Mock<ISession>(MockBehavior.Strict);
+            SessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             ConnectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
         }
 

--- a/test/Renci.SshNet.Tests/Classes/Channels/ClientChannelTest_OnSessionChannelOpenConfirmationReceived_OnOpenConfirmation_Exception.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ClientChannelTest_OnSessionChannelOpenConfirmationReceived_OnOpenConfirmation_Exception.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -40,6 +41,7 @@ namespace Renci.SshNet.Tests.Classes.Channels
             _channelExceptionRegister = new List<ExceptionEventArgs>();
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
 
             _channel = new ClientChannelStub(_sessionMock.Object, _localChannelNumber, _localWindowSize, _localPacketSize);
             _channel.Exception += (sender, args) => _channelExceptionRegister.Add(args);

--- a/test/Renci.SshNet.Tests/Classes/Channels/ClientChannelTest_OnSessionChannelOpenFailureReceived_OnOpenFailure_Exception.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ClientChannelTest_OnSessionChannelOpenFailureReceived_OnOpenFailure_Exception.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -38,6 +39,7 @@ namespace Renci.SshNet.Tests.Classes.Channels
             _channelExceptionRegister = new List<ExceptionEventArgs>();
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
 
             _channel = new ClientChannelStub(_sessionMock.Object, _localChannelNumber, _localWindowSize, _localPacketSize);
             _channel.Exception += (sender, args) => _channelExceptionRegister.Add(args);

--- a/test/Renci.SshNet.Tests/Classes/ClientAuthenticationTestBase.cs
+++ b/test/Renci.SshNet.Tests/Classes/ClientAuthenticationTestBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
 
@@ -22,6 +23,7 @@ namespace Renci.SshNet.Tests.Classes
         {
             ConnectionInfoMock = new Mock<IConnectionInfoInternal>(MockBehavior.Strict);
             SessionMock = new Mock<ISession>(MockBehavior.Strict);
+            SessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             NoneAuthenticationMethodMock = new Mock<IAuthenticationMethod>(MockBehavior.Strict);
             PasswordAuthenticationMethodMock = new Mock<IAuthenticationMethod>(MockBehavior.Strict);
             PublicKeyAuthenticationMethodMock = new Mock<IAuthenticationMethod>(MockBehavior.Strict);

--- a/test/Renci.SshNet.Tests/Classes/Connection/DirectConnectorTestBase.cs
+++ b/test/Renci.SshNet.Tests/Classes/Connection/DirectConnectorTestBase.cs
@@ -1,4 +1,6 @@
-﻿using Moq;
+﻿using Microsoft.Extensions.Logging.Abstractions;
+
+using Moq;
 
 using Renci.SshNet.Connection;
 using Renci.SshNet.Tests.Common;
@@ -18,7 +20,7 @@ namespace Renci.SshNet.Tests.Classes.Connection
 
         protected virtual void SetupData()
         {
-            Connector = new DirectConnector(SocketFactoryMock.Object);
+            Connector = new DirectConnector(SocketFactoryMock.Object, NullLoggerFactory.Instance);
             SocketFactory = new SocketFactory();
         }
 

--- a/test/Renci.SshNet.Tests/Classes/Connection/HttpConnectorTestBase.cs
+++ b/test/Renci.SshNet.Tests/Classes/Connection/HttpConnectorTestBase.cs
@@ -1,4 +1,6 @@
-﻿using Moq;
+﻿using Microsoft.Extensions.Logging.Abstractions;
+
+using Moq;
 
 using Renci.SshNet.Connection;
 using Renci.SshNet.Tests.Common;
@@ -18,7 +20,7 @@ namespace Renci.SshNet.Tests.Classes.Connection
 
         protected virtual void SetupData()
         {
-            Connector = new HttpConnector(SocketFactoryMock.Object);
+            Connector = new HttpConnector(SocketFactoryMock.Object, NullLoggerFactory.Instance);
             SocketFactory = new SocketFactory();
         }
 

--- a/test/Renci.SshNet.Tests/Classes/Connection/Socks4ConnectorTestBase.cs
+++ b/test/Renci.SshNet.Tests/Classes/Connection/Socks4ConnectorTestBase.cs
@@ -1,5 +1,7 @@
 ﻿using System.Net;
 
+using Microsoft.Extensions.Logging.Abstractions;
+
 using Moq;
 
 using Renci.SshNet.Connection;
@@ -20,7 +22,7 @@ namespace Renci.SshNet.Tests.Classes.Connection
 
         protected virtual void SetupData()
         {
-            Connector = new Socks4Connector(SocketFactoryMock.Object);
+            Connector = new Socks4Connector(SocketFactoryMock.Object, NullLoggerFactory.Instance);
             SocketFactory = new SocketFactory();
         }
 

--- a/test/Renci.SshNet.Tests/Classes/Connection/Socks5ConnectorTestBase.cs
+++ b/test/Renci.SshNet.Tests/Classes/Connection/Socks5ConnectorTestBase.cs
@@ -2,6 +2,8 @@
 using System.Net;
 using System.Text;
 
+using Microsoft.Extensions.Logging.Abstractions;
+
 using Moq;
 
 using Renci.SshNet.Connection;
@@ -22,7 +24,7 @@ namespace Renci.SshNet.Tests.Classes.Connection
 
         protected virtual void SetupData()
         {
-            Connector = new Socks5Connector(SocketFactoryMock.Object);
+            Connector = new Socks5Connector(SocketFactoryMock.Object, NullLoggerFactory.Instance);
             SocketFactory = new SocketFactory();
         }
 

--- a/test/Renci.SshNet.Tests/Classes/ConnectionInfoTest_Authenticate_Failure.cs
+++ b/test/Renci.SshNet.Tests/Classes/ConnectionInfoTest_Authenticate_Failure.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
 
@@ -29,6 +30,7 @@ namespace Renci.SshNet.Tests.Classes
             _serviceFactoryMock = new Mock<IServiceFactory>(MockBehavior.Strict);
             _clientAuthenticationMock = new Mock<IClientAuthentication>(MockBehavior.Strict);
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
 
             _connectionInfo = new ConnectionInfo(Resources.HOST, int.Parse(Resources.PORT), Resources.USERNAME, ProxyTypes.None,
                 Resources.HOST, int.Parse(Resources.PORT), Resources.USERNAME, Resources.PASSWORD,

--- a/test/Renci.SshNet.Tests/Classes/ConnectionInfoTest_Authenticate_Success.cs
+++ b/test/Renci.SshNet.Tests/Classes/ConnectionInfoTest_Authenticate_Success.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
 
@@ -26,6 +27,7 @@ namespace Renci.SshNet.Tests.Classes
             _serviceFactoryMock = new Mock<IServiceFactory>(MockBehavior.Strict);
             _clientAuthenticationMock = new Mock<IClientAuthentication>(MockBehavior.Strict);
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
 
             _connectionInfo = new ConnectionInfo(Resources.HOST, int.Parse(Resources.PORT), Resources.USERNAME, ProxyTypes.None,
                 Resources.HOST, int.Parse(Resources.PORT), Resources.USERNAME, Resources.PASSWORD,

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Dispose_PortNeverStarted.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Dispose_PortNeverStarted.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -46,6 +47,7 @@ namespace Renci.SshNet.Tests.Classes
 
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
 
             _connectionInfoMock.Setup(p => p.Timeout).Returns(TimeSpan.FromSeconds(15));
             _sessionMock.Setup(p => p.IsConnected).Returns(true);

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Dispose_PortStarted_ChannelBound.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Dispose_PortStarted_ChannelBound.cs
@@ -7,6 +7,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -71,6 +72,7 @@ namespace Renci.SshNet.Tests.Classes
         {
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelDirectTcpip>(MockBehavior.Strict);
         }
 

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Dispose_PortStarted_ChannelNotBound.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Dispose_PortStarted_ChannelNotBound.cs
@@ -5,6 +5,7 @@ using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Threading;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -57,6 +58,7 @@ namespace Renci.SshNet.Tests.Classes
 
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelDirectTcpip>(MockBehavior.Strict);
 
             _connectionInfoMock.Setup(p => p.Timeout).Returns(TimeSpan.FromSeconds(15));

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Dispose_PortStopped.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Dispose_PortStopped.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -46,6 +47,7 @@ namespace Renci.SshNet.Tests.Classes
 
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
 
             _connectionInfoMock.Setup(p => p.Timeout).Returns(TimeSpan.FromSeconds(15));
             _sessionMock.Setup(p => p.IsConnected).Returns(true);

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_SessionErrorOccurred_ChannelBound.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_SessionErrorOccurred_ChannelBound.cs
@@ -7,6 +7,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -72,6 +73,7 @@ namespace Renci.SshNet.Tests.Classes
         {
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelDirectTcpip>(MockBehavior.Strict);
         }
 

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Start_PortNeverStarted.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Start_PortNeverStarted.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -48,6 +49,7 @@ namespace Renci.SshNet.Tests.Classes
 
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelDirectTcpip>(MockBehavior.Strict);
 
             _connectionInfoMock.Setup(p => p.Timeout).Returns(TimeSpan.FromSeconds(15));

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Start_PortStarted.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Start_PortStarted.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -49,6 +50,7 @@ namespace Renci.SshNet.Tests.Classes
 
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelDirectTcpip>(MockBehavior.Strict);
 
             _connectionInfoMock.Setup(p => p.Timeout).Returns(TimeSpan.FromSeconds(15));

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Start_PortStopped.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Start_PortStopped.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -48,6 +49,7 @@ namespace Renci.SshNet.Tests.Classes
 
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelDirectTcpip>(MockBehavior.Strict);
 
             _connectionInfoMock.Setup(p => p.Timeout).Returns(TimeSpan.FromSeconds(15));

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Start_SessionNotConnected.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Start_SessionNotConnected.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -47,6 +48,7 @@ namespace Renci.SshNet.Tests.Classes
             _endpoint = new IPEndPoint(IPAddress.Loopback, 8122);
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
 
             _sessionMock.Setup(p => p.IsConnected).Returns(false);

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Started_SocketSendShutdownImmediately.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Started_SocketSendShutdownImmediately.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -84,6 +85,7 @@ namespace Renci.SshNet.Tests.Classes
         private void CreateMocks()
         {
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelDirectTcpip>(MockBehavior.Strict);
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
         }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Started_SocketVersionNotSupported.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Started_SocketVersionNotSupported.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -68,6 +69,7 @@ namespace Renci.SshNet.Tests.Classes
         private void CreateMocks()
         {
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelDirectTcpip>(MockBehavior.Strict);
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
         }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Stop_PortStarted_ChannelBound.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Stop_PortStarted_ChannelBound.cs
@@ -7,6 +7,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -70,6 +71,7 @@ namespace Renci.SshNet.Tests.Classes
         {
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelDirectTcpip>(MockBehavior.Strict);
         }
 

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Stop_PortStarted_ChannelNotBound.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Stop_PortStarted_ChannelNotBound.cs
@@ -5,6 +5,7 @@ using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Threading;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -57,6 +58,7 @@ namespace Renci.SshNet.Tests.Classes
 
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelDirectTcpip>(MockBehavior.Strict);
 
             _ = _connectionInfoMock.Setup(p => p.Timeout)

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Stop_PortStopped.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Stop_PortStopped.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -46,6 +47,7 @@ namespace Renci.SshNet.Tests.Classes
 
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
 
             _connectionInfoMock.Setup(p => p.Timeout).Returns(TimeSpan.FromSeconds(15));
             _sessionMock.Setup(p => p.IsConnected).Returns(true);

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Dispose_PortDisposed.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Dispose_PortDisposed.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Net;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -42,6 +43,7 @@ namespace Renci.SshNet.Tests.Classes
             _exceptionRegister = new List<ExceptionEventArgs>();
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
 
             var sequence = new MockSequence();

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Dispose_PortNeverStarted.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Dispose_PortNeverStarted.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -51,6 +52,7 @@ namespace Renci.SshNet.Tests.Classes
 
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
 
             _connectionInfoMock.Setup(p => p.Timeout).Returns(TimeSpan.FromSeconds(15));
             _sessionMock.Setup(p => p.IsConnected).Returns(true);

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Dispose_PortStarted_ChannelBound.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Dispose_PortStarted_ChannelBound.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -75,6 +76,7 @@ namespace Renci.SshNet.Tests.Classes
 
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelDirectTcpip>(MockBehavior.Strict);
 
             _connectionInfoMock.Setup(p => p.Timeout).Returns(TimeSpan.FromSeconds(15));

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Dispose_PortStarted_ChannelNotBound.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Dispose_PortStarted_ChannelNotBound.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -52,6 +53,7 @@ namespace Renci.SshNet.Tests.Classes
 
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelDirectTcpip>(MockBehavior.Strict);
 
             _connectionInfoMock.Setup(p => p.Timeout).Returns(TimeSpan.FromSeconds(15));

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Dispose_PortStopped.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Dispose_PortStopped.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -51,6 +52,7 @@ namespace Renci.SshNet.Tests.Classes
 
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
 
             _connectionInfoMock.Setup(p => p.Timeout).Returns(TimeSpan.FromSeconds(15));
             _sessionMock.Setup(p => p.IsConnected).Returns(true);

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Start_PortNeverStarted.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Start_PortNeverStarted.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -52,6 +53,7 @@ namespace Renci.SshNet.Tests.Classes
 
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelDirectTcpip>(MockBehavior.Strict);
 
             _ = _connectionInfoMock.Setup(p => p.Timeout)

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Start_PortStarted.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Start_PortStarted.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -52,6 +53,7 @@ namespace Renci.SshNet.Tests.Classes
 
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelDirectTcpip>(MockBehavior.Strict);
 
             _ = _connectionInfoMock.Setup(p => p.Timeout)

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Start_PortStopped.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Start_PortStopped.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -52,6 +53,7 @@ namespace Renci.SshNet.Tests.Classes
 
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelDirectTcpip>(MockBehavior.Strict);
 
             _ = _connectionInfoMock.Setup(p => p.Timeout)

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Start_SessionNotConnected.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Start_SessionNotConnected.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -52,6 +53,7 @@ namespace Renci.SshNet.Tests.Classes
                 random.Next(IPEndPoint.MinPort, IPEndPoint.MaxPort));
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
 
             _sessionMock.Setup(p => p.IsConnected).Returns(false);

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Start_SessionNull.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Start_SessionNull.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -51,6 +52,7 @@ namespace Renci.SshNet.Tests.Classes
                 random.Next(IPEndPoint.MinPort, IPEndPoint.MaxPort));
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
 
             _sessionMock.Setup(p => p.IsConnected).Returns(false);

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Stop_PortNeverStarted.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Stop_PortNeverStarted.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -51,6 +52,7 @@ namespace Renci.SshNet.Tests.Classes
                 random.Next(IPEndPoint.MinPort, IPEndPoint.MaxPort));
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
 
             _forwardedPort = new ForwardedPortLocal(_localEndpoint.Address.ToString(), (uint)_localEndpoint.Port,

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Stop_PortStarted_ChannelBound.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Stop_PortStarted_ChannelBound.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -65,6 +66,7 @@ namespace Renci.SshNet.Tests.Classes
         {
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelDirectTcpip>(MockBehavior.Strict);
         }
 

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Stop_PortStarted_ChannelNotBound.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Stop_PortStarted_ChannelNotBound.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -52,6 +53,7 @@ namespace Renci.SshNet.Tests.Classes
 
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelDirectTcpip>(MockBehavior.Strict);
 
             _connectionInfoMock.Setup(p => p.Timeout).Returns(TimeSpan.FromSeconds(15));

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Stop_PortStopped.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Stop_PortStopped.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -50,6 +51,7 @@ namespace Renci.SshNet.Tests.Classes
 
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
 
             _connectionInfoMock.Setup(p => p.Timeout).Returns(TimeSpan.FromSeconds(15));
             _sessionMock.Setup(p => p.IsConnected).Returns(true);

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Dispose_PortNeverStarted.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Dispose_PortNeverStarted.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Net;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -52,6 +53,7 @@ namespace Renci.SshNet.Tests.Classes
 
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
 
             _connectionInfoMock.Setup(p => p.Timeout).Returns(TimeSpan.FromSeconds(15));
             _sessionMock.Setup(p => p.IsConnected).Returns(true);

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Dispose_PortStarted_ChannelBound.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Dispose_PortStarted_ChannelBound.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Net;
 using System.Threading;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -71,6 +72,7 @@ namespace Renci.SshNet.Tests.Classes
         {
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelForwardedTcpip>(MockBehavior.Strict);
         }
 

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Dispose_PortStopped.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Dispose_PortStopped.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Net;
 using System.Threading;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -54,6 +55,7 @@ namespace Renci.SshNet.Tests.Classes
 
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
 
             _connectionInfoMock.Setup(p => p.Timeout).Returns(TimeSpan.FromSeconds(15));
             _sessionMock.Setup(p => p.IsConnected).Returns(true);

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Start_PortNeverStarted.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Start_PortNeverStarted.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Net;
 using System.Threading;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -61,6 +62,7 @@ namespace Renci.SshNet.Tests.Classes
 
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
 
             _connectionInfoMock.Setup(p => p.Timeout).Returns(TimeSpan.FromSeconds(15));
             _sessionMock.Setup(p => p.IsConnected).Returns(true);

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Start_PortStarted.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Start_PortStarted.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Net;
 using System.Threading;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -62,6 +63,7 @@ namespace Renci.SshNet.Tests.Classes
 
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
 
             _connectionInfoMock.Setup(p => p.Timeout).Returns(TimeSpan.FromSeconds(15));
             _sessionMock.Setup(p => p.IsConnected).Returns(true);

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Start_PortStopped.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Start_PortStopped.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Net;
 using System.Threading;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -61,6 +62,7 @@ namespace Renci.SshNet.Tests.Classes
 
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
 
             _connectionInfoMock.Setup(p => p.Timeout).Returns(TimeSpan.FromSeconds(15));
             _sessionMock.Setup(p => p.IsConnected).Returns(true);

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Start_SessionNotConnected.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Start_SessionNotConnected.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Net;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -56,6 +57,7 @@ namespace Renci.SshNet.Tests.Classes
             _remoteEndpoint = new IPEndPoint(IPAddress.Parse("193.168.1.5"), random.Next(IPEndPoint.MinPort, IPEndPoint.MaxPort));
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
 
             _ = _sessionMock.Setup(p => p.IsConnected)

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Started.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Started.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Net;
 using System.Threading;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -59,6 +60,7 @@ namespace Renci.SshNet.Tests.Classes
 
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
 
             _connectionInfoMock.Setup(p => p.Timeout).Returns(TimeSpan.FromSeconds(15));
             _sessionMock.Setup(p => p.IsConnected).Returns(true);

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Stop_PortNeverStarted.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Stop_PortNeverStarted.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Net;
 using System.Threading;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -61,6 +62,7 @@ namespace Renci.SshNet.Tests.Classes
 
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
 
             _connectionInfoMock.Setup(p => p.Timeout).Returns(TimeSpan.FromSeconds(15));
             _sessionMock.Setup(p => p.IsConnected).Returns(true);

--- a/test/Renci.SshNet.Tests/Classes/ServiceFactoryTest_CreateConnector.cs
+++ b/test/Renci.SshNet.Tests/Classes/ServiceFactoryTest_CreateConnector.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -20,6 +21,7 @@ namespace Renci.SshNet.Tests.Classes
         {
             _serviceFactory = new ServiceFactory();
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
+            _connectionInfoMock.Setup(p => p.LoggerFactory).Returns(NullLoggerFactory.Instance);
             _socketFactoryMock = new Mock<ISocketFactory>(MockBehavior.Strict);
         }
 

--- a/test/Renci.SshNet.Tests/Classes/ServiceFactoryTest_CreateSftpFileReader_EndLStatThrowsSshException.cs
+++ b/test/Renci.SshNet.Tests/Classes/ServiceFactoryTest_CreateSftpFileReader_EndLStatThrowsSshException.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -39,6 +40,7 @@ namespace Renci.SshNet.Tests.Classes
         private void CreateMocks()
         {
             _sftpSessionMock = new Mock<ISftpSession>(MockBehavior.Strict);
+            _sftpSessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _sftpFileReaderMock = new Mock<ISftpFileReader>(MockBehavior.Strict);
         }
 

--- a/test/Renci.SshNet.Tests/Classes/ServiceFactoryTest_CreateShellStream_ChannelOpenThrowsException.cs
+++ b/test/Renci.SshNet.Tests/Classes/ServiceFactoryTest_CreateShellStream_ChannelOpenThrowsException.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Text;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -44,6 +45,7 @@ namespace Renci.SshNet.Tests.Classes
         private void CreateMocks()
         {
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _channelSessionMock = new Mock<IChannelSession>(MockBehavior.Strict);
         }

--- a/test/Renci.SshNet.Tests/Classes/ServiceFactoryTest_CreateShellStream_SendPseudoTerminalRequestReturnsFalse.cs
+++ b/test/Renci.SshNet.Tests/Classes/ServiceFactoryTest_CreateShellStream_SendPseudoTerminalRequestReturnsFalse.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Text;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -41,6 +42,7 @@ namespace Renci.SshNet.Tests.Classes
         private void CreateMocks()
         {
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _channelSessionMock = new Mock<IChannelSession>(MockBehavior.Strict);
         }

--- a/test/Renci.SshNet.Tests/Classes/ServiceFactoryTest_CreateShellStream_SendPseudoTerminalRequestThrowsException.cs
+++ b/test/Renci.SshNet.Tests/Classes/ServiceFactoryTest_CreateShellStream_SendPseudoTerminalRequestThrowsException.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Text;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -44,6 +45,7 @@ namespace Renci.SshNet.Tests.Classes
         private void CreateMocks()
         {
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _channelSessionMock = new Mock<IChannelSession>(MockBehavior.Strict);
         }

--- a/test/Renci.SshNet.Tests/Classes/ServiceFactoryTest_CreateShellStream_SendShellRequestReturnsFalse.cs
+++ b/test/Renci.SshNet.Tests/Classes/ServiceFactoryTest_CreateShellStream_SendShellRequestReturnsFalse.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Text;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -41,6 +42,7 @@ namespace Renci.SshNet.Tests.Classes
         private void CreateMocks()
         {
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _channelSessionMock = new Mock<IChannelSession>(MockBehavior.Strict);
         }

--- a/test/Renci.SshNet.Tests/Classes/ServiceFactoryTest_CreateShellStream_SendShellRequestThrowsException.cs
+++ b/test/Renci.SshNet.Tests/Classes/ServiceFactoryTest_CreateShellStream_SendShellRequestThrowsException.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Text;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -43,6 +44,7 @@ namespace Renci.SshNet.Tests.Classes
         private void CreateMocks()
         {
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _channelSessionMock = new Mock<IChannelSession>(MockBehavior.Strict);
         }

--- a/test/Renci.SshNet.Tests/Classes/ServiceFactoryTest_CreateShellStream_Success.cs
+++ b/test/Renci.SshNet.Tests/Classes/ServiceFactoryTest_CreateShellStream_Success.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Text;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -40,6 +41,7 @@ namespace Renci.SshNet.Tests.Classes
         private void CreateMocks()
         {
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _channelSessionMock = new Mock<IChannelSession>(MockBehavior.Strict);
         }

--- a/test/Renci.SshNet.Tests/Classes/SessionTest_ConnectedBase.cs
+++ b/test/Renci.SshNet.Tests/Classes/SessionTest_ConnectedBase.cs
@@ -6,6 +6,7 @@ using System.Net.Sockets;
 using System.Security.Cryptography;
 using System.Threading;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -173,7 +174,7 @@ namespace Renci.SshNet.Tests.Classes
                 };
             ServerListener.Start();
 
-            ClientSocket = new DirectConnector(_socketFactory).Connect(ConnectionInfo);
+            ClientSocket = new DirectConnector(_socketFactory, NullLoggerFactory.Instance).Connect(ConnectionInfo);
 
             void SendKeyExchangeInit()
             {

--- a/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ServerAndClientDisconnectRace.cs
+++ b/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ServerAndClientDisconnectRace.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Security.Cryptography;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -132,7 +133,7 @@ namespace Renci.SshNet.Tests.Classes
 
             ServerListener.Start();
 
-            ClientSocket = new DirectConnector(_socketFactory).Connect(ConnectionInfo);
+            ClientSocket = new DirectConnector(_socketFactory, NullLoggerFactory.Instance).Connect(ConnectionInfo);
         }
 
         private void CreateMocks()

--- a/test/Renci.SshNet.Tests/Classes/SessionTest_ConnectingBase.cs
+++ b/test/Renci.SshNet.Tests/Classes/SessionTest_ConnectingBase.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Security.Cryptography;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -199,7 +200,7 @@ namespace Renci.SshNet.Tests.Classes
             };
             ServerListener.Start();
 
-            ClientSocket = new DirectConnector(_socketFactory).Connect(ConnectionInfo);
+            ClientSocket = new DirectConnector(_socketFactory, NullLoggerFactory.Instance).Connect(ConnectionInfo);
         }
 
         private void CreateMocks()

--- a/test/Renci.SshNet.Tests/Classes/SessionTest_SocketConnected_BadPacketAndDispose.cs
+++ b/test/Renci.SshNet.Tests/Classes/SessionTest_SocketConnected_BadPacketAndDispose.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using System.Net.Sockets;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -78,7 +79,7 @@ namespace Renci.SshNet.Tests.Classes
 
             _session = new Session(_connectionInfo, _serviceFactoryMock.Object, _socketFactoryMock.Object);
 
-            _clientSocket = new DirectConnector(_socketFactory).Connect(_connectionInfo);
+            _clientSocket = new DirectConnector(_socketFactory, NullLoggerFactory.Instance).Connect(_connectionInfo);
         }
 
         protected void SetupMocks()

--- a/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileReaderTestBase.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileReaderTestBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -19,6 +20,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp
         protected void CreateMocks()
         {
             SftpSessionMock = new Mock<ISftpSession>(MockBehavior.Strict);
+            SftpSessionMock.Setup(s => s.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
         }
 
         protected abstract void SetupMocks();

--- a/test/Renci.SshNet.Tests/Classes/Sftp/SftpSessionTest_Connected_RequestRead.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/SftpSessionTest_Connected_RequestRead.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Text;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -98,6 +99,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp
         private void CreateMocks()
         {
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelSessionMock = new Mock<IChannelSession>(MockBehavior.Strict);
         }
 

--- a/test/Renci.SshNet.Tests/Classes/Sftp/SftpSessionTest_Connected_RequestStatVfs.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/SftpSessionTest_Connected_RequestStatVfs.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Text;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -91,6 +92,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp
         private void CreateMocks()
         {
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelSessionMock = new Mock<IChannelSession>(MockBehavior.Strict);
         }
 

--- a/test/Renci.SshNet.Tests/Classes/Sftp/SftpSessionTest_DataReceived_MultipleSftpMessagesInSingleSshDataMessage.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/SftpSessionTest_DataReceived_MultipleSftpMessagesInSingleSshDataMessage.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Text;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -113,6 +114,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp
         private void CreateMocks()
         {
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelSessionMock = new Mock<IChannelSession>(MockBehavior.Strict);
             _sftpResponseFactoryMock = new Mock<ISftpResponseFactory>(MockBehavior.Strict);
         }

--- a/test/Renci.SshNet.Tests/Classes/Sftp/SftpSessionTest_DataReceived_MultipleSftpMessagesSplitOverMultipleSshDataMessages.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/SftpSessionTest_DataReceived_MultipleSftpMessagesSplitOverMultipleSshDataMessages.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Text;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -113,6 +114,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp
         private void CreateMocks()
         {
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelSessionMock = new Mock<IChannelSession>(MockBehavior.Strict);
             _sftpResponseFactoryMock = new Mock<ISftpResponseFactory>(MockBehavior.Strict);
         }

--- a/test/Renci.SshNet.Tests/Classes/Sftp/SftpSessionTest_DataReceived_SingleSftpMessageInSshDataMessage.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/SftpSessionTest_DataReceived_SingleSftpMessageInSshDataMessage.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Text;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -96,6 +97,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp
         private void CreateMocks()
         {
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelSessionMock = new Mock<IChannelSession>(MockBehavior.Strict);
             _sftpResponseFactoryMock = new Mock<ISftpResponseFactory>(MockBehavior.Strict);
         }

--- a/test/Renci.SshNet.Tests/Classes/SftpClientTest.UploadFile.cs
+++ b/test/Renci.SshNet.Tests/Classes/SftpClientTest.UploadFile.cs
@@ -4,6 +4,8 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -172,6 +174,8 @@ namespace Renci.SshNet.Tests.Classes
             public IChannelSession CreateChannelSession() => new ChannelSession(this, 0, int.MaxValue, int.MaxValue);
 
             public WaitHandle MessageListenerCompleted => throw new NotImplementedException();
+
+            public ILoggerFactory SessionLoggerFactory => NullLoggerFactory.Instance;
 
             public void Connect()
             {

--- a/test/Renci.SshNet.Tests/Classes/SftpClientTest_AsyncExceptions.cs
+++ b/test/Renci.SshNet.Tests/Classes/SftpClientTest_AsyncExceptions.cs
@@ -4,6 +4,8 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -215,6 +217,8 @@ namespace Renci.SshNet.Tests.Classes
             public IChannelSession CreateChannelSession() => new ChannelSession(this, 0, int.MaxValue, int.MaxValue);
 
             public WaitHandle MessageListenerCompleted => throw new NotImplementedException();
+
+            public ILoggerFactory SessionLoggerFactory => NullLoggerFactory.Instance;
 
             public void Connect()
             {

--- a/test/Renci.SshNet.Tests/Classes/ShellStreamTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/ShellStreamTest.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Text;
 using System.Threading;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -47,6 +48,7 @@ namespace Renci.SshNet.Tests.Classes
 
             _encoding = Encoding.UTF8;
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _channelSessionMock = new Mock<IChannelSession>(MockBehavior.Strict);
         }

--- a/test/Renci.SshNet.Tests/Classes/ShellStreamTest_ReadExpect.cs
+++ b/test/Renci.SshNet.Tests/Classes/ShellStreamTest_ReadExpect.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -32,6 +33,7 @@ namespace Renci.SshNet.Tests.Classes
             connectionInfoMock.Setup(p => p.Encoding).Returns(Encoding.UTF8);
 
             var sessionMock = new Mock<ISession>();
+            sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
 
             sessionMock.Setup(p => p.ConnectionInfo).Returns(connectionInfoMock.Object);
             sessionMock.Setup(p => p.CreateChannelSession()).Returns(_channelSessionStub);

--- a/test/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferEmptyAndWriteMoreBytesThanBufferSize.cs
+++ b/test/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferEmptyAndWriteMoreBytesThanBufferSize.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -65,6 +66,7 @@ namespace Renci.SshNet.Tests.Classes
         private void CreateMocks()
         {
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _channelSessionMock = new Mock<IChannelSession>(MockBehavior.Strict);
         }

--- a/test/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferEmptyAndWriteNumberOfBytesEqualToBufferSize.cs
+++ b/test/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferEmptyAndWriteNumberOfBytesEqualToBufferSize.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -59,6 +60,7 @@ namespace Renci.SshNet.Tests.Classes
         private void CreateMocks()
         {
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _channelSessionMock = new Mock<IChannelSession>(MockBehavior.Strict);
         }

--- a/test/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferEmptyAndWriteZeroBytes.cs
+++ b/test/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferEmptyAndWriteZeroBytes.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -58,6 +59,7 @@ namespace Renci.SshNet.Tests.Classes
         private void CreateMocks()
         {
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _channelSessionMock = new Mock<IChannelSession>(MockBehavior.Strict);
         }

--- a/test/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferFullAndWriteLessBytesThanBufferSize.cs
+++ b/test/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferFullAndWriteLessBytesThanBufferSize.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -61,6 +62,7 @@ namespace Renci.SshNet.Tests.Classes
         private void CreateMocks()
         {
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _channelSessionMock = new Mock<IChannelSession>(MockBehavior.Strict);
         }

--- a/test/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferFullAndWriteZeroBytes.cs
+++ b/test/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferFullAndWriteZeroBytes.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -61,6 +62,7 @@ namespace Renci.SshNet.Tests.Classes
         private void CreateMocks()
         {
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _channelSessionMock = new Mock<IChannelSession>(MockBehavior.Strict);
         }

--- a/test/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferNotEmptyAndWriteLessBytesThanBufferCanContain.cs
+++ b/test/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferNotEmptyAndWriteLessBytesThanBufferCanContain.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -61,6 +62,7 @@ namespace Renci.SshNet.Tests.Classes
         private void CreateMocks()
         {
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _channelSessionMock = new Mock<IChannelSession>(MockBehavior.Strict);
         }

--- a/test/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferNotEmptyAndWriteMoreBytesThanBufferCanContain.cs
+++ b/test/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferNotEmptyAndWriteMoreBytesThanBufferCanContain.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -67,6 +68,7 @@ namespace Renci.SshNet.Tests.Classes
         private void CreateMocks()
         {
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _channelSessionMock = new Mock<IChannelSession>(MockBehavior.Strict);
         }

--- a/test/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferNotEmptyAndWriteZeroBytes.cs
+++ b/test/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferNotEmptyAndWriteZeroBytes.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -61,6 +62,7 @@ namespace Renci.SshNet.Tests.Classes
         private void CreateMocks()
         {
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
             _channelSessionMock = new Mock<IChannelSession>(MockBehavior.Strict);
         }

--- a/test/Renci.SshNet.Tests/Classes/SshClientTest_CreateShellStream_TerminalNameAndColumnsAndRowsAndWidthAndHeightAndBufferSizeAndTerminalModes_Connected.cs
+++ b/test/Renci.SshNet.Tests/Classes/SshClientTest_CreateShellStream_TerminalNameAndColumnsAndRowsAndWidthAndHeightAndBufferSizeAndTerminalModes_Connected.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -109,6 +110,7 @@ namespace Renci.SshNet.Tests.Classes
         private ShellStream CreateShellStream()
         {
             var sessionMock = new Mock<ISession>(MockBehavior.Loose);
+            sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             var channelSessionMock = new Mock<IChannelSession>(MockBehavior.Strict);
 
             sessionMock.Setup(p => p.ConnectionInfo)

--- a/test/Renci.SshNet.Tests/Classes/SshClientTest_CreateShellStream_TerminalNameAndColumnsAndRowsAndWidthAndHeightAndBufferSize_Connected.cs
+++ b/test/Renci.SshNet.Tests/Classes/SshClientTest_CreateShellStream_TerminalNameAndColumnsAndRowsAndWidthAndHeightAndBufferSize_Connected.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -104,6 +105,7 @@ namespace Renci.SshNet.Tests.Classes
         private ShellStream CreateShellStream()
         {
             var sessionMock = new Mock<ISession>(MockBehavior.Loose);
+            sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             var channelSessionMock = new Mock<IChannelSession>(MockBehavior.Strict);
 
             _ = sessionMock.Setup(p => p.ConnectionInfo)

--- a/test/Renci.SshNet.Tests/Classes/SshCommandTest_BeginExecute_EndExecuteInvokedOnAsyncResultFromPreviousInvocation.cs
+++ b/test/Renci.SshNet.Tests/Classes/SshCommandTest_BeginExecute_EndExecuteInvokedOnAsyncResultFromPreviousInvocation.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Text;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -37,6 +38,7 @@ namespace Renci.SshNet.Tests.Classes
             var random = new Random();
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelSessionAMock = new Mock<IChannelSession>(MockBehavior.Strict);
             _channelSessionBMock = new Mock<IChannelSession>(MockBehavior.Strict);
             _commandText = random.Next().ToString(CultureInfo.InvariantCulture);

--- a/test/Renci.SshNet.Tests/Classes/SshCommandTest_BeginExecute_EndExecuteNotInvokedOnAsyncResultFromPreviousInvocation.cs
+++ b/test/Renci.SshNet.Tests/Classes/SshCommandTest_BeginExecute_EndExecuteNotInvokedOnAsyncResultFromPreviousInvocation.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Text;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -34,6 +35,7 @@ namespace Renci.SshNet.Tests.Classes
             var random = new Random();
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelSessionMock = new Mock<IChannelSession>(MockBehavior.Strict);
             _commandText = random.Next().ToString(CultureInfo.InvariantCulture);
             _encoding = Encoding.UTF8;

--- a/test/Renci.SshNet.Tests/Classes/SshCommandTest_Dispose.cs
+++ b/test/Renci.SshNet.Tests/Classes/SshCommandTest_Dispose.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.IO;
 using System.Text;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -35,6 +36,7 @@ namespace Renci.SshNet.Tests.Classes
         private void Arrange()
         {
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _commandText = new Random().Next().ToString(CultureInfo.InvariantCulture);
             _encoding = Encoding.UTF8;
             _channelSessionMock = new Mock<IChannelSession>(MockBehavior.Strict);

--- a/test/Renci.SshNet.Tests/Classes/SshCommandTest_EndExecute_AsyncResultFromOtherInstance.cs
+++ b/test/Renci.SshNet.Tests/Classes/SshCommandTest_EndExecute_AsyncResultFromOtherInstance.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Text;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -35,6 +36,7 @@ namespace Renci.SshNet.Tests.Classes
         private void Arrange()
         {
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelSessionAMock = new Mock<IChannelSession>(MockBehavior.Strict);
             _channelSessionBMock = new Mock<IChannelSession>(MockBehavior.Strict);
             _commandText = new Random().Next().ToString(CultureInfo.InvariantCulture);

--- a/test/Renci.SshNet.Tests/Classes/SshCommandTest_EndExecute_AsyncResultIsNull.cs
+++ b/test/Renci.SshNet.Tests/Classes/SshCommandTest_EndExecute_AsyncResultIsNull.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Text;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -31,6 +32,7 @@ namespace Renci.SshNet.Tests.Classes
         private void Arrange()
         {
             _sessionMock = new Mock<ISession>();
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _commandText = new Random().Next().ToString(CultureInfo.InvariantCulture);
             _encoding = Encoding.UTF8;
             _asyncResult = null;

--- a/test/Renci.SshNet.Tests/Classes/SshCommandTest_EndExecute_ChannelOpen.cs
+++ b/test/Renci.SshNet.Tests/Classes/SshCommandTest_EndExecute_ChannelOpen.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Text;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -42,6 +43,7 @@ namespace Renci.SshNet.Tests.Classes
             var random = new Random();
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelSessionMock = new Mock<IChannelSession>(MockBehavior.Strict);
             _commandText = random.Next().ToString(CultureInfo.InvariantCulture);
             _encoding = Encoding.UTF8;

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_Connect_Connected.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_Connect_Connected.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -40,6 +41,7 @@ namespace Renci.SshNet.Tests.Classes
             _errorOccurredRegister = new List<ExceptionEventArgs>();
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelSession>(MockBehavior.Strict);
 
             _sequence = new MockSequence();

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_Connect_Disconnected.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_Connect_Disconnected.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -40,6 +41,7 @@ namespace Renci.SshNet.Tests.Classes
             _errorOccurredRegister = new List<ExceptionEventArgs>();
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelBeforeDisconnectMock = new Mock<IChannelSession>(MockBehavior.Strict);
             _channelAfterDisconnectMock = new Mock<IChannelSession>(MockBehavior.Strict);
 

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_Connect_Disposed.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_Connect_Disposed.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -39,6 +40,7 @@ namespace Renci.SshNet.Tests.Classes
             _errorOccurredRegister = new List<ExceptionEventArgs>();
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelSession>(MockBehavior.Strict);
 
             var sequence = new MockSequence();

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_Connect_SendSubsystemRequestFails.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_Connect_SendSubsystemRequestFails.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -40,6 +41,7 @@ namespace Renci.SshNet.Tests.Classes
             _errorOccurredRegister = new List<ExceptionEventArgs>();
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelSession>(MockBehavior.Strict);
 
             _sequence = new MockSequence();

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_Disconnect_Connected.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_Disconnect_Connected.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -39,6 +40,7 @@ namespace Renci.SshNet.Tests.Classes
             _errorOccurredRegister = new List<ExceptionEventArgs>();
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelSession>(MockBehavior.Strict);
 
             _sequence = new MockSequence();

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_Disconnect_Disposed.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_Disconnect_Disposed.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -38,6 +39,7 @@ namespace Renci.SshNet.Tests.Classes
             _errorOccurredRegister = new List<ExceptionEventArgs>();
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelSession>(MockBehavior.Strict);
 
             var sequence = new MockSequence();

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_Disconnect_NeverConnected.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_Disconnect_NeverConnected.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -36,6 +37,7 @@ namespace Renci.SshNet.Tests.Classes
             _errorOccurredRegister = new List<ExceptionEventArgs>();
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
 
             _subsystemSession = new SubsystemSessionStub(_sessionMock.Object,
                                                          _subsystemName,

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_Dispose_Connected.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_Dispose_Connected.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -38,6 +39,7 @@ namespace Renci.SshNet.Tests.Classes
             _errorOccurredRegister = new List<ExceptionEventArgs>();
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelSession>(MockBehavior.Strict);
 
             var sequence = new MockSequence();

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_Dispose_Disconnected.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_Dispose_Disconnected.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -38,6 +39,7 @@ namespace Renci.SshNet.Tests.Classes
             _errorOccurredRegister = new List<ExceptionEventArgs>();
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelSession>(MockBehavior.Strict);
 
             var sequence = new MockSequence();

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_Dispose_Disposed.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_Dispose_Disposed.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -38,6 +39,7 @@ namespace Renci.SshNet.Tests.Classes
             _errorOccurredRegister = new List<ExceptionEventArgs>();
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelSession>(MockBehavior.Strict);
 
             var sequence = new MockSequence();

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_Dispose_NeverConnected.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_Dispose_NeverConnected.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -37,6 +38,7 @@ namespace Renci.SshNet.Tests.Classes
             _errorOccurredRegister = new List<ExceptionEventArgs>();
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
 
             _subsystemSession = new SubsystemSessionStub(_sessionMock.Object,
                                                          _subsystemName,

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnChannelDataReceived_Connected.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnChannelDataReceived_Connected.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -43,6 +44,7 @@ namespace Renci.SshNet.Tests.Classes
                 new[] { (byte)random.Next(byte.MinValue, byte.MaxValue) });
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelSession>(MockBehavior.Strict);
 
             _sequence = new MockSequence();

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnChannelDataReceived_Disposed.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnChannelDataReceived_Disposed.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -42,6 +43,7 @@ namespace Renci.SshNet.Tests.Classes
                 new[] { (byte)random.Next(byte.MinValue, byte.MaxValue) });
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelSession>(MockBehavior.Strict);
 
             var sequence = new MockSequence();

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnChannelDataReceived_OnDataReceived_Exception.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnChannelDataReceived_OnDataReceived_Exception.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -45,6 +46,7 @@ namespace Renci.SshNet.Tests.Classes
             _onDataReceivedException = new SystemException();
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelSession>(MockBehavior.Strict);
 
             var sequence = new MockSequence();

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnChannelException_Connected.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnChannelException_Connected.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -42,6 +43,7 @@ namespace Renci.SshNet.Tests.Classes
             _channelExceptionEventArgs = new ExceptionEventArgs(new SystemException());
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelSession>(MockBehavior.Strict);
 
             _sequence = new MockSequence();

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnChannelException_Disposed.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnChannelException_Disposed.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -40,6 +41,7 @@ namespace Renci.SshNet.Tests.Classes
             _channelExceptionEventArgs = new ExceptionEventArgs(new SystemException());
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelSession>(MockBehavior.Strict);
 
             var sequence = new MockSequence();

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnSessionDisconnected_Connected.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnSessionDisconnected_Connected.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -39,6 +40,7 @@ namespace Renci.SshNet.Tests.Classes
             _errorOccurredRegister = new List<ExceptionEventArgs>();
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelSession>(MockBehavior.Strict);
 
             _sequence = new MockSequence();

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnSessionDisconnected_Disposed.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnSessionDisconnected_Disposed.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -38,6 +39,7 @@ namespace Renci.SshNet.Tests.Classes
             _errorOccurredRegister = new List<ExceptionEventArgs>();
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelSession>(MockBehavior.Strict);
 
             var sequence = new MockSequence();

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnSessionErrorOccurred_Connected.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnSessionErrorOccurred_Connected.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -42,6 +43,7 @@ namespace Renci.SshNet.Tests.Classes
             _errorOccurredEventArgs = new ExceptionEventArgs(new SystemException());
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelSession>(MockBehavior.Strict);
 
             _sequence = new MockSequence();

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnSessionErrorOccurred_Disposed.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnSessionErrorOccurred_Disposed.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -40,6 +41,7 @@ namespace Renci.SshNet.Tests.Classes
             _errorOccurredEventArgs = new ExceptionEventArgs(new SystemException());
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelSession>(MockBehavior.Strict);
 
             var sequence = new MockSequence();

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_SendData_Connected.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_SendData_Connected.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -41,6 +42,7 @@ namespace Renci.SshNet.Tests.Classes
             _data = new[] { (byte)random.Next(byte.MinValue, byte.MaxValue) };
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelSession>(MockBehavior.Strict);
 
             _sequence = new MockSequence();

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_SendData_Disposed.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_SendData_Disposed.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -39,6 +40,7 @@ namespace Renci.SshNet.Tests.Classes
             _errorOccurredRegister = new List<ExceptionEventArgs>();
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelSession>(MockBehavior.Strict);
 
             var sequence = new MockSequence();

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_SendData_NeverConnected.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_SendData_NeverConnected.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -42,6 +43,7 @@ namespace Renci.SshNet.Tests.Classes
             _data = new[] { (byte)random.Next(byte.MinValue, byte.MaxValue) };
 
             _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             _channelMock = new Mock<IChannelSession>(MockBehavior.Strict);
 
             _sequence = new MockSequence();


### PR DESCRIPTION
Refactor logging to allow a loggerfactory per session specified in the ConnectionInfo.

This commit introduces an `ILoggerFactory` to various classes, replacing the static logger factory with an instance-based approach for more flexible and session-specific logging. These changes improve the logging framework's flexibility and maintainability and allow unit testing of logging.