### PR TITLE
Remove calls to Socket.Poll and use SocketShutdown.Both

### DIFF
--- a/src/Renci.SshNet/Abstractions/SocketAbstraction.cs
+++ b/src/Renci.SshNet/Abstractions/SocketAbstraction.cs
@@ -12,34 +12,6 @@ namespace Renci.SshNet.Abstractions
 {
     internal static partial class SocketAbstraction
     {
-        public static bool CanRead(Socket socket)
-        {
-            if (socket.Connected)
-            {
-                return socket.Poll(-1, SelectMode.SelectRead) && socket.Available > 0;
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Returns a value indicating whether the specified <see cref="Socket"/> can be used
-        /// to send data.
-        /// </summary>
-        /// <param name="socket">The <see cref="Socket"/> to check.</param>
-        /// <returns>
-        /// <see langword="true"/> if <paramref name="socket"/> can be written to; otherwise, <see langword="false"/>.
-        /// </returns>
-        public static bool CanWrite(Socket socket)
-        {
-            if (socket != null && socket.Connected)
-            {
-                return socket.Poll(-1, SelectMode.SelectWrite);
-            }
-
-            return false;
-        }
-
         public static Socket Connect(IPEndPoint remoteEndpoint, TimeSpan connectTimeout)
         {
             var socket = new Socket(remoteEndpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };

--- a/src/Renci.SshNet/Common/Extensions.cs
+++ b/src/Renci.SshNet/Common/Extensions.cs
@@ -10,7 +10,6 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
-using Renci.SshNet.Abstractions;
 using Renci.SshNet.Messages;
 
 namespace Renci.SshNet.Common
@@ -317,16 +316,6 @@ namespace Renci.SshNet.Common
             Buffer.BlockCopy(first, 0, concat, 0, first.Length);
             Buffer.BlockCopy(second, 0, concat, first.Length, second.Length);
             return concat;
-        }
-
-        internal static bool CanRead(this Socket socket)
-        {
-            return SocketAbstraction.CanRead(socket);
-        }
-
-        internal static bool CanWrite(this Socket socket)
-        {
-            return SocketAbstraction.CanWrite(socket);
         }
 
         internal static bool IsConnected(this Socket socket)

--- a/test/Renci.SshNet.Tests/Classes/AbstractionsTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/AbstractionsTest.cs
@@ -9,12 +9,6 @@ namespace Renci.SshNet.Tests.Classes
     public class AbstractionsTest
     {
         [TestMethod]
-        public void SocketAbstraction_CanWrite_ShouldReturnFalseWhenSocketIsNull()
-        {
-            Assert.IsFalse(SocketAbstraction.CanWrite(null));
-        }
-
-        [TestMethod]
         public void CryptoAbstraction_GenerateRandom_ShouldPerformNoOpWhenDataIsZeroLength()
         {
             Assert.AreEqual(0, CryptoAbstraction.GenerateRandom(0).Length);

--- a/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ConnectionReset.cs
+++ b/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ConnectionReset.cs
@@ -64,8 +64,6 @@ namespace Renci.SshNet.Tests.Classes
 
             var connectionException = (SshConnectionException)exception;
             Assert.AreEqual(DisconnectReason.ConnectionLost, connectionException.DisconnectReason);
-            Assert.IsNull(connectionException.InnerException);
-            Assert.AreEqual("An established connection was aborted by the server.", connectionException.Message);
         }
 
         [TestMethod]
@@ -137,45 +135,29 @@ namespace Renci.SshNet.Tests.Classes
         public void ISession_WaitOnHandle_WaitHandle_ShouldThrowSshConnectionException()
         {
             var session = (ISession)Session;
-            var waitHandle = new ManualResetEvent(false);
+            using var waitHandle = new ManualResetEvent(false);
 
-            try
-            {
-                session.WaitOnHandle(waitHandle);
-                Assert.Fail();
-            }
-            catch (SshConnectionException ex)
-            {
-                Assert.AreEqual("An established connection was aborted by the server.", ex.Message);
-                Assert.IsNull(ex.InnerException);
-                Assert.AreEqual(DisconnectReason.ConnectionLost, ex.DisconnectReason);
-            }
+            var ex = Assert.ThrowsExactly<SshConnectionException>(() => session.WaitOnHandle(waitHandle));
+
+            Assert.AreEqual(DisconnectReason.ConnectionLost, ex.DisconnectReason);
         }
 
         [TestMethod]
         public void ISession_WaitOnHandle_WaitHandleAndTimeout_ShouldThrowSshConnectionException()
         {
             var session = (ISession)Session;
-            var waitHandle = new ManualResetEvent(false);
+            using var waitHandle = new ManualResetEvent(false);
 
-            try
-            {
-                session.WaitOnHandle(waitHandle, Timeout.InfiniteTimeSpan);
-                Assert.Fail();
-            }
-            catch (SshConnectionException ex)
-            {
-                Assert.AreEqual(DisconnectReason.ConnectionLost, ex.DisconnectReason);
-                Assert.IsNull(ex.InnerException);
-                Assert.AreEqual("An established connection was aborted by the server.", ex.Message);
-            }
+            var ex = Assert.ThrowsExactly<SshConnectionException>(() => session.WaitOnHandle(waitHandle));
+
+            Assert.AreEqual(DisconnectReason.ConnectionLost, ex.DisconnectReason);
         }
 
         [TestMethod]
         public void ISession_TryWait_WaitHandleAndTimeout_ShouldReturnDisconnected()
         {
             var session = (ISession)Session;
-            var waitHandle = new ManualResetEvent(false);
+            using var waitHandle = new ManualResetEvent(false);
 
             var result = session.TryWait(waitHandle, Timeout.InfiniteTimeSpan);
 
@@ -186,7 +168,7 @@ namespace Renci.SshNet.Tests.Classes
         public void ISession_TryWait_WaitHandleAndTimeoutAndException_ShouldReturnDisconnected()
         {
             var session = (ISession)Session;
-            var waitHandle = new ManualResetEvent(false);
+            using var waitHandle = new ManualResetEvent(false);
 
             var result = session.TryWait(waitHandle, Timeout.InfiniteTimeSpan, out var exception);
 

--- a/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ServerSendsBadPacket.cs
+++ b/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ServerSendsBadPacket.cs
@@ -91,13 +91,20 @@ namespace Renci.SshNet.Tests.Classes
         }
 
         [TestMethod]
-        public void ReceiveOnServerSocketShouldReturnZero()
+        public void ServerShouldBeDisconnected()
         {
-            var buffer = new byte[1];
+            try
+            {
+                var buffer = new byte[1];
 
-            var actual = ServerSocket.Receive(buffer, 0, buffer.Length, SocketFlags.None);
+                var actual = ServerSocket.Receive(buffer, 0, buffer.Length, SocketFlags.None);
 
-            Assert.AreEqual(0, actual);
+                Assert.AreEqual(0, actual); // FIN
+            }
+            catch (SocketException sx)
+            {
+                Assert.AreEqual(SocketError.ConnectionReset, sx.SocketErrorCode); // RST
+            }
         }
 
         [TestMethod]


### PR DESCRIPTION
The message loop currently sits in a call to Poll until the socket has data to read or it is closed. This is unnecessary - it can equally just sit in the call to Receive.

The call to Poll in Session.IsConnected is also unnecessary - we can instead just call Socket.Connected. This only returns the connection state as of the last operation, but we are always performing operations in the message loop (or else we are not connected), so it should work equally well while being cheaper.

Lastly, when shutting down the socket, shut down both sides rather than just the sending side (SocketShutdown.Both rather than SocketShutdown.Send) - at this point we do not care about reading anything else. This makes it (more) certain that we will break out of the Receive call in the message loop, as has been noted in #355 for whatever remaining issues still exist there.