### PR TITLE
Tests: fix missing PermitTTY in RemoteSshdConfig Reset

### DIFF
--- a/test/Renci.SshNet.IntegrationTests/Common/RemoteSshdConfigExtensions.cs
+++ b/test/Renci.SshNet.IntegrationTests/Common/RemoteSshdConfigExtensions.cs
@@ -23,6 +23,7 @@ namespace Renci.SshNet.IntegrationTests.Common
                             .ClearHostKeyAlgorithms()
                             .ClearPublicKeyAcceptedAlgorithms()
                             .ClearMessageAuthenticationCodeAlgorithms()
+                            .PermitTTY(true)
                             .WithUsePAM(true)
                             .Update()
                             .Restart();


### PR DESCRIPTION
this fixes a test failure in `Common_CreateMoreChannelsThanMaxSessions` when running the tests multiple times against the same SSH server instance. The failure is specifically triggered by `SshTests_TTYDisabled.SetUp()` calling `PermitTTY(false)`, but `Reset()` not setting it back to `true`.

this was noticed in https://github.com/sshnet/SSH.NET/pull/1704#issuecomment-3343210311 .

To repro, you have to modify `InfrastructureFixture.InitializeAsync()` to always use the local container instead of setting one up with Testcontainers.

Then run the following. This uses podman, but should in theory also work with docker.

```
#!/bin/bash -e
podman build -t renci-ssh-tests-server-image -f test/Renci.SshNet.IntegrationTests/Dockerfile test/Renci.SshNet.IntegrationTests/
dotnet build -f net9.0 test/Renci.SshNet.IntegrationTests/Renci.SshNet.IntegrationTests.csproj

podman container rm -f -t 0 sshserver || true
podman run --rm -h renci-ssh-tests-server -d -p 2222:22 --name sshserver renci-ssh-tests-server-image

filter="FullyQualifiedName~ConnectivityTests.Common_CreateMoreChannelsThanMaxSessions|FullyQualifiedName~SshTests_TTYDisabled.Ssh_CreateShellNoTerminal"

dotnet test -f net9.0 --tl:off -v normal --no-build test/Renci.SshNet.IntegrationTests/Renci.SshNet.IntegrationTests.csproj
dotnet test -f net9.0 --tl:off -v normal --no-build test/Renci.SshNet.IntegrationTests/Renci.SshNet.IntegrationTests.csproj
```