### PR TITLE
Automatically publish tags to NuGet with Trusted Publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,7 +187,8 @@ jobs:
         name: Coverlet Results Windows .NET
         path: coverlet
 
-  Publish:
+  Publish-GitHub-Package:
+    name: Publish GitHub Package
     runs-on: ubuntu-24.04
     if: github.ref == 'refs/heads/develop'
     permissions:
@@ -214,3 +215,32 @@ jobs:
           dotnet nuget push "*.nupkg" \
             --source github \
             --api-key ${{ secrets.GITHUB_TOKEN }}
+
+  Publish-NuGet-Package:
+    name: Publish NuGet Package
+    runs-on: ubuntu-24.04
+    if: startsWith(github.event.ref, 'refs/tags/20')
+    permissions:
+      id-token: write
+    needs:
+      - Windows
+      - Linux
+      - Windows-Integration-Tests-NetFramework
+      - Windows-Integration-Tests-Net
+    steps:
+      - name: Download NuGet Package
+        uses: actions/download-artifact@v5
+        with:
+          name: NuGet Package
+
+      - name: NuGet login (OIDC → temp API key)
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
+      - name: Publish to NuGet Registry
+        run: |
+          dotnet nuget push "*.nupkg" \
+            --source https://api.nuget.org/v3/index.json \
+            --api-key ${{ steps.login.outputs.NUGET_API_KEY }}


### PR DESCRIPTION
this automates the publishing of releases to nuget.org and makes use of trusted publishing. See

https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing
https://devblogs.microsoft.com/dotnet/enhanced-security-is-here-with-the-new-trust-publishing-on-nuget-org/

This is obviously untested and would require setup in GitHub and NuGet:
- a `NUGET_USER` secret must be added to the Repository settings
- Trusted publishing must be set up on nuget.org as described [here](https://devblogs.microsoft.com/dotnet/enhanced-security-is-here-with-the-new-trust-publishing-on-nuget-org/#getting-started-%F0%9F%9A%80)