### PR TITLE
Update to MSTest 4

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <!-- Should stay on LTS .NET releases. -->
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.9" />
-    <PackageVersion Include="MSTest" Version="4.0.1" />
+    <PackageVersion Include="MSTest" Version="4.0.2" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.7.115" />
     <PackageVersion Include="PolySharp" Version="1.15.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <!-- Should stay on LTS .NET releases. -->
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.9" />
-    <PackageVersion Include="MSTest" Version="3.9.3" />
+    <PackageVersion Include="MSTest" Version="4.0.1" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.7.115" />
     <PackageVersion Include="PolySharp" Version="1.15.0" />

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -102,6 +102,12 @@ dotnet_diagnostic.SA1623.severity = none
 # For unit test projects, we do not care about documentation.
 dotnet_diagnostic.SA1629.severity = none
 
+# Workaround https://github.com/SonarSource/sonar-dotnet/issues/9767
+dotnet_diagnostic.S1450.severity = none
+dotnet_diagnostic.S1764.severity = none
+dotnet_diagnostic.S3260.severity = none
+dotnet_diagnostic.S5445.severity = none
+
 #### .NET Compiler Platform analysers rules ####
 
 # CA1001: Types that own disposable fields should be disposable

--- a/test/Renci.SshNet.IntegrationBenchmarks/Properties/AssemblyInfo.cs
+++ b/test/Renci.SshNet.IntegrationBenchmarks/Properties/AssemblyInfo.cs
@@ -1,0 +1,1 @@
+[assembly: DoNotParallelize]

--- a/test/Renci.SshNet.IntegrationTests/AuthenticationTests.cs
+++ b/test/Renci.SshNet.IntegrationTests/AuthenticationTests.cs
@@ -436,7 +436,7 @@ namespace Renci.SshNet.IntegrationTests
                 catch (SshAuthenticationException ex)
                 {
                     Assert.IsNull(ex.InnerException);
-                    Assert.StartsWith("AuthenticationPrompt.Response is null for prompt \"Password: \"", ex.Message, $"Message was \"{ex.Message}\"");
+                    Assert.StartsWith("AuthenticationPrompt.Response is null for prompt \"Password: \"", ex.Message);
                 }
             }
         }

--- a/test/Renci.SshNet.IntegrationTests/AuthenticationTests.cs
+++ b/test/Renci.SshNet.IntegrationTests/AuthenticationTests.cs
@@ -436,7 +436,7 @@ namespace Renci.SshNet.IntegrationTests
                 catch (SshAuthenticationException ex)
                 {
                     Assert.IsNull(ex.InnerException);
-                    Assert.IsTrue(ex.Message.StartsWith("AuthenticationPrompt.Response is null for prompt \"Password: \""), $"Message was \"{ex.Message}\"");
+                    Assert.StartsWith("AuthenticationPrompt.Response is null for prompt \"Password: \"", ex.Message, $"Message was \"{ex.Message}\"");
                 }
             }
         }

--- a/test/Renci.SshNet.IntegrationTests/ConnectivityTests.cs
+++ b/test/Renci.SshNet.IntegrationTests/ConnectivityTests.cs
@@ -432,7 +432,7 @@ namespace Renci.SshNet.IntegrationTests
                 var ex = Assert.Throws<SshConnectionException>(client.Connect);
 
                 Assert.AreEqual(DisconnectReason.KeyExchangeFailed, ex.DisconnectReason);
-                Assert.IsTrue(ex.Message.StartsWith("No matching host key algorithm"), ex.Message);
+                Assert.StartsWith("No matching host key algorithm", ex.Message, ex.Message);
             }
         }
 

--- a/test/Renci.SshNet.IntegrationTests/ConnectivityTests.cs
+++ b/test/Renci.SshNet.IntegrationTests/ConnectivityTests.cs
@@ -432,7 +432,7 @@ namespace Renci.SshNet.IntegrationTests
                 var ex = Assert.Throws<SshConnectionException>(client.Connect);
 
                 Assert.AreEqual(DisconnectReason.KeyExchangeFailed, ex.DisconnectReason);
-                Assert.StartsWith("No matching host key algorithm", ex.Message, ex.Message);
+                Assert.StartsWith("No matching host key algorithm", ex.Message);
             }
         }
 

--- a/test/Renci.SshNet.IntegrationTests/Logging/TestConsoleLogger.cs
+++ b/test/Renci.SshNet.IntegrationTests/Logging/TestConsoleLogger.cs
@@ -1,0 +1,40 @@
+#nullable enable
+using Microsoft.Extensions.Logging;
+
+namespace Renci.SshNet.IntegrationTests.Logging
+{
+    internal class TestConsoleLogger(string categoryName) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+        {
+            return null;
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append(logLevel);
+            sb.Append(": ");
+            sb.Append(categoryName);
+            sb.Append(": ");
+
+            string message = formatter(state, exception);
+            sb.Append(message);
+
+            if (exception != null)
+            {
+                sb.Append(": ");
+                sb.Append(exception);
+            }
+
+            string line = sb.ToString();
+            Console.WriteLine(line);
+        }
+    }
+}

--- a/test/Renci.SshNet.IntegrationTests/Logging/TestConsoleLoggerProvider.cs
+++ b/test/Renci.SshNet.IntegrationTests/Logging/TestConsoleLoggerProvider.cs
@@ -1,0 +1,18 @@
+#nullable enable
+
+using Microsoft.Extensions.Logging;
+
+namespace Renci.SshNet.IntegrationTests.Logging
+{
+    internal class TestConsoleLoggerProvider : ILoggerProvider
+    {
+        public ILogger CreateLogger(string categoryName)
+        {
+            return new TestConsoleLogger(categoryName);
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/test/Renci.SshNet.IntegrationTests/Logging/TestConsoleLoggerProviderExtensions.cs
+++ b/test/Renci.SshNet.IntegrationTests/Logging/TestConsoleLoggerProviderExtensions.cs
@@ -1,0 +1,16 @@
+#nullable enable
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+
+namespace Renci.SshNet.IntegrationTests.Logging
+{
+    internal static class TestConsoleLoggerProviderExtensions
+    {
+        internal static void AddTestConsoleLogger(this ILoggingBuilder builder)
+        {
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, TestConsoleLoggerProvider>());
+        }
+    }
+}

--- a/test/Renci.SshNet.IntegrationTests/OldIntegrationTests/SftpClientTest.ListDirectory.cs
+++ b/test/Renci.SshNet.IntegrationTests/OldIntegrationTests/SftpClientTest.ListDirectory.cs
@@ -43,7 +43,7 @@ namespace Renci.SshNet.IntegrationTests.OldIntegrationTests
 
                 var files = sftp.ListDirectory(".");
 
-                Assert.IsTrue(files.Count() > 0);
+                Assert.IsGreaterThan(0, files.Count());
 
                 foreach (var file in files)
                 {
@@ -71,7 +71,7 @@ namespace Renci.SshNet.IntegrationTests.OldIntegrationTests
                     Debug.WriteLine(file.FullName);
                 }
 
-                Assert.IsTrue(count > 0);
+                Assert.IsGreaterThan(0, count);
 
                 sftp.Disconnect();
             }
@@ -87,7 +87,7 @@ namespace Renci.SshNet.IntegrationTests.OldIntegrationTests
 
                 var files = sftp.ListDirectory(string.Empty);
 
-                Assert.IsTrue(files.Count() > 0);
+                Assert.IsGreaterThan(0, files.Count());
 
                 foreach (var file in files)
                 {
@@ -128,7 +128,7 @@ namespace Renci.SshNet.IntegrationTests.OldIntegrationTests
                 var files = sftp.ListDirectory(".");
 
                 //  Ensure that directory has at least 10000 items
-                Assert.IsTrue(files.Count() > 10000);
+                Assert.IsGreaterThan(10000, files.Count());
 
                 sftp.Disconnect();
             }
@@ -158,7 +158,7 @@ namespace Renci.SshNet.IntegrationTests.OldIntegrationTests
 
                 var files = sftp.ListDirectory(".");
 
-                Assert.IsTrue(files.First().FullName.StartsWith(string.Format("{0}", sftp.WorkingDirectory)));
+                Assert.StartsWith(string.Format("{0}", sftp.WorkingDirectory), files.First().FullName);
 
                 sftp.ChangeDirectory("test1_1");
 
@@ -178,7 +178,7 @@ namespace Renci.SshNet.IntegrationTests.OldIntegrationTests
 
                 files = sftp.ListDirectory("test1/test1_1");
 
-                Assert.IsTrue(files.First().FullName.StartsWith(string.Format("{0}/test1/test1_1", sftp.WorkingDirectory)));
+                Assert.StartsWith(string.Format("{0}/test1/test1_1", sftp.WorkingDirectory), files.First().FullName);
 
                 sftp.ChangeDirectory("test1/test1_1");
 
@@ -227,7 +227,7 @@ namespace Renci.SshNet.IntegrationTests.OldIntegrationTests
 
                 var files = sftp.ListDirectory(".");
 
-                Assert.IsTrue(files.First().FullName.StartsWith(string.Format("{0}", sftp.WorkingDirectory)));
+                Assert.StartsWith(string.Format("{0}", sftp.WorkingDirectory), files.First().FullName);
 
                 await sftp.ChangeDirectoryAsync("test1_1", CancellationToken.None).ConfigureAwait(false);
 
@@ -247,7 +247,7 @@ namespace Renci.SshNet.IntegrationTests.OldIntegrationTests
 
                 files = sftp.ListDirectory("test1/test1_1");
 
-                Assert.IsTrue(files.First().FullName.StartsWith(string.Format("{0}/test1/test1_1", sftp.WorkingDirectory)));
+                Assert.StartsWith(string.Format("{0}/test1/test1_1", sftp.WorkingDirectory), files.First().FullName);
 
                 await sftp.ChangeDirectoryAsync("test1/test1_1", CancellationToken.None).ConfigureAwait(false);
 

--- a/test/Renci.SshNet.IntegrationTests/OldIntegrationTests/SftpClientTest.SynchronizeDirectories.cs
+++ b/test/Renci.SshNet.IntegrationTests/OldIntegrationTests/SftpClientTest.SynchronizeDirectories.cs
@@ -24,7 +24,7 @@ namespace Renci.SshNet.IntegrationTests.OldIntegrationTests
                 string searchPattern = Path.GetFileName(uploadedFileName);
                 var upLoadedFiles = sftp.SynchronizeDirectories(sourceDir, destDir, searchPattern);
 
-                Assert.IsTrue(upLoadedFiles.Count() > 0);
+                Assert.IsGreaterThan(0, upLoadedFiles.Count());
 
                 foreach (var file in upLoadedFiles)
                 {
@@ -63,7 +63,7 @@ namespace Renci.SshNet.IntegrationTests.OldIntegrationTests
 
                 var upLoadedFiles = sftp.EndSynchronizeDirectories(asyncResult);
 
-                Assert.IsTrue(upLoadedFiles.Count() > 0);
+                Assert.IsGreaterThan(0, upLoadedFiles.Count());
 
                 foreach (var file in upLoadedFiles)
                 {

--- a/test/Renci.SshNet.IntegrationTests/OldIntegrationTests/SshCommandTest.cs
+++ b/test/Renci.SshNet.IntegrationTests/OldIntegrationTests/SshCommandTest.cs
@@ -226,7 +226,7 @@ namespace Renci.SshNet.IntegrationTests.OldIntegrationTests
                 {
                     Assert.Fail("Operation should fail");
                 }
-                Assert.IsTrue(cmd.ExitStatus > 0);
+                Assert.IsGreaterThan(0, cmd.ExitStatus.Value);
 
                 client.Disconnect();
             }
@@ -244,7 +244,7 @@ namespace Renci.SshNet.IntegrationTests.OldIntegrationTests
                 {
                     Assert.Fail("Operation should fail");
                 }
-                Assert.IsTrue(cmd.ExitStatus > 0);
+                Assert.IsGreaterThan(0, cmd.ExitStatus.Value);
 
                 var result = ExecuteTestCommand(client);
 

--- a/test/Renci.SshNet.IntegrationTests/OldIntegrationTests/SshCommandTest.cs
+++ b/test/Renci.SshNet.IntegrationTests/OldIntegrationTests/SshCommandTest.cs
@@ -54,7 +54,6 @@ namespace Renci.SshNet.IntegrationTests.OldIntegrationTests
         }
 
         [TestMethod]
-        [Timeout(5000)]
         public void Test_CancelAsync_Unfinished_Command()
         {
             using var client = new SshClient(SshServerHostName, SshServerPort, User.UserName, User.Password);
@@ -76,7 +75,6 @@ namespace Renci.SshNet.IntegrationTests.OldIntegrationTests
         }
 
         [TestMethod]
-        [Timeout(5000)]
         public async Task Test_CancelAsync_Kill_Unfinished_Command()
         {
             using var client = new SshClient(SshServerHostName, SshServerPort, User.UserName, User.Password);
@@ -122,7 +120,6 @@ namespace Renci.SshNet.IntegrationTests.OldIntegrationTests
         }
 
         [TestMethod]
-        [Timeout(5000)]
         public async Task Test_ExecuteAsync_CancellationToken()
         {
             using var client = new SshClient(SshServerHostName, SshServerPort, User.UserName, User.Password);
@@ -195,7 +192,6 @@ namespace Renci.SshNet.IntegrationTests.OldIntegrationTests
         }
 
         [TestMethod]
-        [Timeout(15000)]
         public async Task Test_ExecuteAsync_Disconnect()
         {
             using (var client = new SshClient(SshServerHostName, SshServerPort, User.UserName, User.Password))

--- a/test/Renci.SshNet.IntegrationTests/Properties/AssemblyInfo.cs
+++ b/test/Renci.SshNet.IntegrationTests/Properties/AssemblyInfo.cs
@@ -3,3 +3,5 @@ using System.Diagnostics.CodeAnalysis;
 
 [assembly: ExcludeFromCodeCoverage]
 #endif // NET
+
+[assembly: DoNotParallelize]

--- a/test/Renci.SshNet.IntegrationTests/ScpTests.cs
+++ b/test/Renci.SshNet.IntegrationTests/ScpTests.cs
@@ -380,19 +380,19 @@ namespace Renci.SshNet.IntegrationTests
                 }
 
                 var localFiles = Directory.GetFiles(localDirectory);
-                Assert.AreEqual(2, localFiles.Length);
+                Assert.HasCount(2, localFiles);
                 Assert.IsTrue(localFiles.Contains(localPathFile1));
                 Assert.IsTrue(localFiles.Contains(localPathFile2));
 
                 var localSubDirecties = Directory.GetDirectories(localDirectory);
-                Assert.AreEqual(1, localSubDirecties.Length);
+                Assert.HasCount(1, localSubDirecties);
                 Assert.AreEqual(localPathSubDirectory, localSubDirecties[0]);
 
                 var localFilesSubDirectory = Directory.GetFiles(localPathSubDirectory);
-                Assert.AreEqual(1, localFilesSubDirectory.Length);
+                Assert.HasCount(1, localFilesSubDirectory);
                 Assert.AreEqual(localPathFile3, localFilesSubDirectory[0]);
 
-                Assert.AreEqual(0, Directory.GetDirectories(localPathSubDirectory).Length);
+                Assert.IsEmpty(Directory.GetDirectories(localPathSubDirectory));
             }
             finally
             {

--- a/test/Renci.SshNet.IntegrationTests/ScpTests.cs
+++ b/test/Renci.SshNet.IntegrationTests/ScpTests.cs
@@ -20,7 +20,7 @@ namespace Renci.SshNet.IntegrationTests
         }
 
         [TestMethod]
-        [DynamicData(nameof(GetScpDownloadStreamDirectoryDoesNotExistData), DynamicDataSourceType.Method)]
+        [DynamicData(nameof(GetScpDownloadStreamDirectoryDoesNotExistData))]
         public void Scp_Download_Stream_DirectoryDoesNotExist(IRemotePathTransformation remotePathTransformation,
                                                               string remotePath,
                                                               string remoteFile)
@@ -94,7 +94,7 @@ namespace Renci.SshNet.IntegrationTests
         }
 
         [TestMethod]
-        [DynamicData(nameof(GetScpDownloadStreamFileDoesNotExistData), DynamicDataSourceType.Method)]
+        [DynamicData(nameof(GetScpDownloadStreamFileDoesNotExistData))]
         public void Scp_Download_Stream_FileDoesNotExist(IRemotePathTransformation remotePathTransformation,
                                                          string remotePath,
                                                          string remoteFile)
@@ -170,7 +170,7 @@ namespace Renci.SshNet.IntegrationTests
         }
 
         [TestMethod]
-        [DynamicData(nameof(GetScpDownloadDirectoryInfoDirectoryDoesNotExistData), DynamicDataSourceType.Method)]
+        [DynamicData(nameof(GetScpDownloadDirectoryInfoDirectoryDoesNotExistData))]
         public void Scp_Download_DirectoryInfo_DirectoryDoesNotExist(IRemotePathTransformation remotePathTransformation,
                                                                      string remotePath)
         {
@@ -228,7 +228,7 @@ namespace Renci.SshNet.IntegrationTests
         }
 
         [TestMethod]
-        [DynamicData(nameof(GetScpDownloadDirectoryInfoExistingFileData), DynamicDataSourceType.Method)]
+        [DynamicData(nameof(GetScpDownloadDirectoryInfoExistingFileData))]
         public void Scp_Download_DirectoryInfo_ExistingFile(IRemotePathTransformation remotePathTransformation,
                                                             string remotePath)
         {
@@ -291,7 +291,7 @@ namespace Renci.SshNet.IntegrationTests
         }
 
         [TestMethod]
-        [DynamicData(nameof(GetScpDownloadDirectoryInfoExistingDirectoryData), DynamicDataSourceType.Method)]
+        [DynamicData(nameof(GetScpDownloadDirectoryInfoExistingDirectoryData))]
         public void Scp_Download_DirectoryInfo_ExistingDirectory(IRemotePathTransformation remotePathTransformation,
                                                                  string remotePath)
         {
@@ -434,7 +434,7 @@ namespace Renci.SshNet.IntegrationTests
         }
 
         [TestMethod]
-        [DynamicData(nameof(GetScpDownloadFileInfoDirectoryDoesNotExistData), DynamicDataSourceType.Method)]
+        [DynamicData(nameof(GetScpDownloadFileInfoDirectoryDoesNotExistData))]
         public void Scp_Download_FileInfo_DirectoryDoesNotExist(IRemotePathTransformation remotePathTransformation,
                                                                 string remotePath,
                                                                 string remoteFile)
@@ -506,7 +506,7 @@ namespace Renci.SshNet.IntegrationTests
         }
 
         [TestMethod]
-        [DynamicData(nameof(GetScpDownloadFileInfoFileDoesNotExistData), DynamicDataSourceType.Method)]
+        [DynamicData(nameof(GetScpDownloadFileInfoFileDoesNotExistData))]
         public void Scp_Download_FileInfo_FileDoesNotExist(IRemotePathTransformation remotePathTransformation,
                                                            string remotePath,
                                                            string remoteFile)
@@ -580,7 +580,7 @@ namespace Renci.SshNet.IntegrationTests
         }
 
         [TestMethod]
-        [DynamicData(nameof(GetScpDownloadFileInfoExistingDirectoryData), DynamicDataSourceType.Method)]
+        [DynamicData(nameof(GetScpDownloadFileInfoExistingDirectoryData))]
         public void Scp_Download_FileInfo_ExistingDirectory(IRemotePathTransformation remotePathTransformation,
                                                             string remotePath)
         {
@@ -649,7 +649,7 @@ namespace Renci.SshNet.IntegrationTests
         }
 
         [TestMethod]
-        [DynamicData(nameof(GetScpDownloadFileInfoExistingFileData), DynamicDataSourceType.Method)]
+        [DynamicData(nameof(GetScpDownloadFileInfoExistingFileData))]
         public void Scp_Download_FileInfo_ExistingFile(IRemotePathTransformation remotePathTransformation,
                                                        string remotePath,
                                                        string remoteFile,
@@ -741,7 +741,7 @@ namespace Renci.SshNet.IntegrationTests
         }
 
         [TestMethod]
-        [DynamicData(nameof(GetScpDownloadStreamExistingDirectoryData), DynamicDataSourceType.Method)]
+        [DynamicData(nameof(GetScpDownloadStreamExistingDirectoryData))]
         public void Scp_Download_Stream_ExistingDirectory(IRemotePathTransformation remotePathTransformation,
                                                           string remotePath)
         {
@@ -809,7 +809,7 @@ namespace Renci.SshNet.IntegrationTests
         }
 
         [TestMethod]
-        [DynamicData(nameof(GetScpDownloadStreamExistingFileData), DynamicDataSourceType.Method)]
+        [DynamicData(nameof(GetScpDownloadStreamExistingFileData))]
         public void Scp_Download_Stream_ExistingFile(IRemotePathTransformation remotePathTransformation,
                                                      string remotePath,
                                                      string remoteFile,
@@ -896,7 +896,7 @@ namespace Renci.SshNet.IntegrationTests
         }
 
         [TestMethod]
-        [DynamicData(nameof(GetScpUploadFileStreamDirectoryDoesNotExistData), DynamicDataSourceType.Method)]
+        [DynamicData(nameof(GetScpUploadFileStreamDirectoryDoesNotExistData))]
         public void Scp_Upload_FileStream_DirectoryDoesNotExist(IRemotePathTransformation remotePathTransformation,
                                                                 string remotePath,
                                                                 string remoteFile)
@@ -966,7 +966,7 @@ namespace Renci.SshNet.IntegrationTests
         }
 
         [TestMethod]
-        [DynamicData(nameof(GetScpUploadFileStreamExistingDirectoryData), DynamicDataSourceType.Method)]
+        [DynamicData(nameof(GetScpUploadFileStreamExistingDirectoryData))]
         public void Scp_Upload_FileStream_ExistingDirectory(IRemotePathTransformation remotePathTransformation,
                                                             string remoteFile)
         {
@@ -1029,7 +1029,7 @@ namespace Renci.SshNet.IntegrationTests
         }
 
         [TestMethod]
-        [DynamicData(nameof(ScpUploadFileStreamExistingFileData), DynamicDataSourceType.Method)]
+        [DynamicData(nameof(ScpUploadFileStreamExistingFileData))]
         public void Scp_Upload_FileStream_ExistingFile(IRemotePathTransformation remotePathTransformation,
                                                        string remoteFile)
         {
@@ -1098,7 +1098,7 @@ namespace Renci.SshNet.IntegrationTests
         }
 
         [TestMethod]
-        [DynamicData(nameof(GetScpUploadFileStreamFileDoesNotExistData), DynamicDataSourceType.Method)]
+        [DynamicData(nameof(GetScpUploadFileStreamFileDoesNotExistData))]
         public void Scp_Upload_FileStream_FileDoesNotExist(IRemotePathTransformation remotePathTransformation,
                                                            string remotePath,
                                                            string remoteFile,
@@ -1197,7 +1197,7 @@ namespace Renci.SshNet.IntegrationTests
         /// https://github.com/sshnet/SSH.NET/issues/289
         /// </summary>
         [TestMethod]
-        [DynamicData(nameof(GetScpUploadFileInfoDirectoryDoesNotExistData), DynamicDataSourceType.Method)]
+        [DynamicData(nameof(GetScpUploadFileInfoDirectoryDoesNotExistData))]
         public void Scp_Upload_FileInfo_DirectoryDoesNotExist(IRemotePathTransformation remotePathTransformation,
                                                               string remotePath,
                                                               string remoteFile)
@@ -1277,7 +1277,7 @@ namespace Renci.SshNet.IntegrationTests
         /// https://github.com/sshnet/SSH.NET/issues/286
         /// </summary>
         [TestMethod]
-        [DynamicData(nameof(GetScpUploadFileInfoExistingDirectoryData), DynamicDataSourceType.Method)]
+        [DynamicData(nameof(GetScpUploadFileInfoExistingDirectoryData))]
         public void Scp_Upload_FileInfo_ExistingDirectory(IRemotePathTransformation remotePathTransformation,
                                                           string remoteFile)
         {
@@ -1339,7 +1339,7 @@ namespace Renci.SshNet.IntegrationTests
         }
 
         [TestMethod]
-        [DynamicData(nameof(GetScpUploadFileInfoExistingFileData), DynamicDataSourceType.Method)]
+        [DynamicData(nameof(GetScpUploadFileInfoExistingFileData))]
         public void Scp_Upload_FileInfo_ExistingFile(IRemotePathTransformation remotePathTransformation,
                                                      string remoteFile)
         {
@@ -1417,7 +1417,7 @@ namespace Renci.SshNet.IntegrationTests
         }
 
         [TestMethod]
-        [DynamicData(nameof(GetScpUploadFileInfoFileDoesNotExistData), DynamicDataSourceType.Method)]
+        [DynamicData(nameof(GetScpUploadFileInfoFileDoesNotExistData))]
         public void Scp_Upload_FileInfo_FileDoesNotExist(IRemotePathTransformation remotePathTransformation,
                                                          string remotePath,
                                                          string remoteFile,
@@ -1522,7 +1522,7 @@ namespace Renci.SshNet.IntegrationTests
         }
 
         [TestMethod]
-        [DynamicData(nameof(GetScpUploadDirectoryInfoDirectoryDoesNotExistData), DynamicDataSourceType.Method)]
+        [DynamicData(nameof(GetScpUploadDirectoryInfoDirectoryDoesNotExistData))]
         public void Scp_Upload_DirectoryInfo_DirectoryDoesNotExist(IRemotePathTransformation remotePathTransformation,
                                                                    string remoteDirectory)
         {
@@ -1587,7 +1587,7 @@ namespace Renci.SshNet.IntegrationTests
         }
 
         [TestMethod]
-        [DynamicData(nameof(GetScpUploadDirectoryInfoExistingDirectoryData), DynamicDataSourceType.Method)]
+        [DynamicData(nameof(GetScpUploadDirectoryInfoExistingDirectoryData))]
         public void Scp_Upload_DirectoryInfo_ExistingDirectory(IRemotePathTransformation remotePathTransformation,
                                                                string remoteDirectory)
         {
@@ -1791,7 +1791,7 @@ namespace Renci.SshNet.IntegrationTests
         }
 
         [TestMethod]
-        [DynamicData(nameof(GetScpUploadDirectoryInfoExistingFileData), DynamicDataSourceType.Method)]
+        [DynamicData(nameof(GetScpUploadDirectoryInfoExistingFileData))]
         public void Scp_Upload_DirectoryInfo_ExistingFile(IRemotePathTransformation remotePathTransformation,
                                                           string remoteDirectory)
         {

--- a/test/Renci.SshNet.IntegrationTests/SftpTests.cs
+++ b/test/Renci.SshNet.IntegrationTests/SftpTests.cs
@@ -26,7 +26,7 @@ namespace Renci.SshNet.IntegrationTests
         }
 
         [TestMethod]
-        [DynamicData(nameof(GetSftpUploadFileFileStreamData), DynamicDataSourceType.Method)]
+        [DynamicData(nameof(GetSftpUploadFileFileStreamData))]
         public void Sftp_UploadFile_FileStream(int size)
         {
             var file = CreateTempFile(size);

--- a/test/Renci.SshNet.IntegrationTests/SftpTests.cs
+++ b/test/Renci.SshNet.IntegrationTests/SftpTests.cs
@@ -3669,7 +3669,7 @@ namespace Renci.SshNet.IntegrationTests
                     client.ChangeDirectory(remoteDirectory);
 
                     var directoryContent = client.ListDirectory(".").OrderBy(p => p.Name).ToList();
-                    Assert.AreEqual(5, directoryContent.Count);
+                    Assert.HasCount(5, directoryContent);
 
                     Assert.AreEqual(".", directoryContent[0].Name);
                     Assert.AreEqual($"{remoteDirectory}/.", directoryContent[0].FullName);

--- a/test/Renci.SshNet.IntegrationTests/SshTests.cs
+++ b/test/Renci.SshNet.IntegrationTests/SshTests.cs
@@ -74,7 +74,7 @@ namespace Renci.SshNet.IntegrationTests
 
                     var line = shellStream.ReadLine();
                     Assert.IsNotNull(line);
-                    Assert.IsTrue(line.EndsWith("Hello!"), line);
+                    Assert.EndsWith("Hello!", line, line);
 
                     Assert.IsTrue(shellStream.ReadLine() is null || shellStream.ReadLine() is null); // we might first get e.g. "renci-ssh-tests-server:~$"
                 }
@@ -94,7 +94,7 @@ namespace Renci.SshNet.IntegrationTests
                     shellStream.WriteLine($"echo {foo}");
                     var line = shellStream.ReadLine(TimeSpan.FromSeconds(1));
                     Assert.IsNotNull(line);
-                    Assert.IsTrue(line.EndsWith(foo), line);
+                    Assert.EndsWith(foo, line, line);
                 }
             }
         }
@@ -221,7 +221,7 @@ namespace Renci.SshNet.IntegrationTests
                     var outputString = outputReader.ReadLine();
 
                     Assert.IsNotNull(outputString);
-                    Assert.IsTrue(outputString.EndsWith(foo), outputString);
+                    Assert.EndsWith(foo, outputString, outputString);
 
                     shell.Stop();
                 }
@@ -341,7 +341,7 @@ namespace Renci.SshNet.IntegrationTests
                                 lines.Add(line);
                             }
 
-                            Assert.AreEqual(6, lines.Count, string.Join("\n", lines));
+                            Assert.HasCount(6, lines, string.Join("\n", lines));
                             Assert.AreEqual(expectedResult, string.Join("\n", lines));
                         }
 
@@ -383,7 +383,7 @@ namespace Renci.SshNet.IntegrationTests
                 socksSocket.Send(httpGetRequest);
 
                 var httpResponse = GetHttpResponse(socksSocket, Encoding.ASCII);
-                Assert.IsTrue(httpResponse.Contains(searchText), httpResponse);
+                Assert.Contains(searchText, httpResponse, httpResponse);
             }
 
             Assert.IsTrue(socksSocket.Connected);
@@ -427,7 +427,7 @@ namespace Renci.SshNet.IntegrationTests
 
                     socksSocket.Send(httpGetRequest);
                     var httpResponse = GetHttpResponse(socksSocket, Encoding.ASCII);
-                    Assert.IsTrue(httpResponse.Contains(searchText), httpResponse);
+                    Assert.Contains(searchText, httpResponse, httpResponse);
 
                     // Verify if port is still open
                     socksSocket.Send(httpGetRequest);
@@ -447,7 +447,7 @@ namespace Renci.SshNet.IntegrationTests
 
                     socksSocket.Send(httpGetRequest);
                     httpResponse = GetHttpResponse(socksSocket, Encoding.ASCII);
-                    Assert.IsTrue(httpResponse.Contains(searchText), httpResponse);
+                    Assert.Contains(searchText, httpResponse, httpResponse);
 
                     forwardedPort.Dispose();
 
@@ -496,7 +496,7 @@ namespace Renci.SshNet.IntegrationTests
 
                 socksSocket.Send(httpGetRequest);
                 var httpResponse = GetHttpResponse(socksSocket, Encoding.ASCII);
-                Assert.IsTrue(httpResponse.Contains(searchText), httpResponse);
+                Assert.Contains(searchText, httpResponse, httpResponse);
 
                 forwardedPort.Dispose();
 

--- a/test/Renci.SshNet.IntegrationTests/SshTests.cs
+++ b/test/Renci.SshNet.IntegrationTests/SshTests.cs
@@ -74,7 +74,7 @@ namespace Renci.SshNet.IntegrationTests
 
                     var line = shellStream.ReadLine();
                     Assert.IsNotNull(line);
-                    Assert.EndsWith("Hello!", line, line);
+                    Assert.EndsWith("Hello!", line);
 
                     Assert.IsTrue(shellStream.ReadLine() is null || shellStream.ReadLine() is null); // we might first get e.g. "renci-ssh-tests-server:~$"
                 }
@@ -94,7 +94,7 @@ namespace Renci.SshNet.IntegrationTests
                     shellStream.WriteLine($"echo {foo}");
                     var line = shellStream.ReadLine(TimeSpan.FromSeconds(1));
                     Assert.IsNotNull(line);
-                    Assert.EndsWith(foo, line, line);
+                    Assert.EndsWith(foo, line);
                 }
             }
         }
@@ -221,7 +221,7 @@ namespace Renci.SshNet.IntegrationTests
                     var outputString = outputReader.ReadLine();
 
                     Assert.IsNotNull(outputString);
-                    Assert.EndsWith(foo, outputString, outputString);
+                    Assert.EndsWith(foo, outputString);
 
                     shell.Stop();
                 }
@@ -383,7 +383,7 @@ namespace Renci.SshNet.IntegrationTests
                 socksSocket.Send(httpGetRequest);
 
                 var httpResponse = GetHttpResponse(socksSocket, Encoding.ASCII);
-                Assert.Contains(searchText, httpResponse, httpResponse);
+                Assert.Contains(searchText, httpResponse);
             }
 
             Assert.IsTrue(socksSocket.Connected);
@@ -427,7 +427,7 @@ namespace Renci.SshNet.IntegrationTests
 
                     socksSocket.Send(httpGetRequest);
                     var httpResponse = GetHttpResponse(socksSocket, Encoding.ASCII);
-                    Assert.Contains(searchText, httpResponse, httpResponse);
+                    Assert.Contains(searchText, httpResponse);
 
                     // Verify if port is still open
                     socksSocket.Send(httpGetRequest);
@@ -447,7 +447,7 @@ namespace Renci.SshNet.IntegrationTests
 
                     socksSocket.Send(httpGetRequest);
                     httpResponse = GetHttpResponse(socksSocket, Encoding.ASCII);
-                    Assert.Contains(searchText, httpResponse, httpResponse);
+                    Assert.Contains(searchText, httpResponse);
 
                     forwardedPort.Dispose();
 
@@ -496,7 +496,7 @@ namespace Renci.SshNet.IntegrationTests
 
                 socksSocket.Send(httpGetRequest);
                 var httpResponse = GetHttpResponse(socksSocket, Encoding.ASCII);
-                Assert.Contains(searchText, httpResponse, httpResponse);
+                Assert.Contains(searchText, httpResponse);
 
                 forwardedPort.Dispose();
 

--- a/test/Renci.SshNet.IntegrationTests/SshTests_TTYDisabled.cs
+++ b/test/Renci.SshNet.IntegrationTests/SshTests_TTYDisabled.cs
@@ -62,7 +62,7 @@ namespace Renci.SshNet.IntegrationTests
                     shellStream.WriteLine($"echo {foo}");
                     var line = shellStream.ReadLine(TimeSpan.FromSeconds(1));
                     Assert.IsNotNull(line);
-                    Assert.IsTrue(line.EndsWith(foo), line);
+                    Assert.EndsWith(foo, line, line);
                 }
             }
         }
@@ -122,7 +122,7 @@ namespace Renci.SshNet.IntegrationTests
                     var outputString = outputReader.ReadLine();
 
                     Assert.IsNotNull(outputString);
-                    Assert.IsTrue(outputString.EndsWith(foo), outputString);
+                    Assert.EndsWith(foo, outputString, outputString);
 
                     shell.Stop();
                 }

--- a/test/Renci.SshNet.IntegrationTests/SshTests_TTYDisabled.cs
+++ b/test/Renci.SshNet.IntegrationTests/SshTests_TTYDisabled.cs
@@ -62,7 +62,7 @@ namespace Renci.SshNet.IntegrationTests
                     shellStream.WriteLine($"echo {foo}");
                     var line = shellStream.ReadLine(TimeSpan.FromSeconds(1));
                     Assert.IsNotNull(line);
-                    Assert.EndsWith(foo, line, line);
+                    Assert.EndsWith(foo, line);
                 }
             }
         }
@@ -122,7 +122,7 @@ namespace Renci.SshNet.IntegrationTests
                     var outputString = outputReader.ReadLine();
 
                     Assert.IsNotNull(outputString);
-                    Assert.EndsWith(foo, outputString, outputString);
+                    Assert.EndsWith(foo, outputString);
 
                     shell.Stop();
                 }

--- a/test/Renci.SshNet.IntegrationTests/TestsFixtures/InfrastructureFixture.cs
+++ b/test/Renci.SshNet.IntegrationTests/TestsFixtures/InfrastructureFixture.cs
@@ -6,6 +6,8 @@ using DotNet.Testcontainers.Images;
 
 using Microsoft.Extensions.Logging;
 
+using Renci.SshNet.IntegrationTests.Logging;
+
 namespace Renci.SshNet.IntegrationTests.TestsFixtures
 {
     public sealed class InfrastructureFixture : IDisposable
@@ -16,7 +18,7 @@ namespace Renci.SshNet.IntegrationTests.TestsFixtures
             {
                 builder.SetMinimumLevel(LogLevel.Debug);
                 builder.AddFilter("testcontainers", LogLevel.Information);
-                builder.AddConsole();
+                builder.AddTestConsoleLogger();
             });
 
             SshNetLoggingConfiguration.InitializeLogging(_loggerFactory);

--- a/test/Renci.SshNet.Tests/Classes/AbstractionsTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/AbstractionsTest.cs
@@ -11,7 +11,7 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void CryptoAbstraction_GenerateRandom_ShouldPerformNoOpWhenDataIsZeroLength()
         {
-            Assert.AreEqual(0, CryptoAbstraction.GenerateRandom(0).Length);
+            Assert.IsEmpty(CryptoAbstraction.GenerateRandom(0));
         }
 
         [TestMethod]
@@ -22,8 +22,8 @@ namespace Renci.SshNet.Tests.Classes
             var dataA = CryptoAbstraction.GenerateRandom(dataLength);
             var dataB = CryptoAbstraction.GenerateRandom(dataLength);
 
-            Assert.AreEqual(dataLength, dataA.Length);
-            Assert.AreEqual(dataLength, dataB.Length);
+            Assert.HasCount(dataLength, dataA);
+            Assert.HasCount(dataLength, dataB);
 
             CollectionAssert.AreNotEqual(dataA, dataB);
         }

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelForwardedTcpipTest_Dispose_SessionIsConnectedAndChannelIsOpen.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelForwardedTcpipTest_Dispose_SessionIsConnectedAndChannelIsOpen.cs
@@ -174,8 +174,8 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ChannelShouldShutdownSocketToRemoteListener()
         {
-            Assert.AreEqual(1, _connectedRegister.Count);
-            Assert.AreEqual(1, _disconnectedRegister.Count);
+            Assert.HasCount(1, _connectedRegister);
+            Assert.HasCount(1, _disconnectedRegister);
             Assert.AreSame(_connectedRegister[0], _disconnectedRegister[0]);
         }
 

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_Dispose_Disposed.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_Dispose_Disposed.cs
@@ -131,13 +131,13 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ExceptionShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelExceptionRegister.Count);
+            Assert.IsEmpty(_channelExceptionRegister);
         }
 
         [TestMethod]
         public void ClosedEventShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _channelClosedRegister.Count);
+            Assert.HasCount(1, _channelClosedRegister);
             Assert.AreEqual(_localChannelNumber, _channelClosedRegister[0].ChannelNumber);
         }
 

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_Dispose_SessionIsConnectedAndChannelIsOpen_ChannelCloseAndChannelEofReceived_DisposeInEventHandler.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_Dispose_SessionIsConnectedAndChannelIsOpen_ChannelCloseAndChannelEofReceived_DisposeInEventHandler.cs
@@ -123,13 +123,13 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ExceptionShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelExceptionRegister.Count, _channelExceptionRegister.AsString());
+            Assert.IsEmpty(_channelExceptionRegister, _channelExceptionRegister.AsString());
         }
 
         [TestMethod]
         public void ClosedEventShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _channelClosedRegister.Count);
+            Assert.HasCount(1, _channelClosedRegister);
             Assert.AreEqual(_localChannelNumber, _channelClosedRegister[0].ChannelNumber);
         }
 

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_Dispose_SessionIsConnectedAndChannelIsOpen_ChannelCloseAndChannelEofReceived_SendChannelCloseMessageFailure.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_Dispose_SessionIsConnectedAndChannelIsOpen_ChannelCloseAndChannelEofReceived_SendChannelCloseMessageFailure.cs
@@ -113,13 +113,13 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ExceptionShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelExceptionRegister.Count);
+            Assert.IsEmpty(_channelExceptionRegister);
         }
 
         [TestMethod]
         public void ClosedEventShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _channelClosedRegister.Count);
+            Assert.HasCount(1, _channelClosedRegister);
             Assert.AreEqual(_localChannelNumber, _channelClosedRegister[0].ChannelNumber);
         }
 

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_Dispose_SessionIsConnectedAndChannelIsOpen_ChannelCloseAndChannelEofReceived_SendChannelCloseMessageSuccess.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_Dispose_SessionIsConnectedAndChannelIsOpen_ChannelCloseAndChannelEofReceived_SendChannelCloseMessageSuccess.cs
@@ -121,13 +121,13 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ExceptionShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelExceptionRegister.Count, _channelExceptionRegister.AsString());
+            Assert.IsEmpty(_channelExceptionRegister, _channelExceptionRegister.AsString());
         }
 
         [TestMethod]
         public void ClosedEventShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _channelClosedRegister.Count);
+            Assert.HasCount(1, _channelClosedRegister);
             Assert.AreEqual(_localChannelNumber, _channelClosedRegister[0].ChannelNumber);
         }
 

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_Dispose_SessionIsConnectedAndChannelIsOpen_ChannelCloseReceived_SendChannelCloseMessageFailure.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_Dispose_SessionIsConnectedAndChannelIsOpen_ChannelCloseReceived_SendChannelCloseMessageFailure.cs
@@ -110,13 +110,13 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ExceptionShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelExceptionRegister.Count);
+            Assert.IsEmpty(_channelExceptionRegister);
         }
 
         [TestMethod]
         public void ClosedEventShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _channelClosedRegister.Count);
+            Assert.HasCount(1, _channelClosedRegister);
             Assert.AreEqual(_localChannelNumber, _channelClosedRegister[0].ChannelNumber);
         }
 

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_Dispose_SessionIsConnectedAndChannelIsOpen_ChannelCloseReceived_SendChannelCloseMessageSuccess.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_Dispose_SessionIsConnectedAndChannelIsOpen_ChannelCloseReceived_SendChannelCloseMessageSuccess.cs
@@ -118,13 +118,13 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ExceptionShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelExceptionRegister.Count, _channelExceptionRegister.AsString());
+            Assert.IsEmpty(_channelExceptionRegister, _channelExceptionRegister.AsString());
         }
 
         [TestMethod]
         public void ClosedEventShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _channelClosedRegister.Count);
+            Assert.HasCount(1, _channelClosedRegister);
             Assert.AreEqual(_localChannelNumber, _channelClosedRegister[0].ChannelNumber);
         }
 

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_Dispose_SessionIsConnectedAndChannelIsOpen_ChannelEofReceived_SendChannelCloseMessageFailure.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_Dispose_SessionIsConnectedAndChannelIsOpen_ChannelEofReceived_SendChannelCloseMessageFailure.cs
@@ -109,13 +109,13 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ExceptionShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelExceptionRegister.Count);
+            Assert.IsEmpty(_channelExceptionRegister);
         }
 
         [TestMethod]
         public void ClosedEventShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelClosedRegister.Count);
+            Assert.IsEmpty(_channelClosedRegister);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_Dispose_SessionIsConnectedAndChannelIsOpen_ChannelEofReceived_SendChannelCloseMessageSuccess.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_Dispose_SessionIsConnectedAndChannelIsOpen_ChannelEofReceived_SendChannelCloseMessageSuccess.cs
@@ -124,13 +124,13 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ExceptionShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelExceptionRegister.Count);
+            Assert.IsEmpty(_channelExceptionRegister);
         }
 
         [TestMethod]
         public void ClosedEventShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _channelClosedRegister.Count);
+            Assert.HasCount(1, _channelClosedRegister);
             Assert.AreEqual(_localChannelNumber, _channelClosedRegister[0].ChannelNumber);
         }
 

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_Dispose_SessionIsConnectedAndChannelIsOpen_NoChannelCloseOrChannelEofReceived.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_Dispose_SessionIsConnectedAndChannelIsOpen_NoChannelCloseOrChannelEofReceived.cs
@@ -129,13 +129,13 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ExceptionShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelExceptionRegister.Count);
+            Assert.IsEmpty(_channelExceptionRegister);
         }
 
         [TestMethod]
         public void ClosedEventShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _channelClosedRegister.Count);
+            Assert.HasCount(1, _channelClosedRegister);
             Assert.AreEqual(_localChannelNumber, _channelClosedRegister[0].ChannelNumber);
         }
 

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_Dispose_SessionIsConnectedAndChannelIsOpen_NoChannelCloseOrChannelEofReceived_SendChannelEofMessageFailure.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_Dispose_SessionIsConnectedAndChannelIsOpen_NoChannelCloseOrChannelEofReceived_SendChannelEofMessageFailure.cs
@@ -128,13 +128,13 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ExceptionShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelExceptionRegister.Count);
+            Assert.IsEmpty(_channelExceptionRegister);
         }
 
         [TestMethod]
         public void ClosedEventShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _channelClosedRegister.Count);
+            Assert.HasCount(1, _channelClosedRegister);
             Assert.AreEqual(_localChannelNumber, _channelClosedRegister[0].ChannelNumber);
         }
 

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_Dispose_SessionIsNotConnectedAndChannelIsOpen_ChannelCloseAndChannelEofReceived.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_Dispose_SessionIsNotConnectedAndChannelIsOpen_ChannelCloseAndChannelEofReceived.cs
@@ -109,13 +109,13 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ExceptionShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelExceptionRegister.Count);
+            Assert.IsEmpty(_channelExceptionRegister);
         }
 
         [TestMethod]
         public void ClosedEventShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _channelClosedRegister.Count);
+            Assert.HasCount(1, _channelClosedRegister);
             Assert.AreEqual(_localChannelNumber, _channelClosedRegister[0].ChannelNumber);
         }
 

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_Dispose_SessionIsNotConnectedAndChannelIsOpen_ChannelCloseReceived.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_Dispose_SessionIsNotConnectedAndChannelIsOpen_ChannelCloseReceived.cs
@@ -106,13 +106,13 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ExceptionShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelExceptionRegister.Count);
+            Assert.IsEmpty(_channelExceptionRegister);
         }
 
         [TestMethod]
         public void ClosedEventShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _channelClosedRegister.Count);
+            Assert.HasCount(1, _channelClosedRegister);
             Assert.AreEqual(_localChannelNumber, _channelClosedRegister[0].ChannelNumber);
         }
 

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_Dispose_SessionIsNotConnectedAndChannelIsOpen_NoChannelCloseOrChannelEofReceived.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_Dispose_SessionIsNotConnectedAndChannelIsOpen_NoChannelCloseOrChannelEofReceived.cs
@@ -101,13 +101,13 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ExceptionShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelExceptionRegister.Count);
+            Assert.IsEmpty(_channelExceptionRegister);
         }
 
         [TestMethod]
         public void ClosedEventShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _channelClosedRegister.Count);
+            Assert.IsEmpty(_channelClosedRegister);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_OnSessionChannelCloseReceived_SessionIsConnectedAndChannelIsOpen.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_OnSessionChannelCloseReceived_SessionIsConnectedAndChannelIsOpen.cs
@@ -117,13 +117,13 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ExceptionShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelExceptionRegister.Count, _channelExceptionRegister.AsString());
+            Assert.IsEmpty(_channelExceptionRegister, _channelExceptionRegister.AsString());
         }
 
         [TestMethod]
         public void ClosedEventShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _channelClosedRegister.Count);
+            Assert.HasCount(1, _channelClosedRegister);
             Assert.AreEqual(_localChannelNumber, _channelClosedRegister[0].ChannelNumber);
         }
 

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_Open_ExceptionWaitingOnOpenConfirmation.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_Open_ExceptionWaitingOnOpenConfirmation.cs
@@ -98,13 +98,13 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ExceptionShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelExceptionRegister.Count);
+            Assert.IsEmpty(_channelExceptionRegister);
         }
 
         [TestMethod]
         public void ClosedEventShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelClosedRegister.Count);
+            Assert.IsEmpty(_channelClosedRegister);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_Open_OnOpenFailureReceived_NoRetriesAvailable.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_Open_OnOpenFailureReceived_NoRetriesAvailable.cs
@@ -122,13 +122,13 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ExceptionShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelExceptionRegister.Count);
+            Assert.IsEmpty(_channelExceptionRegister);
         }
 
         [TestMethod]
         public void ClosedEventShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelClosedRegister.Count);
+            Assert.IsEmpty(_channelClosedRegister);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_Open_OnOpenFailureReceived_RetriesAvailable.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelSessionTest_Open_OnOpenFailureReceived_RetriesAvailable.cs
@@ -135,13 +135,13 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ExceptionShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelExceptionRegister.Count);
+            Assert.IsEmpty(_channelExceptionRegister);
         }
 
         [TestMethod]
         public void ClosedEventShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelClosedRegister.Count);
+            Assert.IsEmpty(_channelClosedRegister);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_Dispose_SessionIsConnectedAndChannelIsNotOpen.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_Dispose_SessionIsConnectedAndChannelIsNotOpen.cs
@@ -66,13 +66,13 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ClosedEventShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelClosedRegister.Count);
+            Assert.IsEmpty(_channelClosedRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelExceptionRegister.Count);
+            Assert.IsEmpty(_channelExceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_Dispose_SessionIsConnectedAndChannelIsOpen_EofNotReceived.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_Dispose_SessionIsConnectedAndChannelIsOpen_EofNotReceived.cs
@@ -133,13 +133,13 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void WaitOnHandleOnSessionShouldWaitForChannelCloseMessageToBeReceived()
         {
-            Assert.IsTrue(_closeTimer.ElapsedMilliseconds >= 100, "Elapsed milliseconds=" + _closeTimer.ElapsedMilliseconds);
+            Assert.IsGreaterThanOrEqualTo(100, _closeTimer.ElapsedMilliseconds, "Elapsed milliseconds=" + _closeTimer.ElapsedMilliseconds);
         }
 
         [TestMethod]
         public void ClosedEventShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _channelClosedRegister.Count);
+            Assert.HasCount(1, _channelClosedRegister);
             Assert.AreEqual(_localChannelNumber, _channelClosedRegister[0].ChannelNumber);
         }
 
@@ -152,7 +152,7 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ExceptionShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelExceptionRegister.Count);
+            Assert.IsEmpty(_channelExceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_Dispose_SessionIsConnectedAndChannelIsOpen_EofNotReceived_SendEofInvoked.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_Dispose_SessionIsConnectedAndChannelIsOpen_EofNotReceived_SendEofInvoked.cs
@@ -139,13 +139,13 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void WaitOnHandleOnSessionShouldWaitForChannelCloseMessageToBeReceived()
         {
-            Assert.IsTrue(_closeTimer.ElapsedMilliseconds >= 100, "Elapsed milliseconds=" + _closeTimer.ElapsedMilliseconds);
+            Assert.IsGreaterThanOrEqualTo(100, _closeTimer.ElapsedMilliseconds, "Elapsed milliseconds=" + _closeTimer.ElapsedMilliseconds);
         }
 
         [TestMethod]
         public void ClosedEventShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _channelClosedRegister.Count);
+            Assert.HasCount(1, _channelClosedRegister);
             Assert.AreEqual(_localChannelNumber, _channelClosedRegister[0].ChannelNumber);
         }
 
@@ -158,7 +158,7 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ExceptionShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelExceptionRegister.Count);
+            Assert.IsEmpty(_channelExceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_Dispose_SessionIsConnectedAndChannelIsOpen_EofReceived.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_Dispose_SessionIsConnectedAndChannelIsOpen_EofReceived.cs
@@ -173,21 +173,21 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ClosedEventShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _channelClosedRegister.Count);
+            Assert.HasCount(1, _channelClosedRegister);
             Assert.AreEqual(_localChannelNumber, _channelClosedRegister[0].ChannelNumber);
         }
 
         [TestMethod]
         public void EndOfDataEventShouldNotHaveFired()
         {
-            Assert.AreEqual(1, _channelEndOfDataRegister.Count);
+            Assert.HasCount(1, _channelEndOfDataRegister);
             Assert.AreEqual(_localChannelNumber, _channelEndOfDataRegister[0].ChannelNumber);
         }
 
         [TestMethod]
         public void ExceptionShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelExceptionRegister.Count);
+            Assert.IsEmpty(_channelExceptionRegister);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_Dispose_SessionIsConnectedAndChannelIsOpen_EofReceived_DisconnectWaitingForChannelCloseMessage.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_Dispose_SessionIsConnectedAndChannelIsOpen_EofReceived_DisconnectWaitingForChannelCloseMessage.cs
@@ -105,20 +105,20 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ClosedEventShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _channelClosedRegister.Count);
+            Assert.IsEmpty(_channelClosedRegister);
         }
 
         [TestMethod]
         public void EndOfDataEventShouldNotHaveFired()
         {
-            Assert.AreEqual(1, _channelEndOfDataRegister.Count);
+            Assert.HasCount(1, _channelEndOfDataRegister);
             Assert.AreEqual(_localChannelNumber, _channelEndOfDataRegister[0].ChannelNumber);
         }
 
         [TestMethod]
         public void ExceptionShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelExceptionRegister.Count);
+            Assert.IsEmpty(_channelExceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_Dispose_SessionIsConnectedAndChannelIsOpen_EofReceived_TimeoutWaitingForChannelCloseMessage.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_Dispose_SessionIsConnectedAndChannelIsOpen_EofReceived_TimeoutWaitingForChannelCloseMessage.cs
@@ -105,20 +105,20 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ClosedEventShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _channelClosedRegister.Count);
+            Assert.IsEmpty(_channelClosedRegister);
         }
 
         [TestMethod]
         public void EndOfDataEventShouldNotHaveFired()
         {
-            Assert.AreEqual(1, _channelEndOfDataRegister.Count);
+            Assert.HasCount(1, _channelEndOfDataRegister);
             Assert.AreEqual(_localChannelNumber, _channelEndOfDataRegister[0].ChannelNumber);
         }
 
         [TestMethod]
         public void ExceptionShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelExceptionRegister.Count);
+            Assert.IsEmpty(_channelExceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_Dispose_SessionIsNotConnectedAndChannelIsNotOpen.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_Dispose_SessionIsNotConnectedAndChannelIsNotOpen.cs
@@ -66,13 +66,13 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ClosedEventShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelClosedRegister.Count);
+            Assert.IsEmpty(_channelClosedRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelExceptionRegister.Count);
+            Assert.IsEmpty(_channelExceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_Dispose_SessionIsNotConnectedAndChannelIsOpen.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_Dispose_SessionIsNotConnectedAndChannelIsOpen.cs
@@ -66,13 +66,13 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ClosedEventShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelClosedRegister.Count);
+            Assert.IsEmpty(_channelClosedRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelExceptionRegister.Count);
+            Assert.IsEmpty(_channelExceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionChannelCloseReceived_OnClose_Exception.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionChannelCloseReceived_OnClose_Exception.cs
@@ -51,14 +51,14 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ExceptionEventShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _channelExceptionRegister.Count);
+            Assert.HasCount(1, _channelExceptionRegister);
             Assert.AreSame(_onCloseException, _channelExceptionRegister[0].Exception);
         }
 
         [TestMethod]
         public void OnErrorOccurredShouldBeInvokedOnce()
         {
-            Assert.AreEqual(1, _channel.OnErrorOccurredInvocations.Count);
+            Assert.HasCount(1, _channel.OnErrorOccurredInvocations);
             Assert.AreSame(_onCloseException, _channel.OnErrorOccurredInvocations[0]);
         }
     }

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionChannelCloseReceived_SessionIsConnectedAndChannelIsOpen_DisposeChannelInClosedEventHandler.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionChannelCloseReceived_SessionIsConnectedAndChannelIsOpen_DisposeChannelInClosedEventHandler.cs
@@ -121,20 +121,20 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ClosedEventShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _channelClosedRegister.Count);
+            Assert.HasCount(1, _channelClosedRegister);
             Assert.AreEqual(_localChannelNumber, _channelClosedRegister[0].ChannelNumber);
         }
 
         [TestMethod]
         public void EndOfDataEventShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelEndOfDataRegister.Count);
+            Assert.IsEmpty(_channelEndOfDataRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelExceptionRegister.Count);
+            Assert.IsEmpty(_channelExceptionRegister);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionChannelCloseReceived_SessionIsConnectedAndChannelIsOpen_EofNotReceived.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionChannelCloseReceived_SessionIsConnectedAndChannelIsOpen_EofNotReceived.cs
@@ -110,14 +110,14 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ClosedEventShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _channelClosedRegister.Count);
+            Assert.HasCount(1, _channelClosedRegister);
             Assert.AreEqual(_localChannelNumber, _channelClosedRegister[0].ChannelNumber);
         }
 
         [TestMethod]
         public void ExceptionShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelExceptionRegister.Count, _channelExceptionRegister.AsString());
+            Assert.IsEmpty(_channelExceptionRegister, _channelExceptionRegister.AsString());
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionChannelCloseReceived_SessionIsConnectedAndChannelIsOpen_EofReceived.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionChannelCloseReceived_SessionIsConnectedAndChannelIsOpen_EofReceived.cs
@@ -113,14 +113,14 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ClosedEventShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _channelClosedRegister.Count);
+            Assert.HasCount(1, _channelClosedRegister);
             Assert.AreEqual(_localChannelNumber, _channelClosedRegister[0].ChannelNumber);
         }
 
         [TestMethod]
         public void ExceptionShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelExceptionRegister.Count, _channelExceptionRegister.AsString());
+            Assert.IsEmpty(_channelExceptionRegister, _channelExceptionRegister.AsString());
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionChannelDataReceived_OnData_Exception.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionChannelDataReceived_OnData_Exception.cs
@@ -51,14 +51,14 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ExceptionEventShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _channelExceptionRegister.Count);
+            Assert.HasCount(1, _channelExceptionRegister);
             Assert.AreSame(_onDataException, _channelExceptionRegister[0].Exception);
         }
 
         [TestMethod]
         public void OnErrorOccurredShouldBeInvokedOnce()
         {
-            Assert.AreEqual(1, _channel.OnErrorOccurredInvocations.Count);
+            Assert.HasCount(1, _channel.OnErrorOccurredInvocations);
             Assert.AreSame(_onDataException, _channel.OnErrorOccurredInvocations[0]);
         }
     }

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionChannelEofReceived_OnEof_Exception.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionChannelEofReceived_OnEof_Exception.cs
@@ -59,14 +59,14 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ExceptionEventShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _channelExceptionRegister.Count);
+            Assert.HasCount(1, _channelExceptionRegister);
             Assert.AreSame(_onEofException, _channelExceptionRegister[0].Exception);
         }
 
         [TestMethod]
         public void OnErrorOccurredShouldBeInvokedOnce()
         {
-            Assert.AreEqual(1, _channel.OnErrorOccurredInvocations.Count);
+            Assert.HasCount(1, _channel.OnErrorOccurredInvocations);
             Assert.AreSame(_onEofException, _channel.OnErrorOccurredInvocations[0]);
         }
     }

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionChannelExtendedDataReceived_OnExtendedData_Exception.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionChannelExtendedDataReceived_OnExtendedData_Exception.cs
@@ -51,14 +51,14 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ExceptionEventShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _channelExceptionRegister.Count);
+            Assert.HasCount(1, _channelExceptionRegister);
             Assert.AreSame(_onExtendedDataException, _channelExceptionRegister[0].Exception);
         }
 
         [TestMethod]
         public void OnErrorOccurredShouldBeInvokedOnce()
         {
-            Assert.AreEqual(1, _channel.OnErrorOccurredInvocations.Count);
+            Assert.HasCount(1, _channel.OnErrorOccurredInvocations);
             Assert.AreSame(_onExtendedDataException, _channel.OnErrorOccurredInvocations[0]);
         }
     }

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionChannelFailureReceived_OnFailure_Exception.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionChannelFailureReceived_OnFailure_Exception.cs
@@ -51,14 +51,14 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ExceptionEventShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _channelExceptionRegister.Count);
+            Assert.HasCount(1, _channelExceptionRegister);
             Assert.AreSame(_onFailureException, _channelExceptionRegister[0].Exception);
         }
 
         [TestMethod]
         public void OnErrorOccurredShouldBeInvokedOnce()
         {
-            Assert.AreEqual(1, _channel.OnErrorOccurredInvocations.Count);
+            Assert.HasCount(1, _channel.OnErrorOccurredInvocations);
             Assert.AreSame(_onFailureException, _channel.OnErrorOccurredInvocations[0]);
         }
     }

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionChannelRequestReceived_HandleUnknownMessage.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionChannelRequestReceived_HandleUnknownMessage.cs
@@ -70,7 +70,7 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void NoExceptionShouldHaveFired()
         {
-            Assert.AreEqual(0, _channelExceptionRegister.Count);
+            Assert.IsEmpty(_channelExceptionRegister);
         }
     }
 

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionChannelRequestReceived_OnRequest_Exception.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionChannelRequestReceived_OnRequest_Exception.cs
@@ -55,14 +55,14 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ExceptionEventShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _channelExceptionRegister.Count);
+            Assert.HasCount(1, _channelExceptionRegister);
             Assert.AreSame(_onRequestException, _channelExceptionRegister[0].Exception);
         }
 
         [TestMethod]
         public void OnErrorOccurredShouldBeInvokedOnce()
         {
-            Assert.AreEqual(1, _channel.OnErrorOccurredInvocations.Count);
+            Assert.HasCount(1, _channel.OnErrorOccurredInvocations);
             Assert.AreSame(_onRequestException, _channel.OnErrorOccurredInvocations[0]);
         }
     }

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionChannelSuccessReceived_OnSuccess_Exception.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionChannelSuccessReceived_OnSuccess_Exception.cs
@@ -51,14 +51,14 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ExceptionEventShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _channelExceptionRegister.Count);
+            Assert.HasCount(1, _channelExceptionRegister);
             Assert.AreSame(_onSuccessException, _channelExceptionRegister[0].Exception);
         }
 
         [TestMethod]
         public void OnErrorOccurredShouldBeInvokedOnce()
         {
-            Assert.AreEqual(1, _channel.OnErrorOccurredInvocations.Count);
+            Assert.HasCount(1, _channel.OnErrorOccurredInvocations);
             Assert.AreSame(_onSuccessException, _channel.OnErrorOccurredInvocations[0]);
         }
     }

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionChannelWindowAdjustReceived_OnWindowAdjust_Exception.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionChannelWindowAdjustReceived_OnWindowAdjust_Exception.cs
@@ -60,14 +60,14 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ExceptionEventShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _channelExceptionRegister.Count);
+            Assert.HasCount(1, _channelExceptionRegister);
             Assert.AreSame(_onWindowAdjustException, _channelExceptionRegister[0].Exception);
         }
 
         [TestMethod]
         public void OnErrorOccurredShouldBeInvokedOnce()
         {
-            Assert.AreEqual(1, _channel.OnErrorOccurredInvocations.Count);
+            Assert.HasCount(1, _channel.OnErrorOccurredInvocations);
             Assert.AreSame(_onWindowAdjustException, _channel.OnErrorOccurredInvocations[0]);
         }
     }

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionDisconnected_OnDisconnected_Exception.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionDisconnected_OnDisconnected_Exception.cs
@@ -49,14 +49,14 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ExceptionEventShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _channelExceptionRegister.Count);
+            Assert.HasCount(1, _channelExceptionRegister);
             Assert.AreSame(_onDisconnectedException, _channelExceptionRegister[0].Exception);
         }
 
         [TestMethod]
         public void OnErrorOccurredShouldBeInvokedOnce()
         {
-            Assert.AreEqual(1, _channel.OnErrorOccurredInvocations.Count);
+            Assert.HasCount(1, _channel.OnErrorOccurredInvocations);
             Assert.AreSame(_onDisconnectedException, _channel.OnErrorOccurredInvocations[0]);
         }
     }

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionDisconnected_SessionIsConnectedAndChannelIsOpen.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionDisconnected_SessionIsConnectedAndChannelIsOpen.cs
@@ -65,13 +65,13 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ClosedEventShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelClosedRegister.Count);
+            Assert.IsEmpty(_channelClosedRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelExceptionRegister.Count);
+            Assert.IsEmpty(_channelExceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionErrorOccurred_OnErrorOccurred_Exception.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_OnSessionErrorOccurred_OnErrorOccurred_Exception.cs
@@ -51,14 +51,14 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ExceptionEventShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _channelExceptionRegister.Count);
+            Assert.HasCount(1, _channelExceptionRegister);
             Assert.AreSame(_onErrorOccurredException, _channelExceptionRegister[0].Exception);
         }
 
         [TestMethod]
         public void OnErrorOccurredShouldBeInvokedOnce()
         {
-            Assert.AreEqual(1, _channel.OnErrorOccurredInvocations.Count);
+            Assert.HasCount(1, _channel.OnErrorOccurredInvocations);
             Assert.AreSame(_errorOccurredException, _channel.OnErrorOccurredInvocations[0]);
         }
     }

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_SendEof_ChannelIsNotOpen.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_SendEof_ChannelIsNotOpen.cs
@@ -82,13 +82,13 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ClosedEventShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelClosedRegister.Count);
+            Assert.IsEmpty(_channelClosedRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelExceptionRegister.Count);
+            Assert.IsEmpty(_channelExceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_SendEof_ChannelIsOpen.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelTest_SendEof_ChannelIsOpen.cs
@@ -75,13 +75,13 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ClosedEventShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelClosedRegister.Count);
+            Assert.IsEmpty(_channelClosedRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _channelExceptionRegister.Count);
+            Assert.IsEmpty(_channelExceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/Channels/ClientChannelTest_OnSessionChannelOpenConfirmationReceived_OnOpenConfirmation_Exception.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ClientChannelTest_OnSessionChannelOpenConfirmationReceived_OnOpenConfirmation_Exception.cs
@@ -59,14 +59,14 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ExceptionEventShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _channelExceptionRegister.Count);
+            Assert.HasCount(1, _channelExceptionRegister);
             Assert.AreSame(_onOpenConfirmationException, _channelExceptionRegister[0].Exception);
         }
 
         [TestMethod]
         public void OnErrorOccurredShouldBeInvokedOnce()
         {
-            Assert.AreEqual(1, _channel.OnErrorOccurredInvocations.Count);
+            Assert.HasCount(1, _channel.OnErrorOccurredInvocations);
             Assert.AreSame(_onOpenConfirmationException, _channel.OnErrorOccurredInvocations[0]);
         }
     }

--- a/test/Renci.SshNet.Tests/Classes/Channels/ClientChannelTest_OnSessionChannelOpenFailureReceived_OnOpenFailure_Exception.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ClientChannelTest_OnSessionChannelOpenFailureReceived_OnOpenFailure_Exception.cs
@@ -56,14 +56,14 @@ namespace Renci.SshNet.Tests.Classes.Channels
         [TestMethod]
         public void ExceptionEventShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _channelExceptionRegister.Count);
+            Assert.HasCount(1, _channelExceptionRegister);
             Assert.AreSame(_onOpenFailureException, _channelExceptionRegister[0].Exception);
         }
 
         [TestMethod]
         public void OnErrorOccurredShouldBeInvokedOnce()
         {
-            Assert.AreEqual(1, _channel.OnErrorOccurredInvocations.Count);
+            Assert.HasCount(1, _channel.OnErrorOccurredInvocations);
             Assert.AreSame(_onOpenFailureException, _channel.OnErrorOccurredInvocations[0]);
         }
     }

--- a/test/Renci.SshNet.Tests/Classes/Common/ExtensionsTest_Concat.cs
+++ b/test/Renci.SshNet.Tests/Classes/Common/ExtensionsTest_Concat.cs
@@ -85,7 +85,7 @@ namespace Renci.SshNet.Tests.Classes.Common
             var actual = Extensions.Concat(first, second);
 
             Assert.IsNotNull(actual);
-            Assert.AreEqual(first.Length + second.Length, actual.Length);
+            Assert.HasCount(first.Length + second.Length, actual);
             Assert.AreEqual(first[0], actual[0]);
             Assert.AreEqual(first[1], actual[1]);
             Assert.AreEqual(first[2], actual[2]);

--- a/test/Renci.SshNet.Tests/Classes/Common/ExtensionsTest_Pad.cs
+++ b/test/Renci.SshNet.Tests/Classes/Common/ExtensionsTest_Pad.cs
@@ -13,7 +13,7 @@ namespace Renci.SshNet.Tests.Classes.Common
             byte[] value = { 0x0a, 0x0d };
             var padded = value.Pad(2);
             Assert.AreEqual(value, padded);
-            Assert.AreEqual(value.Length, padded.Length);
+            Assert.HasCount(value.Length, padded);
         }
 
         [TestMethod]
@@ -21,7 +21,7 @@ namespace Renci.SshNet.Tests.Classes.Common
         {
             byte[] value = { 0x0a, 0x0d };
             var padded = value.Pad(3);
-            Assert.AreEqual(value.Length + 1, padded.Length);
+            Assert.HasCount(value.Length + 1, padded);
             Assert.AreEqual(0x00, padded[0]);
             Assert.AreEqual(0x0a, padded[1]);
             Assert.AreEqual(0x0d, padded[2]);

--- a/test/Renci.SshNet.Tests/Classes/Common/ExtensionsTest_Take_Count.cs
+++ b/test/Renci.SshNet.Tests/Classes/Common/ExtensionsTest_Take_Count.cs
@@ -44,7 +44,7 @@ namespace Renci.SshNet.Tests.Classes.Common
             var actual = Extensions.Take(value, count);
 
             Assert.IsNotNull(actual);
-            Assert.AreEqual(0, actual.Length);
+            Assert.IsEmpty(actual);
         }
 
         [TestMethod]
@@ -68,7 +68,7 @@ namespace Renci.SshNet.Tests.Classes.Common
             var actual = Extensions.Take(value, count);
 
             Assert.IsNotNull(actual);
-            Assert.AreEqual(count, actual.Length);
+            Assert.HasCount(count, actual);
             Assert.AreEqual(value[0], actual[0]);
             Assert.AreEqual(value[1], actual[1]);
             Assert.AreEqual(value[2], actual[2]);

--- a/test/Renci.SshNet.Tests/Classes/Common/ExtensionsTest_Take_OffsetAndCount.cs
+++ b/test/Renci.SshNet.Tests/Classes/Common/ExtensionsTest_Take_OffsetAndCount.cs
@@ -47,7 +47,7 @@ namespace Renci.SshNet.Tests.Classes.Common
             var actual = Extensions.Take(value, offset, count);
 
             Assert.IsNotNull(actual);
-            Assert.AreEqual(0, actual.Length);
+            Assert.IsEmpty(actual);
         }
 
         [TestMethod]
@@ -60,7 +60,7 @@ namespace Renci.SshNet.Tests.Classes.Common
             var actual = Extensions.Take(value, offset, count);
 
             Assert.IsNotNull(actual);
-            Assert.AreEqual(value.Length, actual.Length);
+            Assert.HasCount(value.Length, actual);
             Assert.AreEqual(value, actual);
         }
 
@@ -74,7 +74,7 @@ namespace Renci.SshNet.Tests.Classes.Common
             var actual = Extensions.Take(value, offset, count);
 
             Assert.IsNotNull(actual);
-            Assert.AreEqual(count, actual.Length);
+            Assert.HasCount(count, actual);
             Assert.AreEqual(value[0], actual[0]);
             Assert.AreEqual(value[1], actual[1]);
             Assert.AreEqual(value[2], actual[2]);
@@ -92,7 +92,7 @@ namespace Renci.SshNet.Tests.Classes.Common
             var actual = Extensions.Take(value, offset, count);
 
             Assert.IsNotNull(actual);
-            Assert.AreEqual(count, actual.Length);
+            Assert.HasCount(count, actual);
             Assert.AreEqual(value[3], actual[0]);
             Assert.AreEqual(value[4], actual[1]);
             Assert.AreEqual(value[5], actual[2]);

--- a/test/Renci.SshNet.Tests/Classes/Common/ExtensionsTest_ToBigInteger2.cs
+++ b/test/Renci.SshNet.Tests/Classes/Common/ExtensionsTest_ToBigInteger2.cs
@@ -15,7 +15,7 @@ namespace Renci.SshNet.Tests.Classes.Common
             var actual = value.ToBigInteger2().ToByteArray(isBigEndian: true);
 
             Assert.IsNotNull(actual);
-            Assert.AreEqual(2, actual.Length);
+            Assert.HasCount(2, actual);
             Assert.AreEqual(0x0a, actual[0]);
             Assert.AreEqual(0x0d, actual[1]);
         }
@@ -28,7 +28,7 @@ namespace Renci.SshNet.Tests.Classes.Common
             var actual = value.ToBigInteger2().ToByteArray(isBigEndian: true);
 
             Assert.IsNotNull(actual);
-            Assert.AreEqual(4, actual.Length);
+            Assert.HasCount(4, actual);
             Assert.AreEqual(0x00, actual[0]);
             Assert.AreEqual(0xff, actual[1]);
             Assert.AreEqual(0x0a, actual[2]);

--- a/test/Renci.SshNet.Tests/Classes/Common/ExtensionsTest_TrimLeadingZeros.cs
+++ b/test/Renci.SshNet.Tests/Classes/Common/ExtensionsTest_TrimLeadingZeros.cs
@@ -34,7 +34,7 @@ namespace Renci.SshNet.Tests.Classes.Common
             var actual = Extensions.TrimLeadingZeros(value);
 
             Assert.IsNotNull(actual);
-            Assert.AreEqual(2, actual.Length);
+            Assert.HasCount(2, actual);
             Assert.AreEqual(0x0a, actual[0]);
             Assert.AreEqual(0x0d, actual[1]);
         }
@@ -47,7 +47,7 @@ namespace Renci.SshNet.Tests.Classes.Common
             var actual = Extensions.TrimLeadingZeros(value);
 
             Assert.IsNotNull(actual);
-            Assert.AreEqual(4, actual.Length);
+            Assert.HasCount(4, actual);
             Assert.AreEqual(0x0a, actual[0]);
             Assert.AreEqual(0x00, actual[1]);
             Assert.AreEqual(0x0d, actual[2]);
@@ -62,7 +62,7 @@ namespace Renci.SshNet.Tests.Classes.Common
             var actual = Extensions.TrimLeadingZeros(value);
 
             Assert.IsNotNull(actual);
-            Assert.AreEqual(3, actual.Length);
+            Assert.HasCount(3, actual);
             Assert.AreEqual(0x0a, actual[0]);
             Assert.AreEqual(0x00, actual[1]);
             Assert.AreEqual(0x0d, actual[2]);
@@ -76,7 +76,7 @@ namespace Renci.SshNet.Tests.Classes.Common
             var actual = Extensions.TrimLeadingZeros(value);
 
             Assert.IsNotNull(actual);
-            Assert.AreEqual(0, actual.Length);
+            Assert.IsEmpty(actual);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/Connection/DirectConnectorTest_Connect_ConnectionRefusedByServer.cs
+++ b/test/Renci.SshNet.Tests/Classes/Connection/DirectConnectorTest_Connect_ConnectionRefusedByServer.cs
@@ -76,7 +76,7 @@ namespace Renci.SshNet.Tests.Classes.Connection
                                           _connectionInfo.Timeout.TotalMilliseconds);
 
             // Compare elapsed time with configured timeout, allowing for a margin of error
-            Assert.IsTrue(_stopWatch.ElapsedMilliseconds < _connectionInfo.Timeout.TotalMilliseconds + 100, errorText);
+            Assert.IsLessThan(_connectionInfo.Timeout.TotalMilliseconds + 100, _stopWatch.ElapsedMilliseconds, errorText);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/Connection/DirectConnectorTest_Connect_ConnectionSucceeded.cs
+++ b/test/Renci.SshNet.Tests/Classes/Connection/DirectConnectorTest_Connect_ConnectionSucceeded.cs
@@ -83,7 +83,7 @@ namespace Renci.SshNet.Tests.Classes.Connection
                                           _connectionInfo.Timeout.TotalMilliseconds);
 
             // Compare elapsed time with configured timeout, allowing for a margin of error
-            Assert.IsTrue(_stopWatch.ElapsedMilliseconds < _connectionInfo.Timeout.TotalMilliseconds + 100, errorText);
+            Assert.IsLessThan(_connectionInfo.Timeout.TotalMilliseconds + 100, _stopWatch.ElapsedMilliseconds, errorText);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/Connection/DirectConnectorTest_Connect_TimeoutConnectingToServer.cs
+++ b/test/Renci.SshNet.Tests/Classes/Connection/DirectConnectorTest_Connect_TimeoutConnectingToServer.cs
@@ -96,8 +96,8 @@ namespace Renci.SshNet.Tests.Classes.Connection
                                           _connectionInfo.Timeout.TotalMilliseconds);
 
             // Compare elapsed time with configured timeout, allowing for a margin of error
-            Assert.IsTrue(_stopWatch.ElapsedMilliseconds >= _connectionInfo.Timeout.TotalMilliseconds - 10, errorText);
-            Assert.IsTrue(_stopWatch.ElapsedMilliseconds < _connectionInfo.Timeout.TotalMilliseconds + 100, errorText);
+            Assert.IsGreaterThanOrEqualTo(_connectionInfo.Timeout.TotalMilliseconds - 10, _stopWatch.ElapsedMilliseconds, errorText);
+            Assert.IsLessThan(_connectionInfo.Timeout.TotalMilliseconds + 100, _stopWatch.ElapsedMilliseconds, errorText);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/Connection/HttpConnectorTest_Connect_ConnectionToProxyRefused.cs
+++ b/test/Renci.SshNet.Tests/Classes/Connection/HttpConnectorTest_Connect_ConnectionToProxyRefused.cs
@@ -86,7 +86,7 @@ namespace Renci.SshNet.Tests.Classes.Connection
                                           _connectionInfo.Timeout.TotalMilliseconds);
 
             // Compare elapsed time with configured timeout, allowing for a margin of error
-            Assert.IsTrue(_stopWatch.ElapsedMilliseconds < _connectionInfo.Timeout.TotalMilliseconds + 100, errorText);
+            Assert.IsLessThan(_connectionInfo.Timeout.TotalMilliseconds + 100, _stopWatch.ElapsedMilliseconds, errorText);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/Connection/HttpConnectorTest_Connect_TimeoutConnectingToProxy.cs
+++ b/test/Renci.SshNet.Tests/Classes/Connection/HttpConnectorTest_Connect_TimeoutConnectingToProxy.cs
@@ -106,8 +106,8 @@ namespace Renci.SshNet.Tests.Classes.Connection
                                           _connectionInfo.Timeout.TotalMilliseconds);
 
             // Compare elapsed time with configured timeout, allowing for a margin of error
-            Assert.IsTrue(_stopWatch.ElapsedMilliseconds >= _connectionInfo.Timeout.TotalMilliseconds - 10, errorText);
-            Assert.IsTrue(_stopWatch.ElapsedMilliseconds < _connectionInfo.Timeout.TotalMilliseconds + 100, errorText);
+            Assert.IsGreaterThanOrEqualTo(_connectionInfo.Timeout.TotalMilliseconds - 10, _stopWatch.ElapsedMilliseconds, errorText);
+            Assert.IsLessThan(_connectionInfo.Timeout.TotalMilliseconds + 100, _stopWatch.ElapsedMilliseconds, errorText);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/Connection/HttpConnectorTest_Connect_TimeoutReadingHttpContent.cs
+++ b/test/Renci.SshNet.Tests/Classes/Connection/HttpConnectorTest_Connect_TimeoutReadingHttpContent.cs
@@ -137,8 +137,8 @@ namespace Renci.SshNet.Tests.Classes.Connection
                                           _connectionInfo.Timeout.TotalMilliseconds);
 
             // Compare elapsed time with configured timeout, allowing for a margin of error
-            Assert.IsTrue(_stopWatch.ElapsedMilliseconds >= _connectionInfo.Timeout.TotalMilliseconds - 10, errorText);
-            Assert.IsTrue(_stopWatch.ElapsedMilliseconds < _connectionInfo.Timeout.TotalMilliseconds + 100, errorText);
+            Assert.IsGreaterThanOrEqualTo(_connectionInfo.Timeout.TotalMilliseconds - 10, _stopWatch.ElapsedMilliseconds, errorText);
+            Assert.IsLessThan(_connectionInfo.Timeout.TotalMilliseconds + 100, _stopWatch.ElapsedMilliseconds, errorText);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/Connection/HttpConnectorTest_Connect_TimeoutReadingStatusLine.cs
+++ b/test/Renci.SshNet.Tests/Classes/Connection/HttpConnectorTest_Connect_TimeoutReadingStatusLine.cs
@@ -107,8 +107,8 @@ namespace Renci.SshNet.Tests.Classes.Connection
                                           _connectionInfo.Timeout.TotalMilliseconds);
 
             // Compare elapsed time with configured timeout, allowing for a margin of error
-            Assert.IsTrue(_stopWatch.ElapsedMilliseconds >= _connectionInfo.Timeout.TotalMilliseconds - 10, errorText);
-            Assert.IsTrue(_stopWatch.ElapsedMilliseconds < _connectionInfo.Timeout.TotalMilliseconds + 100, errorText);
+            Assert.IsGreaterThanOrEqualTo(_connectionInfo.Timeout.TotalMilliseconds - 10, _stopWatch.ElapsedMilliseconds, errorText);
+            Assert.IsLessThan(_connectionInfo.Timeout.TotalMilliseconds + 100, _stopWatch.ElapsedMilliseconds, errorText);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/Connection/ProtocolVersionExchangeTest_ConnectionClosedByServer_NoDataSentByServer.cs
+++ b/test/Renci.SshNet.Tests/Classes/Connection/ProtocolVersionExchangeTest_ConnectionClosedByServer_NoDataSentByServer.cs
@@ -103,7 +103,7 @@ namespace Renci.SshNet.Tests.Classes.Connection
         [TestMethod]
         public void ClientIdentificationWasSentToServer()
         {
-            Assert.AreEqual(5, _dataReceivedByServer.Count);
+            Assert.HasCount(5, _dataReceivedByServer);
 
             Assert.AreEqual(0xed, _dataReceivedByServer[0]);
             Assert.AreEqual(0x95, _dataReceivedByServer[1]);

--- a/test/Renci.SshNet.Tests/Classes/Connection/ProtocolVersionExchangeTest_ServerResponseContainsNullCharacter.cs
+++ b/test/Renci.SshNet.Tests/Classes/Connection/ProtocolVersionExchangeTest_ServerResponseContainsNullCharacter.cs
@@ -111,7 +111,7 @@ namespace Renci.SshNet.Tests.Classes.Connection
         {
             var expected = Encoding.UTF8.GetBytes(_clientVersion);
 
-            Assert.AreEqual(expected.Length + 2, _dataReceivedByServer.Count);
+            Assert.HasCount(expected.Length + 2, _dataReceivedByServer);
 
             Assert.IsTrue(expected.SequenceEqual(_dataReceivedByServer.Take(expected.Length)));
             Assert.AreEqual(Session.CarriageReturn, _dataReceivedByServer[_dataReceivedByServer.Count - 2]);

--- a/test/Renci.SshNet.Tests/Classes/Connection/ProtocolVersionExchangeTest_ServerResponseInvalid_SshIdentificationOnlyContainsProtocolVersion.cs
+++ b/test/Renci.SshNet.Tests/Classes/Connection/ProtocolVersionExchangeTest_ServerResponseInvalid_SshIdentificationOnlyContainsProtocolVersion.cs
@@ -113,7 +113,7 @@ namespace Renci.SshNet.Tests.Classes.Connection
         {
             var expected = Encoding.UTF8.GetBytes(_clientVersion);
 
-            Assert.AreEqual(expected.Length + 2, _dataReceivedByServer.Count);
+            Assert.HasCount(expected.Length + 2, _dataReceivedByServer);
 
             Assert.IsTrue(expected.SequenceEqual(_dataReceivedByServer.Take(expected.Length)));
             Assert.AreEqual(Session.CarriageReturn, _dataReceivedByServer[_dataReceivedByServer.Count - 2]);

--- a/test/Renci.SshNet.Tests/Classes/Connection/ProtocolVersionExchangeTest_ServerResponseValid_Comments.cs
+++ b/test/Renci.SshNet.Tests/Classes/Connection/ProtocolVersionExchangeTest_ServerResponseValid_Comments.cs
@@ -97,7 +97,7 @@ namespace Renci.SshNet.Tests.Classes.Connection
         {
             var expected = Encoding.UTF8.GetBytes(_clientVersion);
 
-            Assert.AreEqual(expected.Length + 2, _dataReceivedByServer.Count);
+            Assert.HasCount(expected.Length + 2, _dataReceivedByServer);
 
             Assert.IsTrue(expected.SequenceEqual(_dataReceivedByServer.Take(expected.Length)));
             Assert.AreEqual(Session.CarriageReturn, _dataReceivedByServer[_dataReceivedByServer.Count - 2]);

--- a/test/Renci.SshNet.Tests/Classes/Connection/ProtocolVersionExchangeTest_ServerResponseValid_EmptySoftwareVersion.cs
+++ b/test/Renci.SshNet.Tests/Classes/Connection/ProtocolVersionExchangeTest_ServerResponseValid_EmptySoftwareVersion.cs
@@ -100,7 +100,7 @@ namespace Renci.SshNet.Tests.Classes.Connection
         {
             var expected = Encoding.UTF8.GetBytes(_clientVersion);
 
-            Assert.AreEqual(expected.Length + 2, _dataReceivedByServer.Count);
+            Assert.HasCount(expected.Length + 2, _dataReceivedByServer);
 
             Assert.IsTrue(expected.SequenceEqual(_dataReceivedByServer.Take(expected.Length)));
             Assert.AreEqual(Session.CarriageReturn, _dataReceivedByServer[_dataReceivedByServer.Count - 2]);

--- a/test/Renci.SshNet.Tests/Classes/Connection/ProtocolVersionExchangeTest_ServerResponseValid_NoComments.cs
+++ b/test/Renci.SshNet.Tests/Classes/Connection/ProtocolVersionExchangeTest_ServerResponseValid_NoComments.cs
@@ -97,7 +97,7 @@ namespace Renci.SshNet.Tests.Classes.Connection
         {
             var expected = Encoding.UTF8.GetBytes(_clientVersion);
 
-            Assert.AreEqual(expected.Length + 2, _dataReceivedByServer.Count);
+            Assert.HasCount(expected.Length + 2, _dataReceivedByServer);
 
             Assert.IsTrue(expected.SequenceEqual(_dataReceivedByServer.Take(expected.Length)));
             Assert.AreEqual(Session.CarriageReturn, _dataReceivedByServer[_dataReceivedByServer.Count - 2]);

--- a/test/Renci.SshNet.Tests/Classes/Connection/ProtocolVersionExchangeTest_ServerResponseValid_TerminatedByLineFeedWithoutCarriageReturn.cs
+++ b/test/Renci.SshNet.Tests/Classes/Connection/ProtocolVersionExchangeTest_ServerResponseValid_TerminatedByLineFeedWithoutCarriageReturn.cs
@@ -99,7 +99,7 @@ namespace Renci.SshNet.Tests.Classes.Connection
         {
             var expected = Encoding.UTF8.GetBytes(_clientVersion);
 
-            Assert.AreEqual(expected.Length + 2, _dataReceivedByServer.Count);
+            Assert.HasCount(expected.Length + 2, _dataReceivedByServer);
 
             Assert.IsTrue(expected.SequenceEqual(_dataReceivedByServer.Take(expected.Length)));
             Assert.AreEqual(Session.CarriageReturn, _dataReceivedByServer[_dataReceivedByServer.Count - 2]);

--- a/test/Renci.SshNet.Tests/Classes/Connection/ProtocolVersionExchangeTest_TimeoutReadingIdentificationString.cs
+++ b/test/Renci.SshNet.Tests/Classes/Connection/ProtocolVersionExchangeTest_TimeoutReadingIdentificationString.cs
@@ -103,7 +103,7 @@ namespace Renci.SshNet.Tests.Classes.Connection
         {
             var expected = Encoding.UTF8.GetBytes(_clientVersion);
 
-            Assert.AreEqual(expected.Length + 2, _dataReceivedByServer.Count);
+            Assert.HasCount(expected.Length + 2, _dataReceivedByServer);
 
             Assert.IsTrue(expected.SequenceEqual(_dataReceivedByServer.Take(expected.Length)));
             Assert.AreEqual(Session.CarriageReturn, _dataReceivedByServer[_dataReceivedByServer.Count - 2]);

--- a/test/Renci.SshNet.Tests/Classes/Connection/Socks4ConnectorTest_Connect_ConnectionToProxyRefused.cs
+++ b/test/Renci.SshNet.Tests/Classes/Connection/Socks4ConnectorTest_Connect_ConnectionToProxyRefused.cs
@@ -75,7 +75,7 @@ namespace Renci.SshNet.Tests.Classes.Connection
                                           _connectionInfo.Timeout.TotalMilliseconds);
 
             // Compare elapsed time with configured timeout, allowing for a margin of error
-            Assert.IsTrue(_stopWatch.ElapsedMilliseconds < _connectionInfo.Timeout.TotalMilliseconds + 100, errorText);
+            Assert.IsLessThan(_connectionInfo.Timeout.TotalMilliseconds + 100, _stopWatch.ElapsedMilliseconds, errorText);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/Connection/Socks4ConnectorTest_Connect_TimeoutConnectingToProxy.cs
+++ b/test/Renci.SshNet.Tests/Classes/Connection/Socks4ConnectorTest_Connect_TimeoutConnectingToProxy.cs
@@ -94,8 +94,8 @@ namespace Renci.SshNet.Tests.Classes.Connection
                                           _connectionInfo.Timeout.TotalMilliseconds);
 
             // Compare elapsed time with configured timeout, allowing for a margin of error
-            Assert.IsTrue(_stopWatch.ElapsedMilliseconds >= _connectionInfo.Timeout.TotalMilliseconds - 10, errorText);
-            Assert.IsTrue(_stopWatch.ElapsedMilliseconds < _connectionInfo.Timeout.TotalMilliseconds + 100, errorText);
+            Assert.IsGreaterThanOrEqualTo(_connectionInfo.Timeout.TotalMilliseconds - 10, _stopWatch.ElapsedMilliseconds, errorText);
+            Assert.IsLessThan(_connectionInfo.Timeout.TotalMilliseconds + 100, _stopWatch.ElapsedMilliseconds, errorText);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/Connection/Socks4ConnectorTest_Connect_TimeoutReadingDestinationAddress.cs
+++ b/test/Renci.SshNet.Tests/Classes/Connection/Socks4ConnectorTest_Connect_TimeoutReadingDestinationAddress.cs
@@ -109,8 +109,8 @@ namespace Renci.SshNet.Tests.Classes.Connection
                                           _connectionInfo.Timeout.TotalMilliseconds);
 
             // Compare elapsed time with configured timeout, allowing for a margin of error
-            Assert.IsTrue(_stopWatch.ElapsedMilliseconds >= _connectionInfo.Timeout.TotalMilliseconds - 10, errorText);
-            Assert.IsTrue(_stopWatch.ElapsedMilliseconds < _connectionInfo.Timeout.TotalMilliseconds + 100, errorText);
+            Assert.IsGreaterThanOrEqualTo(_connectionInfo.Timeout.TotalMilliseconds - 10, _stopWatch.ElapsedMilliseconds, errorText);
+            Assert.IsLessThan(_connectionInfo.Timeout.TotalMilliseconds + 100, _stopWatch.ElapsedMilliseconds, errorText);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/Connection/Socks4ConnectorTest_Connect_TimeoutReadingReplyCode.cs
+++ b/test/Renci.SshNet.Tests/Classes/Connection/Socks4ConnectorTest_Connect_TimeoutReadingReplyCode.cs
@@ -105,8 +105,8 @@ namespace Renci.SshNet.Tests.Classes.Connection
                                           _connectionInfo.Timeout.TotalMilliseconds);
 
             // Compare elapsed time with configured timeout, allowing for a margin of error
-            Assert.IsTrue(_stopWatch.ElapsedMilliseconds >= _connectionInfo.Timeout.TotalMilliseconds - 10, errorText);
-            Assert.IsTrue(_stopWatch.ElapsedMilliseconds < _connectionInfo.Timeout.TotalMilliseconds + 100, errorText);
+            Assert.IsGreaterThanOrEqualTo(_connectionInfo.Timeout.TotalMilliseconds - 10, _stopWatch.ElapsedMilliseconds, errorText);
+            Assert.IsLessThan(_connectionInfo.Timeout.TotalMilliseconds + 100, _stopWatch.ElapsedMilliseconds, errorText);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/Connection/Socks4ConnectorTest_Connect_TimeoutReadingReplyVersion.cs
+++ b/test/Renci.SshNet.Tests/Classes/Connection/Socks4ConnectorTest_Connect_TimeoutReadingReplyVersion.cs
@@ -97,8 +97,8 @@ namespace Renci.SshNet.Tests.Classes.Connection
                                           _connectionInfo.Timeout.TotalMilliseconds);
 
             // Compare elapsed time with configured timeout, allowing for a margin of error
-            Assert.IsTrue(_stopWatch.ElapsedMilliseconds >= _connectionInfo.Timeout.TotalMilliseconds - 10, errorText);
-            Assert.IsTrue(_stopWatch.ElapsedMilliseconds < _connectionInfo.Timeout.TotalMilliseconds + 100, errorText);
+            Assert.IsGreaterThanOrEqualTo(_connectionInfo.Timeout.TotalMilliseconds - 10, _stopWatch.ElapsedMilliseconds, errorText);
+            Assert.IsLessThan(_connectionInfo.Timeout.TotalMilliseconds + 100, _stopWatch.ElapsedMilliseconds, errorText);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/Connection/Socks5ConnectorTest_Connect_ConnectionToProxyRefused.cs
+++ b/test/Renci.SshNet.Tests/Classes/Connection/Socks5ConnectorTest_Connect_ConnectionToProxyRefused.cs
@@ -75,7 +75,7 @@ namespace Renci.SshNet.Tests.Classes.Connection
                                           _connectionInfo.Timeout.TotalMilliseconds);
 
             // Compare elapsed time with configured timeout, allowing for a margin of error
-            Assert.IsTrue(_stopWatch.ElapsedMilliseconds < _connectionInfo.Timeout.TotalMilliseconds + 100, errorText);
+            Assert.IsLessThan(_connectionInfo.Timeout.TotalMilliseconds + 100, _stopWatch.ElapsedMilliseconds, errorText);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/Connection/Socks5ConnectorTest_Connect_TimeoutConnectingToProxy.cs
+++ b/test/Renci.SshNet.Tests/Classes/Connection/Socks5ConnectorTest_Connect_TimeoutConnectingToProxy.cs
@@ -95,8 +95,8 @@ namespace Renci.SshNet.Tests.Classes.Connection
                                           _connectionInfo.Timeout.TotalMilliseconds);
 
             // Compare elapsed time with configured timeout, allowing for a margin of error
-            Assert.IsTrue(_stopWatch.ElapsedMilliseconds >= _connectionInfo.Timeout.TotalMilliseconds - 10, errorText);
-            Assert.IsTrue(_stopWatch.ElapsedMilliseconds < _connectionInfo.Timeout.TotalMilliseconds + 100, errorText);
+            Assert.IsGreaterThanOrEqualTo(_connectionInfo.Timeout.TotalMilliseconds - 10, _stopWatch.ElapsedMilliseconds, errorText);
+            Assert.IsLessThan(_connectionInfo.Timeout.TotalMilliseconds + 100, _stopWatch.ElapsedMilliseconds, errorText);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/Connection/Socks5ConnectorTest_Connect_TimeoutConnectionReply.cs
+++ b/test/Renci.SshNet.Tests/Classes/Connection/Socks5ConnectorTest_Connect_TimeoutConnectionReply.cs
@@ -107,8 +107,8 @@ namespace Renci.SshNet.Tests.Classes.Connection
                                           _connectionInfo.Timeout.TotalMilliseconds);
 
             // Compare elapsed time with configured timeout, allowing for a margin of error
-            Assert.IsTrue(_stopWatch.ElapsedMilliseconds >= _connectionInfo.Timeout.TotalMilliseconds - 10, errorText);
-            Assert.IsTrue(_stopWatch.ElapsedMilliseconds < _connectionInfo.Timeout.TotalMilliseconds + 100, errorText);
+            Assert.IsGreaterThanOrEqualTo(_connectionInfo.Timeout.TotalMilliseconds - 10, _stopWatch.ElapsedMilliseconds, errorText);
+            Assert.IsLessThan(_connectionInfo.Timeout.TotalMilliseconds + 100, _stopWatch.ElapsedMilliseconds, errorText);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Dispose_PortDisposed.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Dispose_PortDisposed.cs
@@ -50,13 +50,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Dispose_PortNeverStarted.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Dispose_PortNeverStarted.cs
@@ -89,13 +89,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Dispose_PortStarted_ChannelBound.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Dispose_PortStarted_ChannelBound.cs
@@ -189,13 +189,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _closingRegister.Count);
+            Assert.HasCount(1, _closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count, _exceptionRegister.AsString());
+            Assert.IsEmpty(_exceptionRegister, _exceptionRegister.AsString());
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Dispose_PortStarted_ChannelNotBound.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Dispose_PortStarted_ChannelNotBound.cs
@@ -131,13 +131,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _closingRegister.Count);
+            Assert.HasCount(1, _closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Dispose_PortStopped.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Dispose_PortStopped.cs
@@ -93,13 +93,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_SessionErrorOccurred_ChannelBound.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_SessionErrorOccurred_ChannelBound.cs
@@ -194,13 +194,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _closingRegister.Count);
+            Assert.HasCount(1, _closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldHaveFiredOne()
         {
-            Assert.AreEqual(1, _exceptionRegister.Count, _exceptionRegister.AsString());
+            Assert.HasCount(1, _exceptionRegister, _exceptionRegister.AsString());
             Assert.IsNotNull(_exceptionRegister[0], _exceptionRegister.AsString());
             Assert.AreSame(_sessionException, _exceptionRegister[0].Exception, _exceptionRegister.AsString());
         }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Start_PortDisposed.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Start_PortDisposed.cs
@@ -66,13 +66,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Start_PortNeverStarted.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Start_PortNeverStarted.cs
@@ -86,13 +86,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Start_PortStarted.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Start_PortStarted.cs
@@ -103,13 +103,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Start_PortStopped.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Start_PortStopped.cs
@@ -90,13 +90,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Start_SessionNotConnected.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Start_SessionNotConnected.cs
@@ -105,13 +105,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Start_SessionNull.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Start_SessionNull.cs
@@ -91,13 +91,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Started_SocketSendShutdownImmediately.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Started_SocketSendShutdownImmediately.cs
@@ -149,13 +149,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNeverBeFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count, _exceptionRegister.AsString());
+            Assert.IsEmpty(_exceptionRegister, _exceptionRegister.AsString());
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Started_SocketVersionNotSupported.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Started_SocketVersionNotSupported.cs
@@ -136,13 +136,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _exceptionRegister.Count, _exceptionRegister.AsString());
+            Assert.HasCount(1, _exceptionRegister, _exceptionRegister.AsString());
 
             var exception = _exceptionRegister[0].Exception;
             Assert.IsNotNull(exception);

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Stop_PortDisposed.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Stop_PortDisposed.cs
@@ -76,13 +76,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Stop_PortNeverStarted.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Stop_PortNeverStarted.cs
@@ -75,13 +75,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Stop_PortStarted_ChannelBound.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Stop_PortStarted_ChannelBound.cs
@@ -191,13 +191,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _closingRegister.Count);
+            Assert.HasCount(1, _closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Stop_PortStarted_ChannelNotBound.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Stop_PortStarted_ChannelNotBound.cs
@@ -135,13 +135,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _closingRegister.Count);
+            Assert.HasCount(1, _closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Stop_PortStopped.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Stop_PortStopped.cs
@@ -93,13 +93,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Dispose_PortDisposed.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Dispose_PortDisposed.cs
@@ -67,13 +67,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _closingRegister.Count);
+            Assert.HasCount(1, _closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Dispose_PortDisposed_NeverStarted.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Dispose_PortDisposed_NeverStarted.cs
@@ -50,13 +50,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Dispose_PortNeverStarted.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Dispose_PortNeverStarted.cs
@@ -95,13 +95,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Dispose_PortStarted_ChannelBound.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Dispose_PortStarted_ChannelBound.cs
@@ -169,13 +169,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _closingRegister.Count);
+            Assert.HasCount(1, _closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Dispose_PortStarted_ChannelNotBound.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Dispose_PortStarted_ChannelNotBound.cs
@@ -100,13 +100,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _closingRegister.Count);
+            Assert.HasCount(1, _closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Dispose_PortStopped.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Dispose_PortStopped.cs
@@ -98,13 +98,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Start_PortDisposed.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Start_PortDisposed.cs
@@ -74,13 +74,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Start_PortNeverStarted.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Start_PortNeverStarted.cs
@@ -109,13 +109,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Start_PortStarted.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Start_PortStarted.cs
@@ -125,13 +125,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Start_PortStopped.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Start_PortStopped.cs
@@ -114,13 +114,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Start_SessionNotConnected.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Start_SessionNotConnected.cs
@@ -110,13 +110,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Start_SessionNull.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Start_SessionNull.cs
@@ -109,13 +109,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Stop_PortDisposed.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Stop_PortDisposed.cs
@@ -56,13 +56,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Stop_PortNeverStarted.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Stop_PortNeverStarted.cs
@@ -92,13 +92,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Stop_PortStarted_ChannelBound.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Stop_PortStarted_ChannelBound.cs
@@ -184,13 +184,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _closingRegister.Count);
+            Assert.HasCount(1, _closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Stop_PortStarted_ChannelNotBound.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Stop_PortStarted_ChannelNotBound.cs
@@ -100,13 +100,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _closingRegister.Count);
+            Assert.HasCount(1, _closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Stop_PortStopped.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortLocalTest_Stop_PortStopped.cs
@@ -99,13 +99,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Dispose_PortDisposed.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Dispose_PortDisposed.cs
@@ -62,13 +62,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Dispose_PortNeverStarted.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Dispose_PortNeverStarted.cs
@@ -103,13 +103,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Dispose_PortStarted_ChannelBound.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Dispose_PortStarted_ChannelBound.cs
@@ -223,13 +223,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _closingRegister.Count);
+            Assert.HasCount(1, _closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Dispose_PortStopped.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Dispose_PortStopped.cs
@@ -133,13 +133,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldHaveFiredOnce()
         {
-            Assert.AreEqual(1, _closingRegister.Count);
+            Assert.HasCount(1, _closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Start_PortDisposed.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Start_PortDisposed.cs
@@ -72,13 +72,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Start_PortNeverStarted.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Start_PortNeverStarted.cs
@@ -137,13 +137,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Start_PortStarted.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Start_PortStarted.cs
@@ -156,13 +156,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Start_PortStopped.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Start_PortStopped.cs
@@ -155,13 +155,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Start_SessionNotConnected.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Start_SessionNotConnected.cs
@@ -120,13 +120,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Start_SessionNull.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Start_SessionNull.cs
@@ -77,13 +77,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Started.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Started.cs
@@ -127,8 +127,8 @@ namespace Renci.SshNet.Tests.Classes
             channelMock.Verify(p => p.Bind(It.Is<IPEndPoint>(ep => ep.Address.Equals(_remoteEndpoint.Address) && ep.Port == _remoteEndpoint.Port), _forwardedPort), Times.Once);
             channelMock.Verify(p => p.Dispose(), Times.Once);
 
-            Assert.AreEqual(0, _closingRegister.Count);
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_closingRegister);
+            Assert.IsEmpty(_exceptionRegister);
         }
 
         [TestMethod]
@@ -153,8 +153,8 @@ namespace Renci.SshNet.Tests.Classes
 
             _sessionMock.Verify(p => p.CreateChannelForwardedTcpip(channelNumber, initialWindowSize, maximumPacketSize), Times.Never);
 
-            Assert.AreEqual(0, _closingRegister.Count);
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_closingRegister);
+            Assert.IsEmpty(_exceptionRegister);
         }
 
         [TestMethod]
@@ -179,8 +179,8 @@ namespace Renci.SshNet.Tests.Classes
 
             _sessionMock.Verify(p => p.CreateChannelForwardedTcpip(channelNumber, initialWindowSize, maximumPacketSize), Times.Never);
 
-            Assert.AreEqual(0, _closingRegister.Count);
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_closingRegister);
+            Assert.IsEmpty(_exceptionRegister);
         }
 
         [TestMethod]
@@ -201,8 +201,8 @@ namespace Renci.SshNet.Tests.Classes
 
             _sessionMock.Verify(p => p.CreateChannelForwardedTcpip(channelNumber, initialWindowSize, maximumPacketSize), Times.Never);
 
-            Assert.AreEqual(0, _closingRegister.Count);
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_closingRegister);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Stop_PortDisposed.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Stop_PortDisposed.cs
@@ -62,13 +62,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Stop_PortNeverStarted.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortRemoteTest_Stop_PortNeverStarted.cs
@@ -127,13 +127,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ClosingShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _closingRegister.Count);
+            Assert.IsEmpty(_closingRegister);
         }
 
         [TestMethod]
         public void ExceptionShouldNotHaveFired()
         {
-            Assert.AreEqual(0, _exceptionRegister.Count);
+            Assert.IsEmpty(_exceptionRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/Messages/Connection/ChannelDataMessageTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Messages/Connection/ChannelDataMessageTest.cs
@@ -114,7 +114,7 @@ namespace Renci.SshNet.Tests.Classes.Messages.Connection
             expectedBytesLength += 4; // Data length
             expectedBytesLength += size; // Data
 
-            Assert.AreEqual(expectedBytesLength, bytes.Length);
+            Assert.HasCount(expectedBytesLength, bytes);
 
             var sshDataStream = new SshDataStream(bytes);
 

--- a/test/Renci.SshNet.Tests/Classes/Messages/Connection/ChannelOpen/ChannelOpenMessageTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Messages/Connection/ChannelOpen/ChannelOpenMessageTest.cs
@@ -92,7 +92,7 @@ namespace Renci.SshNet.Tests.Classes.Messages.Connection
             expectedBytesLength += 4; // MaximumPacketSize
             expectedBytesLength += infoBytes.Length; // Info
 
-            Assert.AreEqual(expectedBytesLength, bytes.Length);
+            Assert.HasCount(expectedBytesLength, bytes);
 
             var sshDataStream = new SshDataStream(bytes);
 

--- a/test/Renci.SshNet.Tests/Classes/Messages/Connection/ChannelRequest/PseudoTerminalInfoTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Messages/Connection/ChannelRequest/PseudoTerminalInfoTest.cs
@@ -59,7 +59,7 @@ namespace Renci.SshNet.Tests.Classes.Messages.Connection
             expectedBytesLength += 4; // Length of "encoded terminal modes"
             expectedBytesLength += (_terminalModeValues.Count * (1 + 4)) + 1; // encoded terminal modes
 
-            Assert.AreEqual(expectedBytesLength, bytes.Length);
+            Assert.HasCount(expectedBytesLength, bytes);
 
             var sshDataStream = new SshDataStream(bytes);
 
@@ -95,7 +95,7 @@ namespace Renci.SshNet.Tests.Classes.Messages.Connection
             expectedBytesLength += 4; // PixelHeight
             expectedBytesLength += 4; // Length of "encoded terminal modes"
 
-            Assert.AreEqual(expectedBytesLength, bytes.Length);
+            Assert.HasCount(expectedBytesLength, bytes);
 
             var sshDataStream = new SshDataStream(bytes);
 
@@ -131,7 +131,7 @@ namespace Renci.SshNet.Tests.Classes.Messages.Connection
             expectedBytesLength += 4; // PixelHeight
             expectedBytesLength += 4; // Length of "encoded terminal modes"
 
-            Assert.AreEqual(expectedBytesLength, bytes.Length);
+            Assert.HasCount(expectedBytesLength, bytes);
 
             var sshDataStream = new SshDataStream(bytes);
 

--- a/test/Renci.SshNet.Tests/Classes/Messages/Transport/IgnoreMessageTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Messages/Transport/IgnoreMessageTest.cs
@@ -27,7 +27,7 @@ namespace Renci.SshNet.Tests.Classes.Messages.Transport
         {
             var target = new IgnoreMessage();
             Assert.IsNotNull(target.Data);
-            Assert.AreEqual(0, target.Data.Length);
+            Assert.IsEmpty(target.Data);
         }
 
         [TestMethod]
@@ -66,7 +66,7 @@ namespace Renci.SshNet.Tests.Classes.Messages.Transport
             expectedBytesLength += 4; // Data length
             expectedBytesLength += _data.Length; // Data
 
-            Assert.AreEqual(expectedBytesLength, bytes.Length);
+            Assert.HasCount(expectedBytesLength, bytes);
 
             var sshDataStream = new SshDataStream(bytes);
 
@@ -90,7 +90,7 @@ namespace Renci.SshNet.Tests.Classes.Messages.Transport
             target.Load(bytes, 1, bytes.Length - 1);
 
             Assert.IsNotNull(target.Data);
-            Assert.AreEqual(0, target.Data.Length);
+            Assert.IsEmpty(target.Data);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/Messages/Transport/KeyExchangeDhGroupExchangeRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Messages/Transport/KeyExchangeDhGroupExchangeRequestTest.cs
@@ -42,7 +42,7 @@ namespace Renci.SshNet.Tests.Classes.Messages.Transport
             expectedBytesLength += 4; // Preferred
             expectedBytesLength += 4; // Maximum
 
-            Assert.AreEqual(expectedBytesLength, bytes.Length);
+            Assert.HasCount(expectedBytesLength, bytes);
 
             var sshDataStream = new SshDataStream(bytes);
 

--- a/test/Renci.SshNet.Tests/Classes/OrderedDictionaryTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/OrderedDictionaryTest.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable MSTEST0037 // Use proper 'Assert' methods
+﻿#pragma warning disable MSTEST0037 // Use proper 'Assert' methods: some tests are for specific interface implementations.
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/test/Renci.SshNet.Tests/Classes/OrderedDictionaryTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/OrderedDictionaryTest.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#pragma warning disable MSTEST0037 // Use proper 'Assert' methods
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -28,11 +29,11 @@ namespace Renci.SshNet.Tests.Classes
                 Assert.AreEqual(expected[i].Value, value);
                 Assert.AreEqual(i, index);
 
-                Assert.Contains(expected[i], o);
+                Assert.IsTrue(((ICollection<KeyValuePair<TKey, TValue>>)o).Contains(expected[i]));
                 Assert.IsTrue(o.ContainsKey(expected[i].Key));
                 Assert.IsTrue(o.ContainsValue(expected[i].Value));
-                Assert.Contains(expected[i].Key, o.Keys);
-                Assert.Contains(expected[i].Value, o.Values);
+                Assert.IsTrue(o.Keys.Contains(expected[i].Key));
+                Assert.IsTrue(o.Values.Contains(expected[i].Value));
 
                 Assert.AreEqual(i, o.IndexOf(expected[i].Key));
 
@@ -41,11 +42,11 @@ namespace Renci.SshNet.Tests.Classes
                 Assert.AreEqual(i, index);
             }
 
-            Assert.HasCount(expected.Count, o.Keys);
+            Assert.AreEqual(expected.Count, o.Keys.Count);
             CollectionAssert.AreEqual(expected.Select(kvp => kvp.Key).ToList(), ToList(o.Keys));
             CollectionAssert.AreEqual(ToList(o.Keys), ToList(((IReadOnlyDictionary<TKey, TValue>)o).Keys));
 
-            Assert.HasCount(expected.Count, o.Values);
+            Assert.AreEqual(expected.Count, o.Values.Count);
             CollectionAssert.AreEqual(expected.Select(kvp => kvp.Value).ToList(), ToList(o.Values));
             CollectionAssert.AreEqual(ToList(o.Values), ToList(((IReadOnlyDictionary<TKey, TValue>)o).Values));
 
@@ -185,8 +186,8 @@ namespace Renci.SshNet.Tests.Classes
         {
             OrderedDictionary<string, int> o = new() { { "a", 4 } };
 
-            Assert.DoesNotContain(new KeyValuePair<string, int>("a", 8), o);
-            Assert.Contains(new KeyValuePair<string, int>("a", 4), o);
+            Assert.IsFalse(((ICollection<KeyValuePair<string, int>>)o).Contains(new KeyValuePair<string, int>("a", 8)));
+            Assert.IsTrue(((ICollection<KeyValuePair<string, int>>)o).Contains(new KeyValuePair<string, int>("a", 4)));
         }
 
         [TestMethod]
@@ -288,7 +289,7 @@ namespace Renci.SshNet.Tests.Classes
             OrderedDictionary<string, float> o = new() { { "a", 4 } };
 
             Assert.ThrowsExactly<KeyNotFoundException>(() => o["doesn't exist"]);
-            Assert.DoesNotContain(new KeyValuePair<string, float>("doesn't exist", 1), o);
+            Assert.IsFalse(((ICollection<KeyValuePair<string, float>>)o).Contains(new KeyValuePair<string, float>("doesn't exist", 1)));
             Assert.IsFalse(o.ContainsKey("doesn't exist"));
             Assert.IsFalse(o.ContainsValue(999));
             Assert.AreEqual(-1, o.IndexOf("doesn't exist"));

--- a/test/Renci.SshNet.Tests/Classes/OrderedDictionaryTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/OrderedDictionaryTest.cs
@@ -28,11 +28,11 @@ namespace Renci.SshNet.Tests.Classes
                 Assert.AreEqual(expected[i].Value, value);
                 Assert.AreEqual(i, index);
 
-                Assert.IsTrue(((ICollection<KeyValuePair<TKey, TValue>>)o).Contains(expected[i]));
+                Assert.Contains(expected[i], o);
                 Assert.IsTrue(o.ContainsKey(expected[i].Key));
                 Assert.IsTrue(o.ContainsValue(expected[i].Value));
-                Assert.IsTrue(o.Keys.Contains(expected[i].Key));
-                Assert.IsTrue(o.Values.Contains(expected[i].Value));
+                Assert.Contains(expected[i].Key, o.Keys);
+                Assert.Contains(expected[i].Value, o.Values);
 
                 Assert.AreEqual(i, o.IndexOf(expected[i].Key));
 
@@ -41,11 +41,11 @@ namespace Renci.SshNet.Tests.Classes
                 Assert.AreEqual(i, index);
             }
 
-            Assert.AreEqual(expected.Count, o.Keys.Count);
+            Assert.HasCount(expected.Count, o.Keys);
             CollectionAssert.AreEqual(expected.Select(kvp => kvp.Key).ToList(), ToList(o.Keys));
             CollectionAssert.AreEqual(ToList(o.Keys), ToList(((IReadOnlyDictionary<TKey, TValue>)o).Keys));
 
-            Assert.AreEqual(expected.Count, o.Values.Count);
+            Assert.HasCount(expected.Count, o.Values);
             CollectionAssert.AreEqual(expected.Select(kvp => kvp.Value).ToList(), ToList(o.Values));
             CollectionAssert.AreEqual(ToList(o.Values), ToList(((IReadOnlyDictionary<TKey, TValue>)o).Values));
 
@@ -185,8 +185,8 @@ namespace Renci.SshNet.Tests.Classes
         {
             OrderedDictionary<string, int> o = new() { { "a", 4 } };
 
-            Assert.IsFalse(((ICollection<KeyValuePair<string, int>>)o).Contains(new KeyValuePair<string, int>("a", 8)));
-            Assert.IsTrue(((ICollection<KeyValuePair<string, int>>)o).Contains(new KeyValuePair<string, int>("a", 4)));
+            Assert.DoesNotContain(new KeyValuePair<string, int>("a", 8), o);
+            Assert.Contains(new KeyValuePair<string, int>("a", 4), o);
         }
 
         [TestMethod]
@@ -288,7 +288,7 @@ namespace Renci.SshNet.Tests.Classes
             OrderedDictionary<string, float> o = new() { { "a", 4 } };
 
             Assert.ThrowsExactly<KeyNotFoundException>(() => o["doesn't exist"]);
-            Assert.IsFalse(((ICollection<KeyValuePair<string, float>>)o).Contains(new KeyValuePair<string, float>("doesn't exist", 1)));
+            Assert.DoesNotContain(new KeyValuePair<string, float>("doesn't exist", 1), o);
             Assert.IsFalse(o.ContainsKey("doesn't exist"));
             Assert.IsFalse(o.ContainsValue(999));
             Assert.AreEqual(-1, o.IndexOf("doesn't exist"));

--- a/test/Renci.SshNet.Tests/Classes/PrivateKeyFileTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/PrivateKeyFileTest.cs
@@ -401,7 +401,7 @@ namespace Renci.SshNet.Tests.Classes
             Assert.AreEqual(Certificate.CertificateType.User, cert.Type);
             Assert.AreEqual("rsa-cert-rsa", cert.KeyId);
             CollectionAssert.AreEqual(new string[] { "sshnet" }, cert.ValidPrincipals.ToList());
-            Assert.AreEqual(0, cert.CriticalOptions.Count);
+            Assert.IsEmpty(cert.CriticalOptions);
             Assert.IsTrue(cert.ValidAfter.EqualsExact(new DateTimeOffset(2024, 07, 17, 20, 50, 34, TimeSpan.Zero)));
             Assert.AreEqual(ulong.MaxValue, cert.ValidBeforeUnixSeconds);
             Assert.AreEqual(DateTimeOffset.MaxValue, cert.ValidBefore);
@@ -415,7 +415,7 @@ namespace Renci.SshNet.Tests.Classes
             }, new Dictionary<string, string>(cert.Extensions));
             Assert.AreEqual("NqLEgdYti0XjUkYjGyQv2Ddy1O5v2NZDZFRtlfESLIA", cert.CertificateAuthorityKeyFingerPrint);
 
-            Assert.AreEqual(6, pkFile.HostKeyAlgorithms.Count);
+            Assert.HasCount(6, pkFile.HostKeyAlgorithms);
 
             var algorithms = pkFile.HostKeyAlgorithms.ToList();
 
@@ -460,7 +460,7 @@ namespace Renci.SshNet.Tests.Classes
             Assert.AreEqual(Certificate.CertificateType.User, cert.Type);
             Assert.AreEqual("ecdsa521certEcdsa", cert.KeyId);
             CollectionAssert.AreEqual(new string[] { "sshnet" }, cert.ValidPrincipals.ToList());
-            Assert.AreEqual(0, cert.CriticalOptions.Count);
+            Assert.IsEmpty(cert.CriticalOptions);
             Assert.AreEqual(0UL, cert.ValidAfterUnixSeconds);
             Assert.IsTrue(cert.ValidAfter.EqualsExact(UnixEpoch));
             Assert.AreEqual(ulong.MaxValue, cert.ValidBeforeUnixSeconds);
@@ -475,7 +475,7 @@ namespace Renci.SshNet.Tests.Classes
             }, new Dictionary<string, string>(cert.Extensions));
             Assert.AreEqual("r/t6I+bZQzN5BhSuntFSHDHlrnNHVM2lAo6gbvynG/4", cert.CertificateAuthorityKeyFingerPrint);
 
-            Assert.AreEqual(2, pkFile.HostKeyAlgorithms.Count);
+            Assert.HasCount(2, pkFile.HostKeyAlgorithms);
 
             var algorithms = pkFile.HostKeyAlgorithms.ToList();
 
@@ -635,7 +635,7 @@ namespace Renci.SshNet.Tests.Classes
         {
             Assert.IsInstanceOfType<RsaKey>(rsaPrivateKeyFile.Key);
             Assert.IsNotNull(rsaPrivateKeyFile.HostKeyAlgorithms);
-            Assert.AreEqual(3, rsaPrivateKeyFile.HostKeyAlgorithms.Count);
+            Assert.HasCount(3, rsaPrivateKeyFile.HostKeyAlgorithms);
 
             var algorithms = rsaPrivateKeyFile.HostKeyAlgorithms.ToList();
 

--- a/test/Renci.SshNet.Tests/Classes/ScpClientTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/ScpClientTest.cs
@@ -77,7 +77,7 @@ namespace Renci.SshNet.Tests.Classes
             Assert.AreEqual(port, passwordConnectionInfo.Port);
             Assert.AreSame(userName, passwordConnectionInfo.Username);
             Assert.IsNotNull(passwordConnectionInfo.AuthenticationMethods);
-            Assert.AreEqual(1, passwordConnectionInfo.AuthenticationMethods.Count);
+            Assert.HasCount(1, passwordConnectionInfo.AuthenticationMethods);
 
             var passwordAuthentication = passwordConnectionInfo.AuthenticationMethods[0] as PasswordAuthenticationMethod;
             Assert.IsNotNull(passwordAuthentication);
@@ -107,7 +107,7 @@ namespace Renci.SshNet.Tests.Classes
             Assert.AreEqual(22, passwordConnectionInfo.Port);
             Assert.AreSame(userName, passwordConnectionInfo.Username);
             Assert.IsNotNull(passwordConnectionInfo.AuthenticationMethods);
-            Assert.AreEqual(1, passwordConnectionInfo.AuthenticationMethods.Count);
+            Assert.HasCount(1, passwordConnectionInfo.AuthenticationMethods);
 
             var passwordAuthentication = passwordConnectionInfo.AuthenticationMethods[0] as PasswordAuthenticationMethod;
             Assert.IsNotNull(passwordAuthentication);
@@ -138,15 +138,15 @@ namespace Renci.SshNet.Tests.Classes
             Assert.AreEqual(port, privateKeyConnectionInfo.Port);
             Assert.AreSame(userName, privateKeyConnectionInfo.Username);
             Assert.IsNotNull(privateKeyConnectionInfo.AuthenticationMethods);
-            Assert.AreEqual(1, privateKeyConnectionInfo.AuthenticationMethods.Count);
+            Assert.HasCount(1, privateKeyConnectionInfo.AuthenticationMethods);
 
             var privateKeyAuthentication = privateKeyConnectionInfo.AuthenticationMethods[0] as PrivateKeyAuthenticationMethod;
             Assert.IsNotNull(privateKeyAuthentication);
             Assert.AreEqual(userName, privateKeyAuthentication.Username);
             Assert.IsNotNull(privateKeyAuthentication.KeyFiles);
-            Assert.AreEqual(privateKeys.Length, privateKeyAuthentication.KeyFiles.Count);
-            Assert.IsTrue(privateKeyAuthentication.KeyFiles.Contains(privateKeys[0]));
-            Assert.IsTrue(privateKeyAuthentication.KeyFiles.Contains(privateKeys[1]));
+            Assert.HasCount(privateKeys.Length, privateKeyAuthentication.KeyFiles);
+            Assert.Contains(privateKeys[0], privateKeyAuthentication.KeyFiles);
+            Assert.Contains(privateKeys[1], privateKeyAuthentication.KeyFiles);
         }
 
         [TestMethod]
@@ -171,15 +171,15 @@ namespace Renci.SshNet.Tests.Classes
             Assert.AreEqual(22, privateKeyConnectionInfo.Port);
             Assert.AreSame(userName, privateKeyConnectionInfo.Username);
             Assert.IsNotNull(privateKeyConnectionInfo.AuthenticationMethods);
-            Assert.AreEqual(1, privateKeyConnectionInfo.AuthenticationMethods.Count);
+            Assert.HasCount(1, privateKeyConnectionInfo.AuthenticationMethods);
 
             var privateKeyAuthentication = privateKeyConnectionInfo.AuthenticationMethods[0] as PrivateKeyAuthenticationMethod;
             Assert.IsNotNull(privateKeyAuthentication);
             Assert.AreEqual(userName, privateKeyAuthentication.Username);
             Assert.IsNotNull(privateKeyAuthentication.KeyFiles);
-            Assert.AreEqual(privateKeys.Length, privateKeyAuthentication.KeyFiles.Count);
-            Assert.IsTrue(privateKeyAuthentication.KeyFiles.Contains(privateKeys[0]));
-            Assert.IsTrue(privateKeyAuthentication.KeyFiles.Contains(privateKeys[1]));
+            Assert.HasCount(privateKeys.Length, privateKeyAuthentication.KeyFiles);
+            Assert.Contains(privateKeys[0], privateKeyAuthentication.KeyFiles);
+            Assert.Contains(privateKeys[1], privateKeyAuthentication.KeyFiles);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/ScpClientTest_Download_PathAndDirectoryInfo_SendExecRequestReturnsFalse.cs
+++ b/test/Renci.SshNet.Tests/Classes/ScpClientTest_Download_PathAndDirectoryInfo_SendExecRequestReturnsFalse.cs
@@ -111,7 +111,7 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void UploadingShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _uploadingRegister.Count);
+            Assert.IsEmpty(_uploadingRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ScpClientTest_Download_PathAndFileInfo_SendExecRequestReturnsFalse.cs
+++ b/test/Renci.SshNet.Tests/Classes/ScpClientTest_Download_PathAndFileInfo_SendExecRequestReturnsFalse.cs
@@ -110,7 +110,7 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void UploadingShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _uploadingRegister.Count);
+            Assert.IsEmpty(_uploadingRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ScpClientTest_Download_PathAndStream_SendExecRequestReturnsFalse.cs
+++ b/test/Renci.SshNet.Tests/Classes/ScpClientTest_Download_PathAndStream_SendExecRequestReturnsFalse.cs
@@ -126,7 +126,7 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void UploadingShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _uploadingRegister.Count);
+            Assert.IsEmpty(_uploadingRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ScpClientTest_Upload_DirectoryInfoAndPath_SendExecRequestReturnsFalse.cs
+++ b/test/Renci.SshNet.Tests/Classes/ScpClientTest_Upload_DirectoryInfoAndPath_SendExecRequestReturnsFalse.cs
@@ -110,7 +110,7 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void UploadingShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _uploadingRegister.Count);
+            Assert.IsEmpty(_uploadingRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/ScpClientTest_Upload_FileInfoAndPath_SendExecRequestReturnsFalse.cs
+++ b/test/Renci.SshNet.Tests/Classes/ScpClientTest_Upload_FileInfoAndPath_SendExecRequestReturnsFalse.cs
@@ -127,7 +127,7 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void UploadingShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _uploadingRegister.Count);
+            Assert.IsEmpty(_uploadingRegister);
         }
 
         private string CreateTemporaryFile(byte[] content)

--- a/test/Renci.SshNet.Tests/Classes/ScpClientTest_Upload_FileInfoAndPath_Success.cs
+++ b/test/Renci.SshNet.Tests/Classes/ScpClientTest_Upload_FileInfoAndPath_Success.cs
@@ -151,7 +151,7 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void UploadingShouldHaveFiredTwice()
         {
-            Assert.AreEqual(2, _uploadingRegister.Count);
+            Assert.HasCount(2, _uploadingRegister);
 
             var uploading = _uploadingRegister[0];
             Assert.IsNotNull(uploading);

--- a/test/Renci.SshNet.Tests/Classes/ScpClientTest_Upload_StreamAndPath_SendExecRequestReturnsFalse.cs
+++ b/test/Renci.SshNet.Tests/Classes/ScpClientTest_Upload_StreamAndPath_SendExecRequestReturnsFalse.cs
@@ -129,7 +129,7 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void UploadingShouldNeverHaveFired()
         {
-            Assert.AreEqual(0, _uploadingRegister.Count);
+            Assert.IsEmpty(_uploadingRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/Security/CertificateHostAlgorithmTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Security/CertificateHostAlgorithmTest.cs
@@ -69,7 +69,7 @@ namespace Renci.SshNet.Tests.Classes.Security
 
             List<CertificateHostAlgorithm> certAlgs = pkFile.HostKeyAlgorithms.OfType<CertificateHostAlgorithm>().ToList();
 
-            Assert.AreEqual(3, certAlgs.Count);
+            Assert.HasCount(3, certAlgs);
 
             for (int i = 0; i < 3; i++)
             {

--- a/test/Renci.SshNet.Tests/Classes/Security/Cryptography/BlockCipherTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Security/Cryptography/BlockCipherTest.cs
@@ -25,7 +25,7 @@ namespace Renci.SshNet.Tests.Classes.Security.Cryptography
             {
                 EncryptBlockDelegate = (inputBuffer, inputOffset, inputCount, outputBuffer, outputOffset) =>
                     {
-                        Assert.AreEqual(8, inputBuffer.Length);
+                        Assert.HasCount(8, inputBuffer);
                         Buffer.BlockCopy(output, 0, outputBuffer, 0, output.Length);
                         return inputBuffer.Length;
                     }
@@ -46,7 +46,7 @@ namespace Renci.SshNet.Tests.Classes.Security.Cryptography
             {
                 EncryptBlockDelegate = (inputBuffer, inputOffset, inputCount, outputBuffer, outputOffset) =>
                 {
-                    Assert.AreEqual(8, inputBuffer.Length);
+                    Assert.HasCount(8, inputBuffer);
                     Buffer.BlockCopy(output, 0, outputBuffer, 0, output.Length);
                     return inputBuffer.Length;
                 }
@@ -67,7 +67,7 @@ namespace Renci.SshNet.Tests.Classes.Security.Cryptography
             {
                 EncryptBlockDelegate = (inputBuffer, inputOffset, inputCount, outputBuffer, outputOffset) =>
                 {
-                    Assert.AreEqual(8, inputBuffer.Length);
+                    Assert.HasCount(8, inputBuffer);
                     Buffer.BlockCopy(output, 0, outputBuffer, 0, output.Length);
                     return inputBuffer.Length;
                 }
@@ -89,7 +89,7 @@ namespace Renci.SshNet.Tests.Classes.Security.Cryptography
             {
                 DecryptBlockDelegate = (inputBuffer, inputOffset, inputCount, outputBuffer, outputOffset) =>
                     {
-                        Assert.AreEqual(8, outputBuffer.Length);
+                        Assert.HasCount(8, outputBuffer);
                         Buffer.BlockCopy(output, 0, outputBuffer, 0, output.Length);
                         Buffer.BlockCopy(padding, 0, outputBuffer, output.Length, padding.Length);
                         return inputBuffer.Length;
@@ -111,7 +111,7 @@ namespace Renci.SshNet.Tests.Classes.Security.Cryptography
             {
                 DecryptBlockDelegate = (inputBuffer, inputOffset, inputCount, outputBuffer, outputOffset) =>
                 {
-                    Assert.AreEqual(8, inputBuffer.Length);
+                    Assert.HasCount(8, inputBuffer);
                     Buffer.BlockCopy(output, 0, outputBuffer, 0, output.Length);
                     return inputBuffer.Length;
                 }

--- a/test/Renci.SshNet.Tests/Classes/SessionTest_Connected.cs
+++ b/test/Renci.SshNet.Tests/Classes/SessionTest_Connected.cs
@@ -45,7 +45,7 @@ namespace Renci.SshNet.Tests.Classes
         public void IncludeStrictKexPseudoAlgorithmInInitKex()
         {
             Assert.IsTrue(FirstKexReceived.Wait(1000));
-            Assert.IsTrue(ServerBytesReceivedRegister.Count > 0);
+            Assert.IsNotEmpty(ServerBytesReceivedRegister);
 
             var kexInitMessage = new KeyExchangeInitMessage();
             kexInitMessage.Load(ServerBytesReceivedRegister[0], 4 + 1 + 1, ServerBytesReceivedRegister[0].Length - 4 - 1 - 1);
@@ -106,7 +106,7 @@ namespace Renci.SshNet.Tests.Classes
             // give session time to process message
             Thread.Sleep(100);
 
-            Assert.AreEqual(1, ServerBytesReceivedRegister.Count);
+            Assert.HasCount(1, ServerBytesReceivedRegister);
         }
 
         [TestMethod]
@@ -128,16 +128,16 @@ namespace Renci.SshNet.Tests.Classes
             if (wantReply)
             {
                 // Should have sent a failure reply.
-                Assert.AreEqual(1, ServerBytesReceivedRegister.Count);
+                Assert.HasCount(1, ServerBytesReceivedRegister);
                 Assert.AreEqual(82, ServerBytesReceivedRegister[0][5], "Expected to have sent SSH_MSG_REQUEST_FAILURE(82)");
             }
             else
             {
                 // Should not have sent any reply.
-                Assert.AreEqual(0, ServerBytesReceivedRegister.Count);
+                Assert.IsEmpty(ServerBytesReceivedRegister);
             }
 
-            Assert.AreEqual(0, ErrorOccurredRegister.Count);
+            Assert.IsEmpty(ErrorOccurredRegister);
         }
 
         [TestMethod]
@@ -218,7 +218,7 @@ namespace Renci.SshNet.Tests.Classes
             // give session time to process message
             Thread.Sleep(100);
 
-            Assert.AreEqual(1, ServerBytesReceivedRegister.Count);
+            Assert.HasCount(1, ServerBytesReceivedRegister);
         }
 
         [TestMethod]
@@ -235,7 +235,7 @@ namespace Renci.SshNet.Tests.Classes
             Thread.Sleep(100);
 
             Assert.IsTrue(actual);
-            Assert.AreEqual(1, ServerBytesReceivedRegister.Count);
+            Assert.HasCount(1, ServerBytesReceivedRegister);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ConnectionReset.cs
+++ b/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ConnectionReset.cs
@@ -35,25 +35,25 @@ namespace Renci.SshNet.Tests.Classes
             Session.Disconnect();
 
             stopwatch.Stop();
-            Assert.IsTrue(stopwatch.ElapsedMilliseconds < 500);
+            Assert.IsLessThan(500, stopwatch.ElapsedMilliseconds);
         }
 
         [TestMethod]
         public void DisconnectedIsNeverRaised()
         {
-            Assert.AreEqual(0, DisconnectedRegister.Count);
+            Assert.IsEmpty(DisconnectedRegister);
         }
 
         [TestMethod]
         public void DisconnectReceivedIsNeverRaised()
         {
-            Assert.AreEqual(0, DisconnectReceivedRegister.Count);
+            Assert.IsEmpty(DisconnectReceivedRegister);
         }
 
         [TestMethod]
         public void ErrorOccurredIsRaisedOnce()
         {
-            Assert.AreEqual(1, ErrorOccurredRegister.Count, ErrorOccurredRegister.AsString());
+            Assert.HasCount(1, ErrorOccurredRegister, ErrorOccurredRegister.AsString());
 
             var errorOccurred = ErrorOccurredRegister[0];
             Assert.IsNotNull(errorOccurred);
@@ -75,7 +75,7 @@ namespace Renci.SshNet.Tests.Classes
             Session.Dispose();
 
             stopwatch.Stop();
-            Assert.IsTrue(stopwatch.ElapsedMilliseconds < 500);
+            Assert.IsLessThan(500, stopwatch.ElapsedMilliseconds);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_Disconnect.cs
+++ b/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_Disconnect.cs
@@ -36,25 +36,25 @@ namespace Renci.SshNet.Tests.Classes
             Session.Disconnect();
 
             stopwatch.Stop();
-            Assert.IsTrue(stopwatch.ElapsedMilliseconds < 500);
+            Assert.IsLessThan(500, stopwatch.ElapsedMilliseconds);
         }
 
         [TestMethod]
         public void DisconnectedIsNeverRaised()
         {
-            Assert.AreEqual(0, DisconnectedRegister.Count);
+            Assert.IsEmpty(DisconnectedRegister);
         }
 
         [TestMethod]
         public void DisconnectReceivedIsNeverRaised()
         {
-            Assert.AreEqual(0, DisconnectReceivedRegister.Count);
+            Assert.IsEmpty(DisconnectReceivedRegister);
         }
 
         [TestMethod]
         public void ErrorOccurredIsNeverRaised()
         {
-            Assert.AreEqual(0, ErrorOccurredRegister.Count, ErrorOccurredRegister.AsString());
+            Assert.IsEmpty(ErrorOccurredRegister, ErrorOccurredRegister.AsString());
         }
 
         [TestMethod]
@@ -66,7 +66,7 @@ namespace Renci.SshNet.Tests.Classes
             Session.Dispose();
 
             stopwatch.Stop();
-            Assert.IsTrue(stopwatch.ElapsedMilliseconds < 500);
+            Assert.IsLessThan(500, stopwatch.ElapsedMilliseconds);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_GlobalRequestMessageAfterAuthenticationRace.cs
+++ b/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_GlobalRequestMessageAfterAuthenticationRace.cs
@@ -36,7 +36,7 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ErrorOccurredShouldNotBeRaised()
         {
-            Assert.AreEqual(0, ErrorOccurredRegister.Count, ErrorOccurredRegister.AsString());
+            Assert.IsEmpty(ErrorOccurredRegister, ErrorOccurredRegister.AsString());
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ServerSendsBadPacket.cs
+++ b/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ServerSendsBadPacket.cs
@@ -45,25 +45,25 @@ namespace Renci.SshNet.Tests.Classes
             Session.Disconnect();
 
             stopwatch.Stop();
-            Assert.IsTrue(stopwatch.ElapsedMilliseconds < 500);
+            Assert.IsLessThan(500, stopwatch.ElapsedMilliseconds);
         }
 
         [TestMethod]
         public void DisconnectedIsNeverRaised()
         {
-            Assert.AreEqual(0, DisconnectedRegister.Count);
+            Assert.IsEmpty(DisconnectedRegister);
         }
 
         [TestMethod]
         public void DisconnectReceivedIsNeverRaised()
         {
-            Assert.AreEqual(0, DisconnectReceivedRegister.Count);
+            Assert.IsEmpty(DisconnectReceivedRegister);
         }
 
         [TestMethod]
         public void ErrorOccurredIsRaisedOnce()
         {
-            Assert.AreEqual(1, ErrorOccurredRegister.Count, ErrorOccurredRegister.AsString());
+            Assert.HasCount(1, ErrorOccurredRegister, ErrorOccurredRegister.AsString());
 
             var errorOccurred = ErrorOccurredRegister[0];
             Assert.IsNotNull(errorOccurred);
@@ -87,7 +87,7 @@ namespace Renci.SshNet.Tests.Classes
             Session.Dispose();
 
             stopwatch.Stop();
-            Assert.IsTrue(stopwatch.ElapsedMilliseconds < 500);
+            Assert.IsLessThan(500, stopwatch.ElapsedMilliseconds);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ServerSendsDisconnectMessage.cs
+++ b/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ServerSendsDisconnectMessage.cs
@@ -48,19 +48,19 @@ namespace Renci.SshNet.Tests.Classes
             Session.Disconnect();
 
             stopwatch.Stop();
-            Assert.IsTrue(stopwatch.ElapsedMilliseconds < 500);
+            Assert.IsLessThan(500, stopwatch.ElapsedMilliseconds);
         }
 
         [TestMethod]
         public void DisconnectedIsRaisedOnce()
         {
-            Assert.AreEqual(1, DisconnectedRegister.Count);
+            Assert.HasCount(1, DisconnectedRegister);
         }
 
         [TestMethod]
         public void DisconnectReceivedIsRaisedOnce()
         {
-            Assert.AreEqual(1, DisconnectReceivedRegister.Count);
+            Assert.HasCount(1, DisconnectReceivedRegister);
 
             var disconnectMessage = DisconnectReceivedRegister[0].Message;
             Assert.IsNotNull(disconnectMessage);
@@ -72,7 +72,7 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ErrorOccurredIsNeverRaised()
         {
-            Assert.AreEqual(0, ErrorOccurredRegister.Count, ErrorOccurredRegister.AsString());
+            Assert.IsEmpty(ErrorOccurredRegister, ErrorOccurredRegister.AsString());
         }
 
         [TestMethod]
@@ -84,7 +84,7 @@ namespace Renci.SshNet.Tests.Classes
             Session.Dispose();
 
             stopwatch.Stop();
-            Assert.IsTrue(stopwatch.ElapsedMilliseconds < 500);
+            Assert.IsLessThan(500, stopwatch.ElapsedMilliseconds);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ServerSendsDisconnectMessageAndShutsDownSocket.cs
+++ b/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ServerSendsDisconnectMessageAndShutsDownSocket.cs
@@ -52,19 +52,19 @@ namespace Renci.SshNet.Tests.Classes
             Session.Disconnect();
 
             stopwatch.Stop();
-            Assert.IsTrue(stopwatch.ElapsedMilliseconds < 500);
+            Assert.IsLessThan(500, stopwatch.ElapsedMilliseconds);
         }
 
         [TestMethod]
         public void DisconnectedIsRaisedOnce()
         {
-            Assert.AreEqual(1, DisconnectedRegister.Count);
+            Assert.HasCount(1, DisconnectedRegister);
         }
 
         [TestMethod]
         public void DisconnectReceivedIsRaisedOnce()
         {
-            Assert.AreEqual(1, DisconnectReceivedRegister.Count);
+            Assert.HasCount(1, DisconnectReceivedRegister);
 
             var disconnectMessage = DisconnectReceivedRegister[0].Message;
             Assert.IsNotNull(disconnectMessage);
@@ -76,7 +76,7 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void ErrorOccurredIsNeverRaised()
         {
-            Assert.AreEqual(0, ErrorOccurredRegister.Count, ErrorOccurredRegister.AsString());
+            Assert.IsEmpty(ErrorOccurredRegister, ErrorOccurredRegister.AsString());
         }
 
         [TestMethod]
@@ -88,7 +88,7 @@ namespace Renci.SshNet.Tests.Classes
             Session.Dispose();
 
             stopwatch.Stop();
-            Assert.IsTrue(stopwatch.ElapsedMilliseconds < 500);
+            Assert.IsLessThan(500, stopwatch.ElapsedMilliseconds);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ServerSendsUnsupportedMessageType.cs
+++ b/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ServerSendsUnsupportedMessageType.cs
@@ -50,25 +50,25 @@ namespace Renci.SshNet.Tests.Classes
             Session.Disconnect();
 
             stopwatch.Stop();
-            Assert.IsTrue(stopwatch.ElapsedMilliseconds < 500);
+            Assert.IsLessThan(500, stopwatch.ElapsedMilliseconds);
         }
 
         [TestMethod]
         public void DisconnectedIsNeverRaised()
         {
-            Assert.AreEqual(0, DisconnectedRegister.Count);
+            Assert.IsEmpty(DisconnectedRegister);
         }
 
         [TestMethod]
         public void DisconnectReceivedIsNeverRaised()
         {
-            Assert.AreEqual(0, DisconnectReceivedRegister.Count);
+            Assert.IsEmpty(DisconnectReceivedRegister);
         }
 
         [TestMethod]
         public void ErrorOccurredIsRaisedOnce()
         {
-            Assert.AreEqual(1, ErrorOccurredRegister.Count, ErrorOccurredRegister.AsString());
+            Assert.HasCount(1, ErrorOccurredRegister, ErrorOccurredRegister.AsString());
 
             var errorOccurred = ErrorOccurredRegister[0];
             Assert.IsNotNull(errorOccurred);
@@ -91,7 +91,7 @@ namespace Renci.SshNet.Tests.Classes
             Session.Dispose();
 
             stopwatch.Stop();
-            Assert.IsTrue(stopwatch.ElapsedMilliseconds < 500);
+            Assert.IsLessThan(500, stopwatch.ElapsedMilliseconds);
         }
 
         [TestMethod]
@@ -123,7 +123,7 @@ namespace Renci.SshNet.Tests.Classes
             Thread.Sleep(100);
 
             Assert.IsNotNull(bytesReceivedByServer);
-            Assert.AreEqual(24, bytesReceivedByServer.Length);
+            Assert.HasCount(24, bytesReceivedByServer);
         }
 
         [TestMethod]
@@ -149,7 +149,7 @@ namespace Renci.SshNet.Tests.Classes
             Thread.Sleep(100);
 
             Assert.IsNotNull(bytesReceivedByServer);
-            Assert.AreEqual(24, bytesReceivedByServer.Length);
+            Assert.HasCount(24, bytesReceivedByServer);
         }
 
         [TestMethod]
@@ -168,7 +168,7 @@ namespace Renci.SshNet.Tests.Classes
             Thread.Sleep(100);
 
             Assert.IsNotNull(bytesReceivedByServer);
-            Assert.AreEqual(24, bytesReceivedByServer.Length);
+            Assert.HasCount(24, bytesReceivedByServer);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ServerShutsDownSendAfterSendingIncompletePacket.cs
+++ b/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ServerShutsDownSendAfterSendingIncompletePacket.cs
@@ -43,25 +43,25 @@ namespace Renci.SshNet.Tests.Classes
             Session.Disconnect();
 
             stopwatch.Stop();
-            Assert.IsTrue(stopwatch.ElapsedMilliseconds < 500);
+            Assert.IsLessThan(500, stopwatch.ElapsedMilliseconds);
         }
 
         [TestMethod]
         public void DisconnectedIsNeverRaised()
         {
-            Assert.AreEqual(0, DisconnectedRegister.Count);
+            Assert.IsEmpty(DisconnectedRegister);
         }
 
         [TestMethod]
         public void DisconnectReceivedIsNeverRaised()
         {
-            Assert.AreEqual(0, DisconnectReceivedRegister.Count);
+            Assert.IsEmpty(DisconnectReceivedRegister);
         }
 
         [TestMethod]
         public void ErrorOccurredIsRaisedOnce()
         {
-            Assert.AreEqual(1, ErrorOccurredRegister.Count, ErrorOccurredRegister.AsString());
+            Assert.HasCount(1, ErrorOccurredRegister, ErrorOccurredRegister.AsString());
 
             var errorOccurred = ErrorOccurredRegister[0];
             Assert.IsNotNull(errorOccurred);
@@ -85,7 +85,7 @@ namespace Renci.SshNet.Tests.Classes
             Session.Dispose();
 
             stopwatch.Stop();
-            Assert.IsTrue(stopwatch.ElapsedMilliseconds < 500);
+            Assert.IsLessThan(500, stopwatch.ElapsedMilliseconds);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ServerShutsDownSocket.cs
+++ b/test/Renci.SshNet.Tests/Classes/SessionTest_Connected_ServerShutsDownSocket.cs
@@ -37,25 +37,25 @@ namespace Renci.SshNet.Tests.Classes
             Session.Disconnect();
 
             stopwatch.Stop();
-            Assert.IsTrue(stopwatch.ElapsedMilliseconds < 500);
+            Assert.IsLessThan(500, stopwatch.ElapsedMilliseconds);
         }
 
         [TestMethod]
         public void DisconnectedIsNeverRaised()
         {
-            Assert.AreEqual(0, DisconnectedRegister.Count);
+            Assert.IsEmpty(DisconnectedRegister);
         }
 
         [TestMethod]
         public void DisconnectReceivedIsNeverRaised()
         {
-            Assert.AreEqual(0, DisconnectReceivedRegister.Count);
+            Assert.IsEmpty(DisconnectReceivedRegister);
         }
 
         [TestMethod]
         public void ErrorOccurredIsRaisedOnce()
         {
-            Assert.AreEqual(1, ErrorOccurredRegister.Count, ErrorOccurredRegister.AsString());
+            Assert.HasCount(1, ErrorOccurredRegister, ErrorOccurredRegister.AsString());
 
             var errorOccurred = ErrorOccurredRegister[0];
             Assert.IsNotNull(errorOccurred);
@@ -79,7 +79,7 @@ namespace Renci.SshNet.Tests.Classes
             Session.Dispose();
 
             stopwatch.Stop();
-            Assert.IsTrue(stopwatch.ElapsedMilliseconds < 500);
+            Assert.IsLessThan(500, stopwatch.ElapsedMilliseconds);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/ExtendedRequests/FStatVfsRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/ExtendedRequests/FStatVfsRequestTest.cs
@@ -60,9 +60,9 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests.ExtendedRequests
 
             request.Complete(statusResponse);
 
-            Assert.AreEqual(1, statusActionInvocations.Count);
+            Assert.HasCount(1, statusActionInvocations);
             Assert.AreSame(statusResponse, statusActionInvocations[0]);
-            Assert.AreEqual(0, extendedReplyActionInvocations.Count);
+            Assert.IsEmpty(extendedReplyActionInvocations);
         }
 
         [TestMethod]
@@ -79,8 +79,8 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests.ExtendedRequests
 
             request.Complete(extendedReplyResponse);
 
-            Assert.AreEqual(0, statusActionInvocations.Count);
-            Assert.AreEqual(1, extendedReplyActionInvocations.Count);
+            Assert.IsEmpty(statusActionInvocations);
+            Assert.HasCount(1, extendedReplyActionInvocations);
             Assert.AreSame(extendedReplyResponse, extendedReplyActionInvocations[0]);
         }
 
@@ -100,7 +100,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests.ExtendedRequests
             expectedBytesLength += 4; // Handle length
             expectedBytesLength += _handle.Length; // Handle
 
-            Assert.AreEqual(expectedBytesLength, bytes.Length);
+            Assert.HasCount(expectedBytesLength, bytes);
 
             var sshDataStream = new SshDataStream(bytes);
 

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/ExtendedRequests/HardLinkRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/ExtendedRequests/HardLinkRequestTest.cs
@@ -65,7 +65,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests.ExtendedRequests
 
             request.Complete(statusResponse);
 
-            Assert.AreEqual(1, statusActionInvocations.Count);
+            Assert.HasCount(1, statusActionInvocations);
             Assert.AreSame(statusResponse, statusActionInvocations[0]);
         }
 
@@ -87,7 +87,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests.ExtendedRequests
             expectedBytesLength += 4; // NewPath length
             expectedBytesLength += _newPathBytes.Length; // NewPath
 
-            Assert.AreEqual(expectedBytesLength, bytes.Length);
+            Assert.HasCount(expectedBytesLength, bytes);
 
             var sshDataStream = new SshDataStream(bytes);
 

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/ExtendedRequests/PosixRenameRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/ExtendedRequests/PosixRenameRequestTest.cs
@@ -69,7 +69,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests.ExtendedRequests
 
             request.Complete(statusResponse);
 
-            Assert.AreEqual(1, statusActionInvocations.Count);
+            Assert.HasCount(1, statusActionInvocations);
             Assert.AreSame(statusResponse, statusActionInvocations[0]);
         }
 
@@ -91,7 +91,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests.ExtendedRequests
             expectedBytesLength += 4; // NewPath length
             expectedBytesLength += _newPathBytes.Length; // NewPath
 
-            Assert.AreEqual(expectedBytesLength, bytes.Length);
+            Assert.HasCount(expectedBytesLength, bytes);
 
             var sshDataStream = new SshDataStream(bytes);
 

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/ExtendedRequests/StatVfsRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/ExtendedRequests/StatVfsRequestTest.cs
@@ -66,9 +66,9 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests.ExtendedRequests
 
             request.Complete(statusResponse);
 
-            Assert.AreEqual(1, statusActionInvocations.Count);
+            Assert.HasCount(1, statusActionInvocations);
             Assert.AreSame(statusResponse, statusActionInvocations[0]);
-            Assert.AreEqual(0, extendedReplyActionInvocations.Count);
+            Assert.IsEmpty(extendedReplyActionInvocations);
         }
 
         [TestMethod]
@@ -85,8 +85,8 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests.ExtendedRequests
 
             request.Complete(extendedReplyResponse);
 
-            Assert.AreEqual(0, statusActionInvocations.Count);
-            Assert.AreEqual(1, extendedReplyActionInvocations.Count);
+            Assert.IsEmpty(statusActionInvocations);
+            Assert.HasCount(1, extendedReplyActionInvocations);
             Assert.AreSame(extendedReplyResponse, extendedReplyActionInvocations[0]);
         }
 
@@ -106,7 +106,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests.ExtendedRequests
             expectedBytesLength += 4; // Path length
             expectedBytesLength += _pathBytes.Length; // Path
 
-            Assert.AreEqual(expectedBytesLength, bytes.Length);
+            Assert.HasCount(expectedBytesLength, bytes);
 
             var sshDataStream = new SshDataStream(bytes);
 

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpBlockRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpBlockRequestTest.cs
@@ -61,7 +61,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             request.Complete(statusResponse);
 
-            Assert.AreEqual(1, statusActionInvocations.Count);
+            Assert.HasCount(1, statusActionInvocations);
             Assert.AreSame(statusResponse, statusActionInvocations[0]);
         }
 
@@ -82,7 +82,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
             expectedBytesLength += 8; // Length
             expectedBytesLength += 4; // LockMask
 
-            Assert.AreEqual(expectedBytesLength, bytes.Length);
+            Assert.HasCount(expectedBytesLength, bytes);
 
             var sshDataStream = new SshDataStream(bytes);
 

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpCloseRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpCloseRequestTest.cs
@@ -52,7 +52,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             request.Complete(statusResponse);
 
-            Assert.AreEqual(1, statusActionInvocations.Count);
+            Assert.HasCount(1, statusActionInvocations);
             Assert.AreSame(statusResponse, statusActionInvocations[0]);
         }
 
@@ -70,7 +70,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
             expectedBytesLength += 4; // Handle length
             expectedBytesLength += _handle.Length; // Handle
 
-            Assert.AreEqual(expectedBytesLength, bytes.Length);
+            Assert.HasCount(expectedBytesLength, bytes);
 
             var sshDataStream = new SshDataStream(bytes);
 

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpFSetStatRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpFSetStatRequestTest.cs
@@ -57,7 +57,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             request.Complete(statusResponse);
 
-            Assert.AreEqual(1, statusActionInvocations.Count);
+            Assert.HasCount(1, statusActionInvocations);
             Assert.AreSame(statusResponse, statusActionInvocations[0]);
         }
 
@@ -76,7 +76,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
             expectedBytesLength += _handle.Length; // Handle
             expectedBytesLength += _attributesBytes.Length; // Attributes
 
-            Assert.AreEqual(expectedBytesLength, bytes.Length);
+            Assert.HasCount(expectedBytesLength, bytes);
 
             var sshDataStream = new SshDataStream(bytes);
 

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpFStatRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpFStatRequestTest.cs
@@ -54,8 +54,8 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             request.Complete(attrsResponse);
 
-            Assert.AreEqual(0, statusActionInvocations.Count);
-            Assert.AreEqual(1, attrsActionInvocations.Count);
+            Assert.IsEmpty(statusActionInvocations);
+            Assert.HasCount(1, attrsActionInvocations);
             Assert.AreSame(attrsResponse, attrsActionInvocations[0]);
         }
 
@@ -73,9 +73,9 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             request.Complete(statusResponse);
 
-            Assert.AreEqual(1, statusActionInvocations.Count);
+            Assert.HasCount(1, statusActionInvocations);
             Assert.AreSame(statusResponse, statusActionInvocations[0]);
-            Assert.AreEqual(0, attrsActionInvocations.Count);
+            Assert.IsEmpty(attrsActionInvocations);
         }
 
         [TestMethod]
@@ -92,7 +92,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
             expectedBytesLength += 4; // Handle length
             expectedBytesLength += _handle.Length; // Handle
 
-            Assert.AreEqual(expectedBytesLength, bytes.Length);
+            Assert.HasCount(expectedBytesLength, bytes);
 
             var sshDataStream = new SshDataStream(bytes);
 

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpLStatRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpLStatRequestTest.cs
@@ -60,8 +60,8 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             request.Complete(attrsResponse);
 
-            Assert.AreEqual(0, statusActionInvocations.Count);
-            Assert.AreEqual(1, attrsActionInvocations.Count);
+            Assert.IsEmpty(statusActionInvocations);
+            Assert.HasCount(1, attrsActionInvocations);
             Assert.AreSame(attrsResponse, attrsActionInvocations[0]);
         }
 
@@ -79,9 +79,9 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             request.Complete(statusResponse);
 
-            Assert.AreEqual(1, statusActionInvocations.Count);
+            Assert.HasCount(1, statusActionInvocations);
             Assert.AreSame(statusResponse, statusActionInvocations[0]);
-            Assert.AreEqual(0, attrsActionInvocations.Count);
+            Assert.IsEmpty(attrsActionInvocations);
         }
 
         [TestMethod]
@@ -98,7 +98,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
             expectedBytesLength += 4; // Pah length
             expectedBytesLength += _pathBytes.Length; // Path
 
-            Assert.AreEqual(expectedBytesLength, bytes.Length);
+            Assert.HasCount(expectedBytesLength, bytes);
 
             var sshDataStream = new SshDataStream(bytes);
 

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpLinkRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpLinkRequestTest.cs
@@ -65,7 +65,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             request.Complete(statusResponse);
 
-            Assert.AreEqual(1, statusActionInvocations.Count);
+            Assert.HasCount(1, statusActionInvocations);
             Assert.AreSame(statusResponse, statusActionInvocations[0]);
         }
 
@@ -86,7 +86,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
             expectedBytesLength += _existingPathBytes.Length; // ExistingPath
             expectedBytesLength += 1; // IsSymLink
 
-            Assert.AreEqual(expectedBytesLength, bytes.Length);
+            Assert.HasCount(expectedBytesLength, bytes);
 
             var sshDataStream = new SshDataStream(bytes);
 

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpMkDirRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpMkDirRequestTest.cs
@@ -63,7 +63,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             request.Complete(statusResponse);
 
-            Assert.AreEqual(1, statusActionInvocations.Count);
+            Assert.HasCount(1, statusActionInvocations);
             Assert.AreSame(statusResponse, statusActionInvocations[0]);
         }
 
@@ -82,7 +82,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
             expectedBytesLength += _pathBytes.Length; // Path
             expectedBytesLength += _attributesBytes.Length; // Attributes
 
-            Assert.AreEqual(expectedBytesLength, bytes.Length);
+            Assert.HasCount(expectedBytesLength, bytes);
 
             var sshDataStream = new SshDataStream(bytes);
 

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpOpenDirRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpOpenDirRequestTest.cs
@@ -60,8 +60,8 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             request.Complete(handleResponse);
 
-            Assert.AreEqual(0, statusActionInvocations.Count);
-            Assert.AreEqual(1, handleActionInvocations.Count);
+            Assert.IsEmpty(statusActionInvocations);
+            Assert.HasCount(1, handleActionInvocations);
             Assert.AreSame(handleResponse, handleActionInvocations[0]);
         }
 
@@ -79,9 +79,9 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             request.Complete(statusResponse);
 
-            Assert.AreEqual(1, statusActionInvocations.Count);
+            Assert.HasCount(1, statusActionInvocations);
             Assert.AreSame(statusResponse, statusActionInvocations[0]);
-            Assert.AreEqual(0, handleActionInvocations.Count);
+            Assert.IsEmpty(handleActionInvocations);
         }
 
         [TestMethod]
@@ -98,7 +98,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
             expectedBytesLength += 4; // Path length
             expectedBytesLength += _pathBytes.Length; // Path
 
-            Assert.AreEqual(expectedBytesLength, bytes.Length);
+            Assert.HasCount(expectedBytesLength, bytes);
 
             var sshDataStream = new SshDataStream(bytes);
 

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpOpenRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpOpenRequestTest.cs
@@ -74,8 +74,8 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             request.Complete(handleResponse);
 
-            Assert.AreEqual(0, statusActionInvocations.Count);
-            Assert.AreEqual(1, handleActionInvocations.Count);
+            Assert.IsEmpty(statusActionInvocations);
+            Assert.HasCount(1, handleActionInvocations);
             Assert.AreSame(handleResponse, handleActionInvocations[0]);
         }
 
@@ -100,9 +100,9 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             request.Complete(statusResponse);
 
-            Assert.AreEqual(1, statusActionInvocations.Count);
+            Assert.HasCount(1, statusActionInvocations);
             Assert.AreSame(statusResponse, statusActionInvocations[0]);
-            Assert.AreEqual(0, handleActionInvocations.Count);
+            Assert.IsEmpty(handleActionInvocations);
         }
 
         [TestMethod]
@@ -121,7 +121,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
             expectedBytesLength += 4; // Flags
             expectedBytesLength += _attributesBytes.Length; // Attributes
 
-            Assert.AreEqual(expectedBytesLength, bytes.Length);
+            Assert.HasCount(expectedBytesLength, bytes);
 
             var sshDataStream = new SshDataStream(bytes);
 

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpReadDirRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpReadDirRequestTest.cs
@@ -55,8 +55,8 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             request.Complete(nameResponse);
 
-            Assert.AreEqual(0, statusActionInvocations.Count);
-            Assert.AreEqual(1, nameActionInvocations.Count);
+            Assert.IsEmpty(statusActionInvocations);
+            Assert.HasCount(1, nameActionInvocations);
             Assert.AreSame(nameResponse, nameActionInvocations[0]);
         }
 
@@ -74,9 +74,9 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             request.Complete(statusResponse);
 
-            Assert.AreEqual(1, statusActionInvocations.Count);
+            Assert.HasCount(1, statusActionInvocations);
             Assert.AreSame(statusResponse, statusActionInvocations[0]);
-            Assert.AreEqual(0, nameActionInvocations.Count);
+            Assert.IsEmpty(nameActionInvocations);
         }
 
         [TestMethod]
@@ -93,7 +93,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
             expectedBytesLength += 4; // Handle length
             expectedBytesLength += _handle.Length; // Handle
 
-            Assert.AreEqual(expectedBytesLength, bytes.Length);
+            Assert.HasCount(expectedBytesLength, bytes);
 
             var sshDataStream = new SshDataStream(bytes);
 

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpReadLinkRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpReadLinkRequestTest.cs
@@ -66,8 +66,8 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             request.Complete(nameResponse);
 
-            Assert.AreEqual(0, statusActionInvocations.Count);
-            Assert.AreEqual(1, nameActionInvocations.Count);
+            Assert.IsEmpty(statusActionInvocations);
+            Assert.HasCount(1, nameActionInvocations);
             Assert.AreSame(nameResponse, nameActionInvocations[0]);
         }
 
@@ -91,9 +91,9 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             request.Complete(statusResponse);
 
-            Assert.AreEqual(1, statusActionInvocations.Count);
+            Assert.HasCount(1, statusActionInvocations);
             Assert.AreSame(statusResponse, statusActionInvocations[0]);
-            Assert.AreEqual(0, nameActionInvocations.Count);
+            Assert.IsEmpty(nameActionInvocations);
         }
 
         [TestMethod]
@@ -110,7 +110,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
             expectedBytesLength += 4; // Path length
             expectedBytesLength += _pathBytes.Length; // Path
 
-            Assert.AreEqual(expectedBytesLength, bytes.Length);
+            Assert.HasCount(expectedBytesLength, bytes);
 
             var sshDataStream = new SshDataStream(bytes);
 

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpReadRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpReadRequestTest.cs
@@ -67,8 +67,8 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             request.Complete(dataResponse);
 
-            Assert.AreEqual(0, statusActionInvocations.Count);
-            Assert.AreEqual(1, dataActionInvocations.Count);
+            Assert.IsEmpty(statusActionInvocations);
+            Assert.HasCount(1, dataActionInvocations);
             Assert.AreSame(dataResponse, dataActionInvocations[0]);
         }
 
@@ -93,9 +93,9 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             request.Complete(statusResponse);
 
-            Assert.AreEqual(1, statusActionInvocations.Count);
+            Assert.HasCount(1, statusActionInvocations);
             Assert.AreSame(statusResponse, statusActionInvocations[0]);
-            Assert.AreEqual(0, dataActionInvocations.Count);
+            Assert.IsEmpty(dataActionInvocations);
         }
 
         [TestMethod]
@@ -114,7 +114,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
             expectedBytesLength += 8; // Offset
             expectedBytesLength += 4; // Length
 
-            Assert.AreEqual(expectedBytesLength, bytes.Length);
+            Assert.HasCount(expectedBytesLength, bytes);
 
             var sshDataStream = new SshDataStream(bytes);
 

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpRealPathRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpRealPathRequestTest.cs
@@ -72,8 +72,8 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             request.Complete(nameResponse);
 
-            Assert.AreEqual(0, statusActionInvocations.Count);
-            Assert.AreEqual(1, nameActionInvocations.Count);
+            Assert.IsEmpty(statusActionInvocations);
+            Assert.HasCount(1, nameActionInvocations);
             Assert.AreSame(nameResponse, nameActionInvocations[0]);
         }
 
@@ -97,9 +97,9 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             request.Complete(statusResponse);
 
-            Assert.AreEqual(1, statusActionInvocations.Count);
+            Assert.HasCount(1, statusActionInvocations);
             Assert.AreSame(statusResponse, statusActionInvocations[0]);
-            Assert.AreEqual(0, nameActionInvocations.Count);
+            Assert.IsEmpty(nameActionInvocations);
         }
 
         [TestMethod]
@@ -126,7 +126,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
             expectedBytesLength += 4; // Path length
             expectedBytesLength += _pathBytes.Length; // Path
 
-            Assert.AreEqual(expectedBytesLength, bytes.Length);
+            Assert.HasCount(expectedBytesLength, bytes);
 
             var sshDataStream = new SshDataStream(bytes);
 

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpRemoveRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpRemoveRequestTest.cs
@@ -58,7 +58,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             request.Complete(statusResponse);
 
-            Assert.AreEqual(1, statusActionInvocations.Count);
+            Assert.HasCount(1, statusActionInvocations);
             Assert.AreSame(statusResponse, statusActionInvocations[0]);
         }
 
@@ -76,7 +76,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
             expectedBytesLength += 4; // Filename length
             expectedBytesLength += _filenameBytes.Length; // Filename
 
-            Assert.AreEqual(expectedBytesLength, bytes.Length);
+            Assert.HasCount(expectedBytesLength, bytes);
 
             var sshDataStream = new SshDataStream(bytes);
 

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpRenameRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpRenameRequestTest.cs
@@ -63,7 +63,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             request.Complete(statusResponse);
 
-            Assert.AreEqual(1, statusActionInvocations.Count);
+            Assert.HasCount(1, statusActionInvocations);
             Assert.AreSame(statusResponse, statusActionInvocations[0]);
         }
 
@@ -83,7 +83,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
             expectedBytesLength += 4; // NewPath length
             expectedBytesLength += _newPathBytes.Length; // NewPath
 
-            Assert.AreEqual(expectedBytesLength, bytes.Length);
+            Assert.HasCount(expectedBytesLength, bytes);
 
             var sshDataStream = new SshDataStream(bytes);
 

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpRmDirRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpRmDirRequestTest.cs
@@ -57,7 +57,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             request.Complete(statusResponse);
 
-            Assert.AreEqual(1, statusActionInvocations.Count);
+            Assert.HasCount(1, statusActionInvocations);
             Assert.AreSame(statusResponse, statusActionInvocations[0]);
         }
 
@@ -78,7 +78,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
             expectedBytesLength += 4; // Path length
             expectedBytesLength += _pathBytes.Length; // Path
 
-            Assert.AreEqual(expectedBytesLength, bytes.Length);
+            Assert.HasCount(expectedBytesLength, bytes);
 
             var sshDataStream = new SshDataStream(bytes);
 

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpSetStatRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpSetStatRequestTest.cs
@@ -68,7 +68,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             request.Complete(statusResponse);
 
-            Assert.AreEqual(1, statusActionInvocations.Count);
+            Assert.HasCount(1, statusActionInvocations);
             Assert.AreSame(statusResponse, statusActionInvocations[0]);
         }
 
@@ -87,7 +87,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
             expectedBytesLength += _pathBytes.Length; // Path
             expectedBytesLength += _attributesBytes.Length; // Attributes
 
-            Assert.AreEqual(expectedBytesLength, bytes.Length);
+            Assert.HasCount(expectedBytesLength, bytes);
 
             var sshDataStream = new SshDataStream(bytes);
 

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpStatRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpStatRequestTest.cs
@@ -59,8 +59,8 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             request.Complete(attrsResponse);
 
-            Assert.AreEqual(0, statusActionInvocations.Count);
-            Assert.AreEqual(1, attrsActionInvocations.Count);
+            Assert.IsEmpty(statusActionInvocations);
+            Assert.HasCount(1, attrsActionInvocations);
             Assert.AreSame(attrsResponse, attrsActionInvocations[0]);
         }
 
@@ -77,8 +77,8 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             request.Complete(statusResponse);
 
-            Assert.AreEqual(1, statusActionInvocations.Count);
-            Assert.AreEqual(0, attrsActionInvocations.Count);
+            Assert.HasCount(1, statusActionInvocations);
+            Assert.IsEmpty(attrsActionInvocations);
             Assert.AreSame(statusResponse, statusActionInvocations[0]);
         }
 
@@ -96,7 +96,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
             expectedBytesLength += 4; // Path length
             expectedBytesLength += _pathBytes.Length; // Path
 
-            Assert.AreEqual(expectedBytesLength, bytes.Length);
+            Assert.HasCount(expectedBytesLength, bytes);
 
             var sshDataStream = new SshDataStream(bytes);
 

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpSymLinkRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpSymLinkRequestTest.cs
@@ -75,7 +75,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             request.Complete(statusResponse);
 
-            Assert.AreEqual(1, statusActionInvocations.Count);
+            Assert.HasCount(1, statusActionInvocations);
             Assert.AreSame(statusResponse, statusActionInvocations[0]);
         }
 
@@ -101,7 +101,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
             expectedBytesLength += 4; // ExistingPath length
             expectedBytesLength += _existingPathBytes.Length; // ExistingPath
 
-            Assert.AreEqual(expectedBytesLength, bytes.Length);
+            Assert.HasCount(expectedBytesLength, bytes);
 
             var sshDataStream = new SshDataStream(bytes);
 

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpUnblockRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpUnblockRequestTest.cs
@@ -55,7 +55,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             request.Complete(statusResponse);
 
-            Assert.AreEqual(1, statusActionInvocations.Count);
+            Assert.HasCount(1, statusActionInvocations);
             Assert.AreSame(statusResponse, statusActionInvocations[0]);
         }
 
@@ -75,7 +75,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
             expectedBytesLength += 8; // Offset
             expectedBytesLength += 8; // Length
 
-            Assert.AreEqual(expectedBytesLength, bytes.Length);
+            Assert.HasCount(expectedBytesLength, bytes);
 
             var sshDataStream = new SshDataStream(bytes);
 

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpWriteRequestTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Requests/SftpWriteRequestTest.cs
@@ -72,7 +72,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
 
             request.Complete(statusResponse);
 
-            Assert.AreEqual(1, statusActionInvocations.Count);
+            Assert.HasCount(1, statusActionInvocations);
             Assert.AreSame(statusResponse, statusActionInvocations[0]);
         }
 
@@ -93,7 +93,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Requests
             expectedBytesLength += 4; // Data length
             expectedBytesLength += _length; // Data
 
-            Assert.AreEqual(expectedBytesLength, bytes.Length);
+            Assert.HasCount(expectedBytesLength, bytes);
 
             var sshDataStream = new SshDataStream(bytes);
 

--- a/test/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferNotEmptyAndWriteLessBytesThanBufferCanContain.cs
+++ b/test/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferNotEmptyAndWriteLessBytesThanBufferCanContain.cs
@@ -136,7 +136,7 @@ namespace Renci.SshNet.Tests.Classes
             _shellStream.Flush();
 
             Assert.IsNotNull(bytesSent);
-            Assert.AreEqual(_bufferData.Length + _count, bytesSent.Length);
+            Assert.HasCount(_bufferData.Length + _count, bytesSent);
             Assert.IsTrue(_bufferData.IsEqualTo(bytesSent.Take(_bufferData.Length)));
             Assert.IsTrue(_data.Take(0, _count).IsEqualTo(bytesSent.Take(_bufferData.Length, _count)));
 

--- a/test/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferNotEmptyAndWriteMoreBytesThanBufferCanContain.cs
+++ b/test/Renci.SshNet.Tests/Classes/ShellStreamTest_Write_WriteBufferNotEmptyAndWriteMoreBytesThanBufferCanContain.cs
@@ -142,7 +142,7 @@ namespace Renci.SshNet.Tests.Classes
             _shellStream.Flush();
 
             Assert.IsNotNull(actualBytesSent);
-            Assert.AreEqual(expectedBytesSent.Length, actualBytesSent.Length);
+            Assert.HasCount(expectedBytesSent.Length, actualBytesSent);
             Assert.IsTrue(expectedBytesSent.IsEqualTo(actualBytesSent));
 
             _channelSessionMock.VerifyAll();

--- a/test/Renci.SshNet.Tests/Classes/SshClientTest_Dispose_ForwardedPortStarted.cs
+++ b/test/Renci.SshNet.Tests/Classes/SshClientTest_Dispose_ForwardedPortStarted.cs
@@ -77,8 +77,7 @@ namespace Renci.SshNet.Tests.Classes
             try
             {
                 var connected = _sshClient.IsConnected;
-                Assert.Fail("IsConnected should have thrown {0} but returned {1}.",
-                    typeof(ObjectDisposedException).FullName, connected);
+                Assert.Fail($"IsConnected should have thrown {typeof(ObjectDisposedException).FullName} but returned {connected}.");
             }
             catch (ObjectDisposedException)
             {

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_Connect_Connected.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_Connect_Connected.cs
@@ -83,13 +83,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void DisconnectHasNeverFired()
         {
-            Assert.AreEqual(0, _disconnectedRegister.Count);
+            Assert.IsEmpty(_disconnectedRegister);
         }
 
         [TestMethod]
         public void ErrorOccurredHasNeverFired()
         {
-            Assert.AreEqual(0, _errorOccurredRegister.Count);
+            Assert.IsEmpty(_errorOccurredRegister);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_Connect_Disconnected.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_Connect_Disconnected.cs
@@ -83,13 +83,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void DisconnectHasNeverFired()
         {
-            Assert.AreEqual(0, _disconnectedRegister.Count);
+            Assert.IsEmpty(_disconnectedRegister);
         }
 
         [TestMethod]
         public void ErrorOccurredHasNeverFired()
         {
-            Assert.AreEqual(0, _errorOccurredRegister.Count);
+            Assert.IsEmpty(_errorOccurredRegister);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_Connect_Disposed.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_Connect_Disposed.cs
@@ -86,13 +86,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void DisconnectHasNeverFired()
         {
-            Assert.AreEqual(0, _disconnectedRegister.Count);
+            Assert.IsEmpty(_disconnectedRegister);
         }
 
         [TestMethod]
         public void ErrorOccurredHasNeverFired()
         {
-            Assert.AreEqual(0, _errorOccurredRegister.Count);
+            Assert.IsEmpty(_errorOccurredRegister);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_Connect_SendSubsystemRequestFails.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_Connect_SendSubsystemRequestFails.cs
@@ -87,13 +87,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void DisconnectHasNeverFired()
         {
-            Assert.AreEqual(0, _disconnectedRegister.Count);
+            Assert.IsEmpty(_disconnectedRegister);
         }
 
         [TestMethod]
         public void ErrorOccurredHasNeverFired()
         {
-            Assert.AreEqual(0, _errorOccurredRegister.Count);
+            Assert.IsEmpty(_errorOccurredRegister);
         }
 
         [TestMethod]
@@ -113,7 +113,7 @@ namespace Renci.SshNet.Tests.Classes
         {
             _sessionMock.Raise(p => p.ErrorOccured += null, new ExceptionEventArgs(new Exception()));
 
-            Assert.AreEqual(0, _errorOccurredRegister.Count);
+            Assert.IsEmpty(_errorOccurredRegister);
         }
 
         [TestMethod]
@@ -121,7 +121,7 @@ namespace Renci.SshNet.Tests.Classes
         {
             _sessionMock.Raise(p => p.Disconnected += null, new EventArgs());
 
-            Assert.AreEqual(0, _disconnectedRegister.Count);
+            Assert.IsEmpty(_disconnectedRegister);
         }
     }
 }

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_Disconnect_Connected.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_Disconnect_Connected.cs
@@ -73,13 +73,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void DisconnectHasNeverFired()
         {
-            Assert.AreEqual(0, _disconnectedRegister.Count);
+            Assert.IsEmpty(_disconnectedRegister);
         }
 
         [TestMethod]
         public void ErrorOccurredHasNeverFired()
         {
-            Assert.AreEqual(0, _errorOccurredRegister.Count);
+            Assert.IsEmpty(_errorOccurredRegister);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_Disconnect_Disposed.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_Disconnect_Disposed.cs
@@ -72,13 +72,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void DisconnectHasNeverFired()
         {
-            Assert.AreEqual(0, _disconnectedRegister.Count);
+            Assert.IsEmpty(_disconnectedRegister);
         }
 
         [TestMethod]
         public void ErrorOccurredHasNeverFired()
         {
-            Assert.AreEqual(0, _errorOccurredRegister.Count);
+            Assert.IsEmpty(_errorOccurredRegister);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_Disconnect_NeverConnected.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_Disconnect_NeverConnected.cs
@@ -54,13 +54,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void DisconnectHasNeverFired()
         {
-            Assert.AreEqual(0, _disconnectedRegister.Count);
+            Assert.IsEmpty(_disconnectedRegister);
         }
 
         [TestMethod]
         public void ErrorOccurredHasNeverFired()
         {
-            Assert.AreEqual(0, _errorOccurredRegister.Count);
+            Assert.IsEmpty(_errorOccurredRegister);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_Dispose_Connected.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_Dispose_Connected.cs
@@ -63,13 +63,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void DisconnectHasNeverFired()
         {
-            Assert.AreEqual(0, _disconnectedRegister.Count);
+            Assert.IsEmpty(_disconnectedRegister);
         }
 
         [TestMethod]
         public void ErrorOccurredHasNeverFired()
         {
-            Assert.AreEqual(0, _errorOccurredRegister.Count);
+            Assert.IsEmpty(_errorOccurredRegister);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_Dispose_Disconnected.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_Dispose_Disconnected.cs
@@ -73,13 +73,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void DisconnectHasNeverFired()
         {
-            Assert.AreEqual(0, _disconnectedRegister.Count);
+            Assert.IsEmpty(_disconnectedRegister);
         }
 
         [TestMethod]
         public void ErrorOccurredHasNeverFired()
         {
-            Assert.AreEqual(0, _errorOccurredRegister.Count);
+            Assert.IsEmpty(_errorOccurredRegister);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_Dispose_Disposed.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_Dispose_Disposed.cs
@@ -73,13 +73,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void DisconnectHasNeverFired()
         {
-            Assert.AreEqual(0, _disconnectedRegister.Count);
+            Assert.IsEmpty(_disconnectedRegister);
         }
 
         [TestMethod]
         public void ErrorOccurredHasNeverFired()
         {
-            Assert.AreEqual(0, _errorOccurredRegister.Count);
+            Assert.IsEmpty(_errorOccurredRegister);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_Dispose_NeverConnected.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_Dispose_NeverConnected.cs
@@ -55,13 +55,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void DisconnectHasNeverFired()
         {
-            Assert.AreEqual(0, _disconnectedRegister.Count);
+            Assert.IsEmpty(_disconnectedRegister);
         }
 
         [TestMethod]
         public void ErrorOccurredHasNeverFired()
         {
-            Assert.AreEqual(0, _errorOccurredRegister.Count);
+            Assert.IsEmpty(_errorOccurredRegister);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnChannelDataReceived_Connected.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnChannelDataReceived_Connected.cs
@@ -69,19 +69,19 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void DisconnectHasNeverFired()
         {
-            Assert.AreEqual(0, _disconnectedRegister.Count);
+            Assert.IsEmpty(_disconnectedRegister);
         }
 
         [TestMethod]
         public void ErrorOccurredHasNeverFired()
         {
-            Assert.AreEqual(0, _errorOccurredRegister.Count);
+            Assert.IsEmpty(_errorOccurredRegister);
         }
 
         [TestMethod]
         public void OnDataReceivedShouldBeInvokedOnce()
         {
-            Assert.AreEqual(1, _subsystemSession.OnDataReceivedInvocations.Count);
+            Assert.HasCount(1, _subsystemSession.OnDataReceivedInvocations);
 
             var received = _subsystemSession.OnDataReceivedInvocations[0];
             Assert.AreEqual(_channelDataEventArgs.Data, received.Data);

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnChannelDataReceived_Disposed.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnChannelDataReceived_Disposed.cs
@@ -70,19 +70,19 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void DisconnectHasNeverFired()
         {
-            Assert.AreEqual(0, _disconnectedRegister.Count);
+            Assert.IsEmpty(_disconnectedRegister);
         }
 
         [TestMethod]
         public void ErrorOccurredHasNeverFired()
         {
-            Assert.AreEqual(0, _errorOccurredRegister.Count);
+            Assert.IsEmpty(_errorOccurredRegister);
         }
 
         [TestMethod]
         public void OnDataReceivedShouldNeverBeInvoked()
         {
-            Assert.AreEqual(0, _subsystemSession.OnDataReceivedInvocations.Count);
+            Assert.IsEmpty(_subsystemSession.OnDataReceivedInvocations);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnChannelDataReceived_OnDataReceived_Exception.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnChannelDataReceived_OnDataReceived_Exception.cs
@@ -72,20 +72,20 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void DisconnectHasNeverFired()
         {
-            Assert.AreEqual(0, _disconnectedRegister.Count);
+            Assert.IsEmpty(_disconnectedRegister);
         }
 
         [TestMethod]
         public void ErrorOccurredHaveFiredOnce()
         {
-            Assert.AreEqual(1, _errorOccurredRegister.Count, _errorOccurredRegister.AsString());
+            Assert.HasCount(1, _errorOccurredRegister, _errorOccurredRegister.AsString());
             Assert.AreSame(_onDataReceivedException, _errorOccurredRegister[0].Exception, _errorOccurredRegister.AsString());
         }
 
         [TestMethod]
         public void OnDataReceivedShouldBeInvokedOnce()
         {
-            Assert.AreEqual(1, _subsystemSession.OnDataReceivedInvocations.Count);
+            Assert.HasCount(1, _subsystemSession.OnDataReceivedInvocations);
 
             var received = _subsystemSession.OnDataReceivedInvocations[0];
             Assert.AreEqual(_channelDataEventArgs.Data, received.Data);

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnChannelException_Connected.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnChannelException_Connected.cs
@@ -68,13 +68,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void DisconnectHasNeverFired()
         {
-            Assert.AreEqual(0, _disconnectedRegister.Count);
+            Assert.IsEmpty(_disconnectedRegister);
         }
 
         [TestMethod]
         public void ErrorOccurredHasFiredOnce()
         {
-            Assert.AreEqual(1, _errorOccurredRegister.Count, _errorOccurredRegister.AsString());
+            Assert.HasCount(1, _errorOccurredRegister, _errorOccurredRegister.AsString());
             Assert.AreSame(_channelExceptionEventArgs.Exception, _errorOccurredRegister[0].Exception, _errorOccurredRegister.AsString());
         }
 

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnChannelException_Disposed.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnChannelException_Disposed.cs
@@ -78,13 +78,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void DisconnectHasNeverFired()
         {
-            Assert.AreEqual(0, _disconnectedRegister.Count);
+            Assert.IsEmpty(_disconnectedRegister);
         }
 
         [TestMethod]
         public void ErrorOccurredHasNeverFired()
         {
-            Assert.AreEqual(0, _errorOccurredRegister.Count);
+            Assert.IsEmpty(_errorOccurredRegister);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnSessionDisconnected_Connected.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnSessionDisconnected_Connected.cs
@@ -70,13 +70,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void DisconnectHasFiredOnce()
         {
-            Assert.AreEqual(1, _disconnectedRegister.Count);
+            Assert.HasCount(1, _disconnectedRegister);
         }
 
         [TestMethod]
         public void ErrorOccurredHasNeverFired()
         {
-            Assert.AreEqual(0, _errorOccurredRegister.Count);
+            Assert.IsEmpty(_errorOccurredRegister);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnSessionDisconnected_Disposed.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnSessionDisconnected_Disposed.cs
@@ -72,13 +72,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void DisconnectHasNeverFired()
         {
-            Assert.AreEqual(0, _disconnectedRegister.Count);
+            Assert.IsEmpty(_disconnectedRegister);
         }
 
         [TestMethod]
         public void ErrorOccurredHasNeverFired()
         {
-            Assert.AreEqual(0, _errorOccurredRegister.Count);
+            Assert.IsEmpty(_errorOccurredRegister);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnSessionErrorOccurred_Connected.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnSessionErrorOccurred_Connected.cs
@@ -68,13 +68,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void DisconnectHasNeverFired()
         {
-            Assert.AreEqual(0, _disconnectedRegister.Count);
+            Assert.IsEmpty(_disconnectedRegister);
         }
 
         [TestMethod]
         public void ErrorOccurredHasFiredOnce()
         {
-            Assert.AreEqual(1, _errorOccurredRegister.Count, _errorOccurredRegister.AsString());
+            Assert.HasCount(1, _errorOccurredRegister, _errorOccurredRegister.AsString());
             Assert.AreSame(_errorOccurredEventArgs.Exception, _errorOccurredRegister[0].Exception, _errorOccurredRegister.AsString());
         }
 

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnSessionErrorOccurred_Disposed.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_OnSessionErrorOccurred_Disposed.cs
@@ -68,13 +68,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void DisconnectHasNeverFired()
         {
-            Assert.AreEqual(0, _disconnectedRegister.Count);
+            Assert.IsEmpty(_disconnectedRegister);
         }
 
         [TestMethod]
         public void ErrorOccurredHasNeverFired()
         {
-            Assert.AreEqual(0, _errorOccurredRegister.Count);
+            Assert.IsEmpty(_errorOccurredRegister);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_SendData_Connected.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_SendData_Connected.cs
@@ -69,13 +69,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void DisconnectHasNeverFired()
         {
-            Assert.AreEqual(0, _disconnectedRegister.Count);
+            Assert.IsEmpty(_disconnectedRegister);
         }
 
         [TestMethod]
         public void ErrorOccurredHasNeverFired()
         {
-            Assert.AreEqual(0, _errorOccurredRegister.Count);
+            Assert.IsEmpty(_errorOccurredRegister);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_SendData_Disposed.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_SendData_Disposed.cs
@@ -82,13 +82,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void DisconnectHasNeverFired()
         {
-            Assert.AreEqual(0, _disconnectedRegister.Count);
+            Assert.IsEmpty(_disconnectedRegister);
         }
 
         [TestMethod]
         public void ErrorOccurredHasNeverFired()
         {
-            Assert.AreEqual(0, _errorOccurredRegister.Count);
+            Assert.IsEmpty(_errorOccurredRegister);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Classes/SubsystemSession_SendData_NeverConnected.cs
+++ b/test/Renci.SshNet.Tests/Classes/SubsystemSession_SendData_NeverConnected.cs
@@ -83,13 +83,13 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public void DisconnectHasNeverFired()
         {
-            Assert.AreEqual(0, _disconnectedRegister.Count);
+            Assert.IsEmpty(_disconnectedRegister);
         }
 
         [TestMethod]
         public void ErrorOccurredHasNeverFired()
         {
-            Assert.AreEqual(0, _errorOccurredRegister.Count);
+            Assert.IsEmpty(_errorOccurredRegister);
         }
 
         [TestMethod]

--- a/test/Renci.SshNet.Tests/Common/TestMethodForPlatformAttribute.cs
+++ b/test/Renci.SshNet.Tests/Common/TestMethodForPlatformAttribute.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -8,18 +10,18 @@ namespace Renci.SshNet.Tests.Common
     [AttributeUsage(AttributeTargets.Method)]
     public sealed class TestMethodForPlatformAttribute : TestMethodAttribute
     {
-        public TestMethodForPlatformAttribute(string platform)
+        public TestMethodForPlatformAttribute(string platform, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1) : base(callerFilePath, callerLineNumber)
         {
             Platform = platform;
         }
 
         public string Platform { get; }
 
-        public override TestResult[] Execute(ITestMethod testMethod)
+        public override async Task<TestResult[]> ExecuteAsync(ITestMethod testMethod)
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Create(Platform)))
             {
-                return base.Execute(testMethod);
+                return await base.ExecuteAsync(testMethod);
             }
 
             var message = $"Test not executed. The test is intended for the '{Platform}' platform only.";

--- a/test/Renci.SshNet.Tests/Properties/AssemblyInfo.cs
+++ b/test/Renci.SshNet.Tests/Properties/AssemblyInfo.cs
@@ -1,5 +1,10 @@
-﻿#if NET
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+#if NET
 using System.Diagnostics.CodeAnalysis;
+
 
 [assembly: ExcludeFromCodeCoverage]
 #endif // NET
+
+[assembly: DoNotParallelize]


### PR DESCRIPTION
MSTest 4 has quite a few new asserts, analyzers and breaking changes, see https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-migration-v3-v4 .

Most of these were automatically fixed by the code fixer, see separate commits.

The update also triggered new sonar analyzer warnings, which seems to a bug in sonar, see https://github.com/SonarSource/sonar-dotnet/issues/9767 . I suppressed these for now.