### PR TITLE
Replace SftpFileStream with Stream in ISftpClient method signatures.

### DIFF
--- a/src/Renci.SshNet/ISftpClient.cs
+++ b/src/Renci.SshNet/ISftpClient.cs
@@ -389,7 +389,7 @@ namespace Renci.SshNet
         /// </summary>
         /// <param name="path">The path and name of the file to create.</param>
         /// <returns>
-        /// A <see cref="SftpFileStream"/> that provides read/write access to the file specified in path.
+        /// A <see cref="Stream"/> that provides read/write access to the file specified in path.
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/>.</exception>
         /// <exception cref="SshConnectionException">Client is not connected.</exception>
@@ -398,7 +398,7 @@ namespace Renci.SshNet
         /// <remarks>
         /// If the target file already exists, it is first truncated to zero bytes.
         /// </remarks>
-        SftpFileStream Create(string path);
+        Stream Create(string path);
 
         /// <summary>
         /// Creates or overwrites the specified file.
@@ -406,7 +406,7 @@ namespace Renci.SshNet
         /// <param name="path">The path and name of the file to create.</param>
         /// <param name="bufferSize">The maximum number of bytes buffered for reads and writes to the file.</param>
         /// <returns>
-        /// A <see cref="SftpFileStream"/> that provides read/write access to the file specified in path.
+        /// A <see cref="Stream"/> that provides read/write access to the file specified in path.
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/>.</exception>
         /// <exception cref="SshConnectionException">Client is not connected.</exception>
@@ -415,7 +415,7 @@ namespace Renci.SshNet
         /// <remarks>
         /// If the target file already exists, it is first truncated to zero bytes.
         /// </remarks>
-        SftpFileStream Create(string path, int bufferSize);
+        Stream Create(string path, int bufferSize);
 
         /// <summary>
         /// Creates remote directory specified by path.
@@ -817,59 +817,59 @@ namespace Renci.SshNet
         IAsyncEnumerable<ISftpFile> ListDirectoryAsync(string path, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Opens a <see cref="SftpFileStream"/> on the specified path with read/write access.
+        /// Opens a <see cref="Stream"/> on the specified path with read/write access.
         /// </summary>
         /// <param name="path">The file to open.</param>
         /// <param name="mode">A <see cref="FileMode"/> value that specifies whether a file is created if one does not exist, and determines whether the contents of existing files are retained or overwritten.</param>
         /// <returns>
-        /// An unshared <see cref="SftpFileStream"/> that provides access to the specified file, with the specified mode and read/write access.
+        /// An unshared <see cref="Stream"/> that provides access to the specified file, with the specified mode and read/write access.
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/>.</exception>
         /// <exception cref="SshConnectionException">Client is not connected.</exception>
         /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
-        SftpFileStream Open(string path, FileMode mode);
+        Stream Open(string path, FileMode mode);
 
         /// <summary>
-        /// Opens a <see cref="SftpFileStream"/> on the specified path, with the specified mode and access.
+        /// Opens a <see cref="Stream"/> on the specified path, with the specified mode and access.
         /// </summary>
         /// <param name="path">The file to open.</param>
         /// <param name="mode">A <see cref="FileMode"/> value that specifies whether a file is created if one does not exist, and determines whether the contents of existing files are retained or overwritten.</param>
         /// <param name="access">A <see cref="FileAccess"/> value that specifies the operations that can be performed on the file.</param>
         /// <returns>
-        /// An unshared <see cref="SftpFileStream"/> that provides access to the specified file, with the specified mode and access.
+        /// An unshared <see cref="Stream"/> that provides access to the specified file, with the specified mode and access.
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/>.</exception>
         /// <exception cref="SshConnectionException">Client is not connected.</exception>
         /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
-        SftpFileStream Open(string path, FileMode mode, FileAccess access);
+        Stream Open(string path, FileMode mode, FileAccess access);
 
         /// <summary>
-        /// Asynchronously opens a <see cref="SftpFileStream"/> on the specified path, with the specified mode and access.
+        /// Asynchronously opens a <see cref="Stream"/> on the specified path, with the specified mode and access.
         /// </summary>
         /// <param name="path">The file to open.</param>
         /// <param name="mode">A <see cref="FileMode"/> value that specifies whether a file is created if one does not exist, and determines whether the contents of existing files are retained or overwritten.</param>
         /// <param name="access">A <see cref="FileAccess"/> value that specifies the operations that can be performed on the file.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to observe.</param>
         /// <returns>
-        /// A <see cref="Task{SftpFileStream}"/> that represents the asynchronous open operation.
-        /// The task result contains the <see cref="SftpFileStream"/> that provides access to the specified file, with the specified mode and access.
+        /// A <see cref="Task{Stream}"/> that represents the asynchronous open operation.
+        /// The task result contains the <see cref="Stream"/> that provides access to the specified file, with the specified mode and access.
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/>.</exception>
         /// <exception cref="SshConnectionException">Client is not connected.</exception>
         /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
-        Task<SftpFileStream> OpenAsync(string path, FileMode mode, FileAccess access, CancellationToken cancellationToken);
+        Task<Stream> OpenAsync(string path, FileMode mode, FileAccess access, CancellationToken cancellationToken);
 
         /// <summary>
         /// Opens an existing file for reading.
         /// </summary>
         /// <param name="path">The file to be opened for reading.</param>
         /// <returns>
-        /// A read-only <see cref="SftpFileStream"/> on the specified path.
+        /// A read-only <see cref="Stream"/> on the specified path.
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/>.</exception>
         /// <exception cref="SshConnectionException">Client is not connected.</exception>
         /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
-        SftpFileStream OpenRead(string path);
+        Stream OpenRead(string path);
 
         /// <summary>
         /// Opens an existing UTF-8 encoded text file for reading.
@@ -888,7 +888,7 @@ namespace Renci.SshNet
         /// </summary>
         /// <param name="path">The file to be opened for writing.</param>
         /// <returns>
-        /// An unshared <see cref="SftpFileStream"/> object on the specified path with <see cref="FileAccess.Write"/> access.
+        /// An unshared <see cref="Stream"/> object on the specified path with <see cref="FileAccess.Write"/> access.
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/>.</exception>
         /// <exception cref="SshConnectionException">Client is not connected.</exception>
@@ -896,7 +896,7 @@ namespace Renci.SshNet
         /// <remarks>
         /// If the file does not exist, it is created.
         /// </remarks>
-        SftpFileStream OpenWrite(string path);
+        Stream OpenWrite(string path);
 
         /// <summary>
         /// Opens a binary file, reads the contents of the file into a byte array, and closes the file.

--- a/src/Renci.SshNet/SftpClient.cs
+++ b/src/Renci.SshNet/SftpClient.cs
@@ -1457,7 +1457,7 @@ namespace Renci.SshNet
         /// </summary>
         /// <param name="path">The path and name of the file to create.</param>
         /// <returns>
-        /// A <see cref="SftpFileStream"/> that provides read/write access to the file specified in path.
+        /// A <see cref="Stream"/> that provides read/write access to the file specified in path.
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/>.</exception>
         /// <exception cref="SshConnectionException">Client is not connected.</exception>
@@ -1466,7 +1466,7 @@ namespace Renci.SshNet
         /// <remarks>
         /// If the target file already exists, it is first truncated to zero bytes.
         /// </remarks>
-        public SftpFileStream Create(string path)
+        public Stream Create(string path)
         {
             return Create(path, (int)_bufferSize);
         }
@@ -1477,7 +1477,7 @@ namespace Renci.SshNet
         /// <param name="path">The path and name of the file to create.</param>
         /// <param name="bufferSize">The maximum number of bytes buffered for reads and writes to the file.</param>
         /// <returns>
-        /// A <see cref="SftpFileStream"/> that provides read/write access to the file specified in path.
+        /// A <see cref="Stream"/> that provides read/write access to the file specified in path.
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/>.</exception>
         /// <exception cref="SshConnectionException">Client is not connected.</exception>
@@ -1486,7 +1486,7 @@ namespace Renci.SshNet
         /// <remarks>
         /// If the target file already exists, it is first truncated to zero bytes.
         /// </remarks>
-        public SftpFileStream Create(string path, int bufferSize)
+        public Stream Create(string path, int bufferSize)
         {
             CheckDisposed();
 
@@ -1597,34 +1597,34 @@ namespace Renci.SshNet
         }
 
         /// <summary>
-        /// Opens a <see cref="SftpFileStream"/> on the specified path with read/write access.
+        /// Opens a <see cref="Stream"/> on the specified path with read/write access.
         /// </summary>
         /// <param name="path">The file to open.</param>
         /// <param name="mode">A <see cref="FileMode"/> value that specifies whether a file is created if one does not exist, and determines whether the contents of existing files are retained or overwritten.</param>
         /// <returns>
-        /// An unshared <see cref="SftpFileStream"/> that provides access to the specified file, with the specified mode and read/write access.
+        /// An unshared <see cref="Stream"/> that provides access to the specified file, with the specified mode and read/write access.
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/>.</exception>
         /// <exception cref="SshConnectionException">Client is not connected.</exception>
         /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
-        public SftpFileStream Open(string path, FileMode mode)
+        public Stream Open(string path, FileMode mode)
         {
             return Open(path, mode, FileAccess.ReadWrite);
         }
 
         /// <summary>
-        /// Opens a <see cref="SftpFileStream"/> on the specified path, with the specified mode and access.
+        /// Opens a <see cref="Stream"/> on the specified path, with the specified mode and access.
         /// </summary>
         /// <param name="path">The file to open.</param>
         /// <param name="mode">A <see cref="FileMode"/> value that specifies whether a file is created if one does not exist, and determines whether the contents of existing files are retained or overwritten.</param>
         /// <param name="access">A <see cref="FileAccess"/> value that specifies the operations that can be performed on the file.</param>
         /// <returns>
-        /// An unshared <see cref="SftpFileStream"/> that provides access to the specified file, with the specified mode and access.
+        /// An unshared <see cref="Stream"/> that provides access to the specified file, with the specified mode and access.
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/>.</exception>
         /// <exception cref="SshConnectionException">Client is not connected.</exception>
         /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
-        public SftpFileStream Open(string path, FileMode mode, FileAccess access)
+        public Stream Open(string path, FileMode mode, FileAccess access)
         {
             CheckDisposed();
 
@@ -1632,24 +1632,24 @@ namespace Renci.SshNet
         }
 
         /// <summary>
-        /// Asynchronously opens a <see cref="SftpFileStream"/> on the specified path, with the specified mode and access.
+        /// Asynchronously opens a <see cref="Stream"/> on the specified path, with the specified mode and access.
         /// </summary>
         /// <param name="path">The file to open.</param>
         /// <param name="mode">A <see cref="FileMode"/> value that specifies whether a file is created if one does not exist, and determines whether the contents of existing files are retained or overwritten.</param>
         /// <param name="access">A <see cref="FileAccess"/> value that specifies the operations that can be performed on the file.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to observe.</param>
         /// <returns>
-        /// A <see cref="Task{SftpFileStream}"/> that represents the asynchronous open operation.
-        /// The task result contains the <see cref="SftpFileStream"/> that provides access to the specified file, with the specified mode and access.
+        /// A <see cref="Task{Stream}"/> that represents the asynchronous open operation.
+        /// The task result contains the <see cref="Stream"/> that provides access to the specified file, with the specified mode and access.
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/>.</exception>
         /// <exception cref="SshConnectionException">Client is not connected.</exception>
         /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
-        public Task<SftpFileStream> OpenAsync(string path, FileMode mode, FileAccess access, CancellationToken cancellationToken)
+        public async Task<Stream> OpenAsync(string path, FileMode mode, FileAccess access, CancellationToken cancellationToken)
         {
             CheckDisposed();
 
-            return SftpFileStream.OpenAsync(_sftpSession, path, mode, access, (int)_bufferSize, cancellationToken);
+            return await SftpFileStream.OpenAsync(_sftpSession, path, mode, access, (int)_bufferSize, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1657,12 +1657,12 @@ namespace Renci.SshNet
         /// </summary>
         /// <param name="path">The file to be opened for reading.</param>
         /// <returns>
-        /// A read-only <see cref="SftpFileStream"/> on the specified path.
+        /// A read-only <see cref="Stream"/> on the specified path.
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/>.</exception>
         /// <exception cref="SshConnectionException">Client is not connected.</exception>
         /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
-        public SftpFileStream OpenRead(string path)
+        public Stream OpenRead(string path)
         {
             return Open(path, FileMode.Open, FileAccess.Read);
         }
@@ -1687,7 +1687,7 @@ namespace Renci.SshNet
         /// </summary>
         /// <param name="path">The file to be opened for writing.</param>
         /// <returns>
-        /// An unshared <see cref="SftpFileStream"/> object on the specified path with <see cref="FileAccess.Write"/> access.
+        /// An unshared <see cref="Stream"/> object on the specified path with <see cref="FileAccess.Write"/> access.
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/>.</exception>
         /// <exception cref="SshConnectionException">Client is not connected.</exception>
@@ -1695,7 +1695,7 @@ namespace Renci.SshNet
         /// <remarks>
         /// If the file does not exist, it is created.
         /// </remarks>
-        public SftpFileStream OpenWrite(string path)
+        public Stream OpenWrite(string path)
         {
             return Open(path, FileMode.OpenOrCreate, FileAccess.Write);
         }

--- a/test/Renci.SshNet.IntegrationTests/SftpTests.cs
+++ b/test/Renci.SshNet.IntegrationTests/SftpTests.cs
@@ -256,7 +256,7 @@ namespace Renci.SshNet.IntegrationTests
                     client.DeleteFile(remoteFile);
                 }
 
-                SftpFileStream fs = null;
+                Stream fs = null;
 
                 try
                 {
@@ -4000,8 +4000,8 @@ namespace Renci.SshNet.IntegrationTests
 #endif
 
         private void TestReadAndWrite(
-            Func<SftpFileStream, byte[], int, int, int> read,
-            Action<SftpFileStream, byte[], int, int> write)
+            Func<Stream, byte[], int, int, int> read,
+            Action<Stream, byte[], int, int> write)
         {
             using (var client = new SftpClient(_connectionInfoFactory.Create()))
             {
@@ -4107,14 +4107,14 @@ namespace Renci.SshNet.IntegrationTests
                 }
             }
 
-            int ReadByte(SftpFileStream s)
+            int ReadByte(Stream s)
             {
                 var buffer = new byte[1];
                 var bytesRead = read(s, buffer, 0, 1);
                 return bytesRead == 0 ? -1 : buffer[0];
             }
 
-            void WriteByte(SftpFileStream s, byte b)
+            void WriteByte(Stream s, byte b)
             {
                 write(s, [b], 0, 1);
             }

--- a/test/Renci.SshNet.Tests/Classes/SftpClientTest_AsyncExceptions.cs
+++ b/test/Renci.SshNet.Tests/Classes/SftpClientTest_AsyncExceptions.cs
@@ -65,7 +65,7 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public async Task Async_ObservesSessionDisconnected()
         {
-            Task<SftpFileStream> openTask = _client.OpenAsync("path", FileMode.Create, FileAccess.Write, CancellationToken.None);
+            var openTask = _client.OpenAsync("path", FileMode.Create, FileAccess.Write, CancellationToken.None);
 
             Assert.IsFalse(openTask.IsCompleted);
 
@@ -78,7 +78,7 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public async Task Async_ObservesChannelClosed()
         {
-            Task<SftpFileStream> openTask = _client.OpenAsync("path", FileMode.Create, FileAccess.Write, CancellationToken.None);
+            var openTask = _client.OpenAsync("path", FileMode.Create, FileAccess.Write, CancellationToken.None);
 
             Assert.IsFalse(openTask.IsCompleted);
 
@@ -93,7 +93,7 @@ namespace Renci.SshNet.Tests.Classes
         {
             using CancellationTokenSource cts = new();
 
-            Task<SftpFileStream> openTask = _client.OpenAsync("path", FileMode.Create, FileAccess.Write, cts.Token);
+            var openTask = _client.OpenAsync("path", FileMode.Create, FileAccess.Write, cts.Token);
 
             Assert.IsFalse(openTask.IsCompleted);
 
@@ -108,7 +108,7 @@ namespace Renci.SshNet.Tests.Classes
         {
             _client.OperationTimeout = TimeSpan.FromMilliseconds(250);
 
-            Task<SftpFileStream> openTask = _client.OpenAsync("path", FileMode.Create, FileAccess.Write, CancellationToken.None);
+            var openTask = _client.OpenAsync("path", FileMode.Create, FileAccess.Write, CancellationToken.None);
 
             var ex = await Assert.ThrowsExactlyAsync<SshOperationTimeoutException>(() => openTask);
         }
@@ -116,7 +116,7 @@ namespace Renci.SshNet.Tests.Classes
         [TestMethod]
         public async Task Async_ObservesErrorOccurred()
         {
-            Task<SftpFileStream> openTask = _client.OpenAsync("path", FileMode.Create, FileAccess.Write, CancellationToken.None);
+            var openTask = _client.OpenAsync("path", FileMode.Create, FileAccess.Write, CancellationToken.None);
 
             Assert.IsFalse(openTask.IsCompleted);
 


### PR DESCRIPTION
I'm opening this PR to initiate discussion around solutions for #1691. The solution implemented here solves #1691 because it is relatively easy to mock a method that returns `Stream`. However, this solution prevents access to the `Timeout` property of `SftpFileStream`. It is also not binary-backwards-compatible but somewhat source-backwards-compatible.