### PR TITLE
Truncate local file in ScpClient.Download

### DIFF
--- a/src/Renci.SshNet/ScpClient.cs
+++ b/src/Renci.SshNet/ScpClient.cs
@@ -831,7 +831,7 @@ namespace Renci.SshNet
                         fileInfo = new FileInfo(Path.Combine(currentDirectoryFullName, fileName));
                     }
 
-                    using (var output = fileInfo.OpenWrite())
+                    using (var output = fileInfo.Open(FileMode.Create, FileAccess.Write))
                     {
                         InternalDownload(channel, input, output, fileName, length);
                     }

--- a/test/Renci.SshNet.IntegrationTests/ScpTests.cs
+++ b/test/Renci.SshNet.IntegrationTests/ScpTests.cs
@@ -679,7 +679,8 @@ namespace Renci.SshNet.IntegrationTests
                 }
             }
 
-            var fileInfo = new FileInfo(Path.GetTempFileName());
+            // Create a local file larger than the remote file in order to test truncation.
+            var fileInfo = new FileInfo(CreateTempFile(size + 64));
 
             try
             {


### PR DESCRIPTION
Similar to #1686 but for the local side of SCP: opening the file should use Create not OpenWrite.

closes #648