### PR TITLE
Rent buffers used in SFTP reads

### DIFF
--- a/src/Renci.SshNet/Common/Extensions.cs
+++ b/src/Renci.SshNet/Common/Extensions.cs
@@ -417,6 +417,14 @@ namespace Renci.SshNet.Common
                 return await completedTask.ConfigureAwait(false);
             }
         }
+
+        extension(Task t)
+        {
+            internal bool IsCompletedSuccessfully
+            {
+                get { return t.Status == TaskStatus.RanToCompletion; }
+            }
+        }
 #endif
     }
 }

--- a/src/Renci.SshNet/Common/ReadOnlyMemoryOwner.cs
+++ b/src/Renci.SshNet/Common/ReadOnlyMemoryOwner.cs
@@ -1,0 +1,87 @@
+﻿#nullable enable
+using System;
+using System.Buffers;
+using System.Diagnostics;
+using System.Net;
+
+namespace Renci.SshNet.Common
+{
+    /// <summary>
+    /// A type representing ownership of a rented, read-only buffer.
+    /// </summary>
+    internal sealed class ReadOnlyMemoryOwner : IMemoryOwner<byte>
+    {
+        private ArrayBuffer _buffer;
+
+        public ReadOnlyMemoryOwner(ArrayBuffer buffer)
+        {
+            _buffer = buffer;
+
+            AssertValid();
+        }
+
+        [Conditional("DEBUG")]
+        private void AssertValid()
+        {
+            Debug.Assert(
+                _buffer.ActiveLength > 0 || _buffer.AvailableLength == 0,
+                "If the buffer is empty, then it should have been returned to the pool.");
+        }
+
+        public int Length
+        {
+            get
+            {
+                AssertValid();
+                return _buffer.ActiveLength;
+            }
+        }
+
+        public bool IsEmpty
+        {
+            get
+            {
+                AssertValid();
+                return _buffer.ActiveLength == 0;
+            }
+        }
+
+        public ReadOnlySpan<byte> Span
+        {
+            get
+            {
+                AssertValid();
+                return _buffer.ActiveReadOnlySpan;
+            }
+        }
+
+        Memory<byte> IMemoryOwner<byte>.Memory
+        {
+            get
+            {
+                AssertValid();
+                return _buffer.ActiveMemory;
+            }
+        }
+
+        public void Slice(int start)
+        {
+            AssertValid();
+
+            _buffer.Discard(start);
+
+            if (_buffer.ActiveLength == 0)
+            {
+                // Return the rented buffer as soon as it's no longer in use.
+                _buffer.ClearAndReturnBuffer();
+            }
+        }
+
+        public void Dispose()
+        {
+            AssertValid();
+
+            _buffer.ClearAndReturnBuffer();
+        }
+    }
+}

--- a/src/Renci.SshNet/Sftp/ISftpSession.cs
+++ b/src/Renci.SshNet/Sftp/ISftpSession.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Renci.SshNet.Common;
 using Renci.SshNet.Sftp.Responses;
 
 namespace Renci.SshNet.Sftp
@@ -198,7 +199,7 @@ namespace Renci.SshNet.Sftp
         /// its <see cref="Task{Task}.Result"/> contains the data read from the file, or an empty
         /// array when the end of the file is reached.
         /// </returns>
-        Task<byte[]> RequestReadAsync(byte[] handle, ulong offset, uint length, CancellationToken cancellationToken);
+        Task<ReadOnlyMemoryOwner> RequestReadAsync(byte[] handle, ulong offset, uint length, CancellationToken cancellationToken);
 
         /// <summary>
         /// Performs a <c>SSH_FXP_READDIR</c> request.

--- a/src/Renci.SshNet/Sftp/Responses/SftpDataResponse.cs
+++ b/src/Renci.SshNet/Sftp/Responses/SftpDataResponse.cs
@@ -1,4 +1,6 @@
-﻿namespace Renci.SshNet.Sftp.Responses
+﻿using System;
+
+namespace Renci.SshNet.Sftp.Responses
 {
     internal sealed class SftpDataResponse : SftpResponse
     {
@@ -7,7 +9,7 @@
             get { return SftpMessageTypes.Data; }
         }
 
-        public byte[] Data { get; set; }
+        public ArraySegment<byte> Data { get; set; }
 
         public SftpDataResponse(uint protocolVersion)
             : base(protocolVersion)
@@ -18,14 +20,14 @@
         {
             base.LoadData();
 
-            Data = ReadBinary();
+            Data = ReadBinarySegment();
         }
 
         protected override void SaveData()
         {
             base.SaveData();
 
-            WriteBinary(Data, 0, Data.Length);
+            WriteBinary(Data.Array, Data.Offset, Data.Count);
         }
     }
 }

--- a/src/Renci.SshNet/Sftp/SftpFileReader.cs
+++ b/src/Renci.SshNet/Sftp/SftpFileReader.cs
@@ -6,9 +6,7 @@ using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-#if !NET
 using Renci.SshNet.Common;
-#endif
 
 namespace Renci.SshNet.Sftp
 {
@@ -58,7 +56,7 @@ namespace Renci.SshNet.Sftp
                 _cts = new CancellationTokenSource();
             }
 
-            public async Task<byte[]> ReadAsync(CancellationToken cancellationToken)
+            public async Task<ReadOnlyMemoryOwner> ReadAsync(CancellationToken cancellationToken)
             {
                 _exception?.Throw();
 
@@ -172,14 +170,21 @@ namespace Renci.SshNet.Sftp
 
                 if (_requests.Count > 0)
                 {
-                    // Cancel outstanding requests and observe the exception on them
-                    // as an effort to prevent unhandled exceptions.
-
                     _cts.Cancel();
 
                     foreach (var request in _requests.Values)
                     {
-                        _ = request.Task.Exception;
+                        // Return rented buffers to the pool, or observe exception on
+                        // the task as an effort to prevent unhandled exceptions.
+
+                        if (request.Task.IsCompletedSuccessfully)
+                        {
+                            request.Task.GetAwaiter().GetResult().Dispose();
+                        }
+                        else
+                        {
+                            _ = request.Task.Exception;
+                        }
                     }
 
                     _requests.Clear();
@@ -190,7 +195,7 @@ namespace Renci.SshNet.Sftp
 
             private sealed class Request
             {
-                public Request(ulong offset, uint count, Task<byte[]> task)
+                public Request(ulong offset, uint count, Task<ReadOnlyMemoryOwner> task)
                 {
                     Offset = offset;
                     Count = count;
@@ -199,7 +204,7 @@ namespace Renci.SshNet.Sftp
 
                 public ulong Offset { get; }
                 public uint Count { get; }
-                public Task<byte[]> Task { get; }
+                public Task<ReadOnlyMemoryOwner> Task { get; }
             }
         }
     }

--- a/src/Renci.SshNet/Sftp/SftpFileStream.cs
+++ b/src/Renci.SshNet/Sftp/SftpFileStream.cs
@@ -26,7 +26,7 @@ namespace Renci.SshNet.Sftp
         private readonly int _readBufferSize;
 
         private SftpFileReader? _sftpFileReader;
-        private ReadOnlyMemory<byte> _readBuffer;
+        private ReadOnlyMemoryOwner _readBuffer;
         private System.Net.ArrayBuffer _writeBuffer;
 
         private long _position;
@@ -153,6 +153,7 @@ namespace Renci.SshNet.Sftp
             _readBufferSize = readBufferSize;
             _position = position;
             _writeBuffer = new System.Net.ArrayBuffer(writeBufferSize);
+            _readBuffer = new ReadOnlyMemoryOwner(new System.Net.ArrayBuffer(0, usePool: true));
             _sftpFileReader = initialReader;
         }
 
@@ -390,7 +391,7 @@ namespace Renci.SshNet.Sftp
 
         private void InvalidateReads()
         {
-            _readBuffer = ReadOnlyMemory<byte>.Empty;
+            _readBuffer.Dispose();
             _sftpFileReader?.Dispose();
             _sftpFileReader = null;
         }
@@ -441,7 +442,7 @@ namespace Renci.SshNet.Sftp
             var bytesRead = Math.Min(buffer.Length, _readBuffer.Length);
 
             _readBuffer.Span.Slice(0, bytesRead).CopyTo(buffer);
-            _readBuffer = _readBuffer.Slice(bytesRead);
+            _readBuffer.Slice(bytesRead);
 
             _position += bytesRead;
 
@@ -494,8 +495,8 @@ namespace Renci.SshNet.Sftp
 
             var bytesRead = Math.Min(buffer.Length, _readBuffer.Length);
 
-            _readBuffer.Slice(0, bytesRead).CopyTo(buffer);
-            _readBuffer = _readBuffer.Slice(bytesRead);
+            _readBuffer.Span.Slice(0, bytesRead).CopyTo(buffer.Span);
+            _readBuffer.Slice(bytesRead);
 
             _position += bytesRead;
 
@@ -649,7 +650,7 @@ namespace Renci.SshNet.Sftp
 
             if (readBufferStart <= newPosition && newPosition <= readBufferEnd)
             {
-                _readBuffer = _readBuffer.Slice((int)(newPosition - readBufferStart));
+                _readBuffer.Slice((int)(newPosition - readBufferStart));
             }
             else
             {

--- a/src/Renci.SshNet/Sftp/SftpSession.cs
+++ b/src/Renci.SshNet/Sftp/SftpSession.cs
@@ -3,6 +3,7 @@ using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,7 +25,7 @@ namespace Renci.SshNet.Sftp
         private readonly Dictionary<uint, SftpRequest> _requests = new Dictionary<uint, SftpRequest>();
         private readonly ISftpResponseFactory _sftpResponseFactory;
         private readonly Encoding _encoding;
-        private System.Net.ArrayBuffer _buffer = new(32 * 1024);
+        private ArrayBuffer _buffer = new(32 * 1024);
         private EventWaitHandle _sftpVersionConfirmed = new AutoResetEvent(initialState: false);
         private IDictionary<string, string> _supportedExtensions;
 
@@ -495,7 +496,7 @@ namespace Renci.SshNet.Sftp
                                                   length,
                                                   response =>
                                                   {
-                                                      data = response.Data;
+                                                      data = response.Data.ToArray();
                                                       wait.SetIgnoringObjectDisposed();
                                                   },
                                                   response =>
@@ -526,28 +527,42 @@ namespace Renci.SshNet.Sftp
         }
 
         /// <inheritdoc/>
-        public Task<byte[]> RequestReadAsync(byte[] handle, ulong offset, uint length, CancellationToken cancellationToken)
+        public Task<ReadOnlyMemoryOwner> RequestReadAsync(byte[] handle, ulong offset, uint length, CancellationToken cancellationToken)
         {
             Debug.Assert(length > 0, "This implementation cannot distinguish between EOF and zero-length reads");
 
             if (cancellationToken.IsCancellationRequested)
             {
-                return Task.FromCanceled<byte[]>(cancellationToken);
+                return Task.FromCanceled<ReadOnlyMemoryOwner>(cancellationToken);
             }
 
-            var tcs = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource<ReadOnlyMemoryOwner>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             SendRequest(new SftpReadRequest(ProtocolVersion,
                                             NextRequestId,
                                             handle,
                                             offset,
                                             length,
-                                            response => tcs.TrySetResult(response.Data),
+                                            response =>
+                                            {
+                                                ArrayBuffer buffer = new(response.Data.Count, usePool: true);
+
+                                                response.Data.AsSpan().CopyTo(buffer.AvailableSpan);
+
+                                                buffer.Commit(response.Data.Count);
+
+                                                ReadOnlyMemoryOwner owner = new(buffer);
+
+                                                if (!tcs.TrySetResult(owner))
+                                                {
+                                                    owner.Dispose();
+                                                }
+                                            },
                                             response =>
                                             {
                                                 if (response.StatusCode == StatusCode.Eof)
                                                 {
-                                                    _ = tcs.TrySetResult(Array.Empty<byte>());
+                                                    _ = tcs.TrySetResult(new(new(0, usePool: true)));
                                                 }
                                                 else
                                                 {

--- a/test/Renci.SshNet.Tests/Classes/Sftp/Responses/SftpDataResponseTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/Responses/SftpDataResponseTest.cs
@@ -32,7 +32,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Responses
         {
             var target = new SftpDataResponse(_protocolVersion);
 
-            Assert.IsNull(target.Data);
+            Assert.AreEqual(default, target.Data);
             Assert.AreEqual(_protocolVersion, target.ProtocolVersion);
             Assert.AreEqual((uint)0, target.ResponseId);
             Assert.AreEqual(SftpMessageTypes.Data, target.SftpMessageType);
@@ -52,7 +52,6 @@ namespace Renci.SshNet.Tests.Classes.Sftp.Responses
 
             target.Load(sshData);
 
-            Assert.IsNotNull(target.Data);
             Assert.IsTrue(target.Data.SequenceEqual(_data));
             Assert.AreEqual(_protocolVersion, target.ProtocolVersion);
             Assert.AreEqual(_responseId, target.ResponseId);

--- a/test/Renci.SshNet.Tests/Classes/Sftp/SftpDataResponseBuilder.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/SftpDataResponseBuilder.cs
@@ -1,4 +1,6 @@
-﻿using Renci.SshNet.Sftp.Responses;
+﻿using System;
+
+using Renci.SshNet.Sftp.Responses;
 
 namespace Renci.SshNet.Tests.Classes.Sftp
 {
@@ -31,7 +33,7 @@ namespace Renci.SshNet.Tests.Classes.Sftp
             return new SftpDataResponse(_protocolVersion)
             {
                 ResponseId = _responseId,
-                Data = _data
+                Data = new ArraySegment<byte>(_data)
             };
         }
     }

--- a/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/SftpFileStreamTest.cs
@@ -217,6 +217,10 @@ namespace Renci.SshNet.Tests.Classes.Sftp
             sessionMock.Setup(s => s.CalculateOptimalReadLength(It.IsAny<uint>())).Returns<uint>(x => x);
             sessionMock.Setup(s => s.CalculateOptimalWriteLength(It.IsAny<uint>(), It.IsAny<byte[]>())).Returns<uint, byte[]>((x, _) => x);
             sessionMock.Setup(s => s.IsOpen).Returns(true);
+            sessionMock
+                .Setup(s => s.RequestReadAsync(It.IsAny<byte[]>(), It.IsAny<ulong>(), It.IsAny<uint>(), It.IsAny<CancellationToken>()))
+                .Returns<byte[], ulong, uint, CancellationToken>((_, _, _, _) => Task.FromResult(new ReadOnlyMemoryOwner(new(0, usePool: true))));
+
             SetupRemoteSize(sessionMock, 0);
 
             var s = SftpFileStream.Open(sessionMock.Object, "file.txt", FileMode.OpenOrCreate, FileAccess.ReadWrite, bufferSize: 1024);
@@ -301,6 +305,9 @@ namespace Renci.SshNet.Tests.Classes.Sftp
             sessionMock.Setup(s => s.CalculateOptimalWriteLength(It.IsAny<uint>(), It.IsAny<byte[]>())).Returns<uint, byte[]>((x, _) => x);
             sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
             sessionMock.Setup(s => s.IsOpen).Returns(true);
+            sessionMock
+                .Setup(s => s.RequestReadAsync(It.IsAny<byte[]>(), It.IsAny<ulong>(), It.IsAny<uint>(), It.IsAny<CancellationToken>()))
+                .Returns<byte[], ulong, uint, CancellationToken>((_, _, _, _) => Task.FromResult(new ReadOnlyMemoryOwner(new(0, usePool: true))));
 
             fstatSetup(sessionMock.Setup(s => s.RequestFStat(It.IsAny<byte[]>())));
 

--- a/test/Renci.SshNet.Tests/Classes/Sftp/SftpSessionTest_DataReceived_MultipleSftpMessagesInSingleSshDataMessage.cs
+++ b/test/Renci.SshNet.Tests/Classes/Sftp/SftpSessionTest_DataReceived_MultipleSftpMessagesInSingleSshDataMessage.cs
@@ -187,12 +187,14 @@ namespace Renci.SshNet.Tests.Classes.Sftp
         protected void Act()
         {
             Task<byte[]> openTask = _sftpSession.RequestOpenAsync(_path, Flags.Read, CancellationToken.None);
-            Task<byte[]> readTask = _sftpSession.RequestReadAsync(_handle, _offset, _length, CancellationToken.None);
+            Task<ReadOnlyMemoryOwner> readTask = _sftpSession.RequestReadAsync(_handle, _offset, _length, CancellationToken.None);
 
             Task.WaitAll(openTask, readTask);
 
             _actualHandle = openTask.Result;
-            _actualData = readTask.Result;
+
+            using ReadOnlyMemoryOwner actualData = readTask.Result;
+            _actualData = actualData.Span.ToArray();
         }
 
         [TestMethod]


### PR DESCRIPTION
An SFTP download performs several reads from the server in parallel, allocating an array to store each result until it's ready to be consumed. Since these buffers are short-lived and normally of the same large-ish size (32KB), it seems like a good candidate for pooling.

In a test download, I see 3 or 4 such buffers allocated in the pool (~100KB), instead of e.g. 1MB or 8MB of arrays allocated (corresponding to the size of the file) at this layer.