### PR TITLE
Add ability to send posix/ansi signals in SshCommand

### DIFF
--- a/src/Renci.SshNet/CommandSignal.cs
+++ b/src/Renci.SshNet/CommandSignal.cs
@@ -1,0 +1,74 @@
+﻿namespace Renci.SshNet
+{
+    /// <summary>
+    /// The ssh compatible POSIX/ANSI signals with their libc compatible values.
+    /// </summary>
+#pragma warning disable CA1720 // Identifier contains type name
+    public enum CommandSignal
+    {
+        /// <summary>
+        /// Hangup (POSIX).
+        /// </summary>
+        HUP = 1,
+
+        /// <summary>
+        /// Interrupt (ANSI).
+        /// </summary>
+        INT = 2,
+
+        /// <summary>
+        /// Quit (POSIX).
+        /// </summary>
+        QUIT = 3,
+
+        /// <summary>
+        /// Illegal instruction (ANSI).
+        /// </summary>
+        ILL = 4,
+
+        /// <summary>
+        /// Abort (ANSI).
+        /// </summary>
+        ABRT = 6,
+
+        /// <summary>
+        /// Floating-point exception (ANSI).
+        /// </summary>
+        FPE = 8,
+
+        /// <summary>
+        /// Kill, unblockable (POSIX).
+        /// </summary>
+        KILL = 9,
+
+        /// <summary>
+        /// User-defined signal 1 (POSIX).
+        /// </summary>
+        USR1 = 10,
+
+        /// <summary>
+        /// Segmentation violation (ANSI).
+        /// </summary>
+        SEGV = 11,
+
+        /// <summary>
+        /// User-defined signal 2 (POSIX).
+        /// </summary>
+        USR2 = 12,
+
+        /// <summary>
+        /// Broken pipe (POSIX).
+        /// </summary>
+        PIPE = 13,
+
+        /// <summary>
+        /// Alarm clock (POSIX).
+        /// </summary>
+        ALRM = 14,
+
+        /// <summary>
+        /// Termination (ANSI).
+        /// </summary>
+        TERM = 15,
+    }
+}

--- a/src/Renci.SshNet/CommandSignals.cs
+++ b/src/Renci.SshNet/CommandSignals.cs
@@ -1,74 +1,73 @@
 ﻿namespace Renci.SshNet
 {
     /// <summary>
-    /// The ssh compatible POSIX/ANSI signals with their libc compatible values.
+    /// The ssh compatible standard POSIX/ANSI signals.
     /// </summary>
-#pragma warning disable CA1720 // Identifier contains type name
-    public enum CommandSignal
+    public static class CommandSignals
     {
         /// <summary>
         /// Hangup (POSIX).
         /// </summary>
-        HUP = 1,
+        public const string SIGHUP = "HUP";
 
         /// <summary>
         /// Interrupt (ANSI).
         /// </summary>
-        INT = 2,
+        public const string SIGINT = "INT";
 
         /// <summary>
         /// Quit (POSIX).
         /// </summary>
-        QUIT = 3,
+        public const string SIGQUIT = "QUIT";
 
         /// <summary>
         /// Illegal instruction (ANSI).
         /// </summary>
-        ILL = 4,
+        public const string SIGILL = "ILL";
 
         /// <summary>
         /// Abort (ANSI).
         /// </summary>
-        ABRT = 6,
+        public const string SIGABRT = "ABRT";
 
         /// <summary>
         /// Floating-point exception (ANSI).
         /// </summary>
-        FPE = 8,
+        public const string SIGFPE = "FPE";
 
         /// <summary>
         /// Kill, unblockable (POSIX).
         /// </summary>
-        KILL = 9,
+        public const string SIGKILL = "KILL";
 
         /// <summary>
         /// User-defined signal 1 (POSIX).
         /// </summary>
-        USR1 = 10,
+        public const string SIGUSR1 = "USR1";
 
         /// <summary>
         /// Segmentation violation (ANSI).
         /// </summary>
-        SEGV = 11,
+        public const string SIGSEGV = "SEGV";
 
         /// <summary>
         /// User-defined signal 2 (POSIX).
         /// </summary>
-        USR2 = 12,
+        public const string SIGUSR2 = "USR2";
 
         /// <summary>
         /// Broken pipe (POSIX).
         /// </summary>
-        PIPE = 13,
+        public const string SIGPIPE = "PIPE";
 
         /// <summary>
         /// Alarm clock (POSIX).
         /// </summary>
-        ALRM = 14,
+        public const string SIGALRM = "ALRM";
 
         /// <summary>
         /// Termination (ANSI).
         /// </summary>
-        TERM = 15,
+        public const string SIGTERM = "TERM";
     }
 }

--- a/src/Renci.SshNet/SshCommand.cs
+++ b/src/Renci.SshNet/SshCommand.cs
@@ -492,7 +492,7 @@ namespace Renci.SshNet
         /// <summary>
         /// Tries to send a POSIX/ANSI signal to the remote process executing the command, such as SIGINT or SIGTERM.
         /// </summary>
-        /// <param name="signal">The signal to send</param>
+        /// <param name="signal">The signal to send.</param>
         /// <returns>If the signal was sent.</returns>
         public bool TrySendSignal(CommandSignal signal)
         {
@@ -524,7 +524,7 @@ namespace Renci.SshNet
         /// <summary>
         /// Tries to send a POSIX/ANSI signal to the remote process executing the command, such as SIGINT or SIGTERM.
         /// </summary>
-        /// <param name="signal">The signal to send</param>
+        /// <param name="signal">The signal to send.</param>
         /// <exception cref="ArgumentException">Signal was not a valid CommandSignal.</exception>
         /// <exception cref="SshConnectionException">The client is not connected.</exception>
         /// <exception cref="SshOperationTimeoutException">The operation timed out.</exception>
@@ -537,6 +537,7 @@ namespace Renci.SshNet
             {
                 throw new ArgumentException("Signal was not a valid CommandSignal.");
             }
+
             if (_tcs is null || _tcs.Task.IsCompleted || _channel?.IsOpen != true)
             {
                 throw new InvalidOperationException("Command has not been started.");

--- a/src/Renci.SshNet/SshCommand.cs
+++ b/src/Renci.SshNet/SshCommand.cs
@@ -478,6 +478,73 @@ namespace Renci.SshNet
             }
         }
 
+        private static string? GetSignalName(CommandSignal signal)
+        {
+#if NETCOREAPP
+            return Enum.GetName(signal);
+#else
+
+            // Boxes signal, but Enum.GetName does not have a non-boxing overload prior to .NET Core.
+            return Enum.GetName(typeof(CommandSignal), signal);
+#endif
+        }
+
+        /// <summary>
+        /// Tries to send a POSIX/ANSI signal to the remote process executing the command, such as SIGINT or SIGTERM.
+        /// </summary>
+        /// <param name="signal">The signal to send</param>
+        /// <returns>If the signal was sent.</returns>
+        public bool TrySendSignal(CommandSignal signal)
+        {
+            var signalName = GetSignalName(signal);
+            if (signalName is null)
+            {
+                return false;
+            }
+
+            if (_tcs is null || _tcs.Task.IsCompleted || _channel?.IsOpen != true)
+            {
+                return false;
+            }
+
+            try
+            {
+                // Try to send the cancellation signal.
+                return _channel.SendSignalRequest(signalName);
+            }
+            catch (Exception)
+            {
+                // Exception can be ignored since we are in a Try method
+                // Possible exceptions here: InvalidOperationException, SshConnectionException, SshOperationTimeoutException
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Tries to send a POSIX/ANSI signal to the remote process executing the command, such as SIGINT or SIGTERM.
+        /// </summary>
+        /// <param name="signal">The signal to send</param>
+        /// <exception cref="ArgumentException">Signal was not a valid CommandSignal.</exception>
+        /// <exception cref="SshConnectionException">The client is not connected.</exception>
+        /// <exception cref="SshOperationTimeoutException">The operation timed out.</exception>
+        /// <exception cref="InvalidOperationException">The size of the packet exceeds the maximum size defined by the protocol.</exception>
+        /// <exception cref="InvalidOperationException">Command has not been started.</exception>
+        public void SendSignal(CommandSignal signal)
+        {
+            var signalName = GetSignalName(signal);
+            if (signalName is null)
+            {
+                throw new ArgumentException("Signal was not a valid CommandSignal.");
+            }
+            if (_tcs is null || _tcs.Task.IsCompleted || _channel?.IsOpen != true)
+            {
+                throw new InvalidOperationException("Command has not been started.");
+            }
+
+            _ = _channel.SendSignalRequest(signalName);
+        }
+
         /// <summary>
         /// Executes the command specified by <see cref="CommandText"/>.
         /// </summary>

--- a/src/Renci.SshNet/SshCommand.cs
+++ b/src/Renci.SshNet/SshCommand.cs
@@ -478,26 +478,14 @@ namespace Renci.SshNet
             }
         }
 
-        private static string? GetSignalName(CommandSignal signal)
-        {
-#if NETCOREAPP
-            return Enum.GetName(signal);
-#else
-
-            // Boxes signal, but Enum.GetName does not have a non-boxing overload prior to .NET Core.
-            return Enum.GetName(typeof(CommandSignal), signal);
-#endif
-        }
-
         /// <summary>
-        /// Tries to send a POSIX/ANSI signal to the remote process executing the command, such as SIGINT or SIGTERM.
+        /// Tries to send a POSIX/ANSI signal to the remote process executing the command, such as SIGTERM or any of the <see cref="CommandSignals"/>.
         /// </summary>
-        /// <param name="signal">The signal to send.</param>
+        /// <param name="signal">The signal to send. See <see cref="CommandSignals"/> for a standard list of signals.</param>
         /// <returns>If the signal was sent.</returns>
-        public bool TrySendSignal(CommandSignal signal)
+        public bool TrySendSignal(string signal)
         {
-            var signalName = GetSignalName(signal);
-            if (signalName is null)
+            if (signal is null)
             {
                 return false;
             }
@@ -510,7 +498,7 @@ namespace Renci.SshNet
             try
             {
                 // Try to send the cancellation signal.
-                return _channel.SendSignalRequest(signalName);
+                return _channel.SendSignalRequest(signal);
             }
             catch (Exception)
             {
@@ -522,18 +510,17 @@ namespace Renci.SshNet
         }
 
         /// <summary>
-        /// Tries to send a POSIX/ANSI signal to the remote process executing the command, such as SIGINT or SIGTERM.
+        /// Tries to send a POSIX/ANSI signal to the remote process executing the command, such as SIGTERM or any of the <see cref="CommandSignals"/>.
         /// </summary>
-        /// <param name="signal">The signal to send.</param>
+        /// <param name="signal">The signal to send. See <see cref="CommandSignals"/> for a standard list of signals.</param>
         /// <exception cref="ArgumentException">Signal was not a valid CommandSignal.</exception>
         /// <exception cref="SshConnectionException">The client is not connected.</exception>
         /// <exception cref="SshOperationTimeoutException">The operation timed out.</exception>
         /// <exception cref="InvalidOperationException">The size of the packet exceeds the maximum size defined by the protocol.</exception>
         /// <exception cref="InvalidOperationException">Command has not been started.</exception>
-        public void SendSignal(CommandSignal signal)
+        public void SendSignal(string signal)
         {
-            var signalName = GetSignalName(signal);
-            if (signalName is null)
+            if (signal is null)
             {
                 throw new ArgumentException("Signal was not a valid CommandSignal.");
             }
@@ -543,7 +530,7 @@ namespace Renci.SshNet
                 throw new InvalidOperationException("Command has not been started.");
             }
 
-            _ = _channel.SendSignalRequest(signalName);
+            _ = _channel.SendSignalRequest(signal);
         }
 
         /// <summary>


### PR DESCRIPTION
I noticed SshCommand does not have a method for sending signals although it is supported by the channel and underlying system.

This code:
- Parses the Signal
- Sends the Signal using the preexisting method

All signals listed in https://datatracker.ietf.org/doc/html/rfc4254#section-6.9 are supported and use their libc compatible values in case someone needs conversion from libc.

Still missing are tests, but i don't understand the test project structure, if someone could help me out there that would be great.