### PR TITLE
Low allocation SshCommand

### DIFF
--- a/src/Renci.SshNet/CommandSignal.cs
+++ b/src/Renci.SshNet/CommandSignal.cs
@@ -1,0 +1,74 @@
+﻿namespace Renci.SshNet
+{
+    /// <summary>
+    /// The ssh compatible POSIX/ANSI signals with their libc compatible values.
+    /// </summary>
+#pragma warning disable CA1720 // Identifier contains type name
+    public enum CommandSignal
+    {
+        /// <summary>
+        /// Hangup (POSIX).
+        /// </summary>
+        HUP = 1,
+
+        /// <summary>
+        /// Interrupt (ANSI).
+        /// </summary>
+        INT = 2,
+
+        /// <summary>
+        /// Quit (POSIX).
+        /// </summary>
+        QUIT = 3,
+
+        /// <summary>
+        /// Illegal instruction (ANSI).
+        /// </summary>
+        ILL = 4,
+
+        /// <summary>
+        /// Abort (ANSI).
+        /// </summary>
+        ABRT = 6,
+
+        /// <summary>
+        /// Floating-point exception (ANSI).
+        /// </summary>
+        FPE = 8,
+
+        /// <summary>
+        /// Kill, unblockable (POSIX).
+        /// </summary>
+        KILL = 9,
+
+        /// <summary>
+        /// User-defined signal 1 (POSIX).
+        /// </summary>
+        USR1 = 10,
+
+        /// <summary>
+        /// Segmentation violation (ANSI).
+        /// </summary>
+        SEGV = 11,
+
+        /// <summary>
+        /// User-defined signal 2 (POSIX).
+        /// </summary>
+        USR2 = 12,
+
+        /// <summary>
+        /// Broken pipe (POSIX).
+        /// </summary>
+        PIPE = 13,
+
+        /// <summary>
+        /// Alarm clock (POSIX).
+        /// </summary>
+        ALRM = 14,
+
+        /// <summary>
+        /// Termination (ANSI).
+        /// </summary>
+        TERM = 15,
+    }
+}

--- a/src/Renci.SshNet/Common/CommandExitedEventArgs.cs
+++ b/src/Renci.SshNet/Common/CommandExitedEventArgs.cs
@@ -1,0 +1,46 @@
+﻿#nullable enable
+using System;
+
+namespace Renci.SshNet.Common
+{
+    /// <summary>
+    /// Class for command exit related events.
+    /// </summary>
+    public class CommandExitedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CommandExitedEventArgs"/> class.
+        /// </summary>
+        /// <param name="exitStatus">The exit status.</param>
+        /// <param name="exitSignal">The exit signal.</param>
+        public CommandExitedEventArgs(int? exitStatus, string? exitSignal)
+        {
+            ExitStatus = exitStatus;
+            ExitSignal = exitSignal;
+        }
+
+        /// <summary>
+        /// Gets the number representing the exit status of the command, if applicable,
+        /// otherwise <see langword="null"/>.
+        /// </summary>
+        /// <remarks>
+        /// The value is not <see langword="null"/> when an exit status code has been returned
+        /// from the server. If the command terminated due to a signal, <see cref="ExitSignal"/>
+        /// may be not <see langword="null"/> instead.
+        /// </remarks>
+        /// <seealso cref="ExitSignal"/>
+        public int? ExitStatus { get; }
+
+
+        /// <summary>
+        /// Gets the name of the signal due to which the command
+        /// terminated violently, if applicable, otherwise <see langword="null"/>.
+        /// </summary>
+        /// <remarks>
+        /// The value (if it exists) is supplied by the server and is usually one of the
+        /// following, as described in https://datatracker.ietf.org/doc/html/rfc4254#section-6.10:
+        /// ABRT, ALRM, FPE, HUP, ILL, INT, KILL, PIPE, QUIT, SEGV, TER, USR1, USR2.
+        /// </remarks>
+        public string? ExitSignal { get; }
+    }
+}

--- a/src/Renci.SshNet/Common/CommandExitedEventArgs.cs
+++ b/src/Renci.SshNet/Common/CommandExitedEventArgs.cs
@@ -31,7 +31,6 @@ namespace Renci.SshNet.Common
         /// <seealso cref="ExitSignal"/>
         public int? ExitStatus { get; }
 
-
         /// <summary>
         /// Gets the name of the signal due to which the command
         /// terminated violently, if applicable, otherwise <see langword="null"/>.

--- a/src/Renci.SshNet/Common/CommandOutputEventArgs.cs
+++ b/src/Renci.SshNet/Common/CommandOutputEventArgs.cs
@@ -1,0 +1,44 @@
+﻿#nullable enable
+using System;
+using System.Text;
+
+namespace Renci.SshNet.Common
+{
+    /// <summary>
+    /// Base class for command output related events.
+    /// </summary>
+    public class CommandOutputEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CommandOutputEventArgs"/> class.
+        /// </summary>
+        /// <param name="rawData">The raw data received.</param>
+        /// <param name="encoding">The encoding used for the transmission.</param>
+        public CommandOutputEventArgs(ArraySegment<byte> rawData, Encoding encoding)
+        {
+            RawData = rawData;
+            Encoding = encoding;
+        }
+
+        /// <summary>
+        /// Gets the received data as <see langword="string"/>.
+        /// </summary>
+        public string Text
+        {
+            get
+            {
+                return Encoding.GetString(RawData.Array, RawData.Offset, RawData.Count);
+            }
+        }
+
+        /// <summary>
+        /// Gets the raw data received from the server. This is the data that was used to create the <see cref="Text"/> property.
+        /// </summary>
+        public ArraySegment<byte> RawData { get; }
+
+        /// <summary>
+        /// Gets the output encoding used.
+        /// </summary>
+        public Encoding Encoding { get; }
+    }
+}

--- a/src/Renci.SshNet/Common/CommandOutputEventArgs.cs
+++ b/src/Renci.SshNet/Common/CommandOutputEventArgs.cs
@@ -27,7 +27,7 @@ namespace Renci.SshNet.Common
         {
             get
             {
-                return Encoding.GetString(RawData.Array, RawData.Offset, RawData.Count);
+                return Encoding.GetString(RawData.Array!, RawData.Offset, RawData.Count);
             }
         }
 

--- a/src/Renci.SshNet/Common/ExtendedCommandEventArgs.cs
+++ b/src/Renci.SshNet/Common/ExtendedCommandEventArgs.cs
@@ -1,0 +1,40 @@
+﻿using System;
+#nullable enable
+using System.Text;
+
+namespace Renci.SshNet.Common
+{
+    /// <summary>
+    /// Class for extended text output related events.
+    /// </summary>
+    public class ExtendedCommandEventArgs : CommandOutputEventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExtendedCommandEventArgs"/> class.
+        /// </summary>
+        /// <param name="rawData">The raw data received.</param>
+        /// <param name="encoding">The encoding used for the transmission.</param>
+        /// <param name="dataTypeCode">The data type code.</param>
+        public ExtendedCommandEventArgs(ArraySegment<byte> rawData, Encoding encoding, uint dataTypeCode)
+            : base(rawData, encoding)
+        {
+            DataTypeCode = dataTypeCode;
+        }
+
+        /// <summary>
+        /// Gets the data type code.
+        /// </summary>
+        public uint DataTypeCode { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the current data represents an stderr output.
+        /// </summary>
+        public bool IsError
+        {
+            get
+            {
+                return DataTypeCode == 1;
+            }
+        }
+    }
+}

--- a/src/Renci.SshNet/ISshClient.cs
+++ b/src/Renci.SshNet/ISshClient.cs
@@ -67,6 +67,38 @@ namespace Renci.SshNet
         public SshCommand RunCommand(string commandText);
 
         /// <summary>
+        /// Creates the command to be executed.
+        /// </summary>
+        /// <param name="commandText">The command text.</param>
+        /// <returns><see cref="SshCommandLite"/> object.</returns>
+        /// <exception cref="SshConnectionException">Client is not connected.</exception>
+        public SshCommandLite CreateCommandLite(string commandText);
+
+        /// <summary>
+        /// Creates the command to be executed with specified encoding.
+        /// </summary>
+        /// <param name="commandText">The command text.</param>
+        /// <param name="encoding">The encoding to use for results.</param>
+        /// <returns><see cref="SshCommandLite"/> object which uses specified encoding.</returns>
+        /// <remarks>This method will change current default encoding.</remarks>
+        /// <exception cref="SshConnectionException">Client is not connected.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="commandText"/> or <paramref name="encoding"/> is <see langword="null"/>.</exception>
+        public SshCommandLite CreateCommandLite(string commandText, Encoding encoding);
+
+        /// <summary>
+        /// Creates and executes the command.
+        /// </summary>
+        /// <param name="commandText">The command text.</param>
+        /// <returns>Returns an instance of <see cref="SshCommandLite"/> with execution results.</returns>
+        /// <remarks>This method internally uses asynchronous calls.</remarks>
+        /// <exception cref="ArgumentException">CommandText property is empty.</exception>
+        /// <exception cref="SshException">Invalid Operation - An existing channel was used to execute this command.</exception>
+        /// <exception cref="InvalidOperationException">Asynchronous operation is already in progress.</exception>
+        /// <exception cref="SshConnectionException">Client is not connected.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="commandText"/> is <see langword="null"/>.</exception>
+        public SshCommandLite RunCommandLite(string commandText);
+
+        /// <summary>
         /// Creates the shell.
         /// </summary>
         /// <param name="input">The input.</param>

--- a/src/Renci.SshNet/SshClient.cs
+++ b/src/Renci.SshNet/SshClient.cs
@@ -210,6 +210,29 @@ namespace Renci.SshNet
         }
 
         /// <inheritdoc />
+        public SshCommandLite CreateCommandLite(string commandText)
+        {
+            return CreateCommandLite(commandText, ConnectionInfo.Encoding);
+        }
+
+        /// <inheritdoc />
+        public SshCommandLite CreateCommandLite(string commandText, Encoding encoding)
+        {
+            EnsureSessionIsOpen();
+
+            ConnectionInfo.Encoding = encoding;
+            return new SshCommandLite(Session!, commandText, encoding);
+        }
+
+        /// <inheritdoc />
+        public SshCommandLite RunCommandLite(string commandText)
+        {
+            var cmd = CreateCommandLite(commandText);
+            _ = cmd.Execute();
+            return cmd;
+        }
+
+        /// <inheritdoc />
         public Shell CreateShell(Stream input, Stream output, Stream extendedOutput, string terminalName, uint columns, uint rows, uint width, uint height, IDictionary<TerminalModes, uint>? terminalModes, int bufferSize)
         {
             EnsureSessionIsOpen();

--- a/src/Renci.SshNet/SshCommand.cs
+++ b/src/Renci.SshNet/SshCommand.cs
@@ -492,7 +492,7 @@ namespace Renci.SshNet
         /// <summary>
         /// Tries to send a POSIX/ANSI signal to the remote process executing the command, such as SIGINT or SIGTERM.
         /// </summary>
-        /// <param name="signal">The signal to send</param>
+        /// <param name="signal">The signal to send.</param>
         /// <returns>If the signal was sent.</returns>
         public bool TrySendSignal(CommandSignal signal)
         {
@@ -524,7 +524,7 @@ namespace Renci.SshNet
         /// <summary>
         /// Tries to send a POSIX/ANSI signal to the remote process executing the command, such as SIGINT or SIGTERM.
         /// </summary>
-        /// <param name="signal">The signal to send</param>
+        /// <param name="signal">The signal to send.</param>
         /// <exception cref="ArgumentException">Signal was not a valid CommandSignal.</exception>
         /// <exception cref="SshConnectionException">The client is not connected.</exception>
         /// <exception cref="SshOperationTimeoutException">The operation timed out.</exception>
@@ -537,6 +537,7 @@ namespace Renci.SshNet
             {
                 throw new ArgumentException("Signal was not a valid CommandSignal.");
             }
+
             if (_tcs is null || _tcs.Task.IsCompleted || _channel?.IsOpen != true)
             {
                 throw new InvalidOperationException("Command has not been started.");

--- a/src/Renci.SshNet/SshCommand.cs
+++ b/src/Renci.SshNet/SshCommand.cs
@@ -478,6 +478,73 @@ namespace Renci.SshNet
             }
         }
 
+        private static string? GetSignalName(CommandSignal signal)
+        {
+#if NETCOREAPP
+            return Enum.GetName(signal);
+#else
+
+            // Boxes signal, but Enum.GetName does not have a non-boxing overload prior to .NET Core.
+            return Enum.GetName(typeof(CommandSignal), signal);
+#endif
+        }
+
+        /// <summary>
+        /// Tries to send a POSIX/ANSI signal to the remote process executing the command, such as SIGINT or SIGTERM.
+        /// </summary>
+        /// <param name="signal">The signal to send</param>
+        /// <returns>If the signal was sent.</returns>
+        public bool TrySendSignal(CommandSignal signal)
+        {
+            var signalName = GetSignalName(signal);
+            if (signalName is null)
+            {
+                return false;
+            }
+
+            if (_tcs is null || _tcs.Task.IsCompleted || _channel?.IsOpen != true)
+            {
+                return false;
+            }
+
+            try
+            {
+                // Try to send the cancellation signal.
+                return _channel.SendSignalRequest(signalName);
+            }
+            catch (Exception)
+            {
+                // Exception can be ignored since we are in a Try method
+                // Possible exceptions here: InvalidOperationException, SshConnectionException, SshOperationTimeoutException
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Tries to send a POSIX/ANSI signal to the remote process executing the command, such as SIGINT or SIGTERM.
+        /// </summary>
+        /// <param name="signal">The signal to send</param>
+        /// <exception cref="ArgumentException">Signal was not a valid CommandSignal.</exception>
+        /// <exception cref="SshConnectionException">The client is not connected.</exception>
+        /// <exception cref="SshOperationTimeoutException">The operation timed out.</exception>
+        /// <exception cref="InvalidOperationException">The size of the packet exceeds the maximum size defined by the protocol.</exception>
+        /// <exception cref="InvalidOperationException">Command has not been started.</exception>
+        public void SendSignal(CommandSignal signal)
+        {
+            var signalName = GetSignalName(signal);
+            if (signalName is null)
+            {
+                throw new ArgumentException("Signal was not a valid CommandSignal.");
+            }
+            if (_tcs is null || _tcs.Task.IsCompleted || _channel?.IsOpen != true)
+            {
+                throw new InvalidOperationException("Command has not been started.");
+            }
+
+            _ = _channel.SendSignalRequest(signalName);
+        }
+
         /// <summary>
         /// Executes the command specified by <see cref="CommandText"/>.
         /// </summary>

--- a/src/Renci.SshNet/SshCommandLite.cs
+++ b/src/Renci.SshNet/SshCommandLite.cs
@@ -1,0 +1,589 @@
+﻿#nullable enable
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Renci.SshNet.Channels;
+using Renci.SshNet.Common;
+using Renci.SshNet.Messages.Connection;
+using Renci.SshNet.Messages.Transport;
+
+namespace Renci.SshNet
+{
+    /// <summary>
+    /// Represents an SSH command that can be executed.
+    /// </summary>
+    public sealed class SshCommandLite : IDisposable
+    {
+        private readonly ISession _session;
+        private readonly Encoding _encoding;
+
+        private IChannelSession _channel;
+        private TaskCompletionSource<object>? _tcs;
+        private CancellationTokenSource? _cts;
+        private CancellationTokenRegistration _tokenRegistration;
+        private bool _isDisposed;
+        private ChannelInputStream? _inputStream;
+        private TimeSpan _commandTimeout;
+
+        /// <summary>
+        /// The token supplied as an argument to <see cref="ExecuteAsync(CancellationToken)"/>.
+        /// </summary>
+        private CancellationToken _userToken;
+
+        /// <summary>
+        /// Whether <see cref="CancelAsync(bool, int)"/> has been called
+        /// (either by a token or manually).
+        /// </summary>
+        private bool _cancellationRequested;
+
+        private int _exitStatus;
+        private volatile bool _haveExitStatus; // volatile to prevent re-ordering of reads/writes of _exitStatus.
+
+        /// <summary>
+        /// Gets the command text.
+        /// </summary>
+        public string CommandText { get; private set; }
+
+        /// <summary>
+        /// Gets the command input and output encoding.
+        /// </summary>
+        public Encoding CommandEncoding
+        {
+            get
+            {
+                return _encoding;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the command timeout.
+        /// </summary>
+        /// <value>
+        /// The command timeout.
+        /// </value>
+        public TimeSpan CommandTimeout
+        {
+            get
+            {
+                return _commandTimeout;
+            }
+            set
+            {
+                value.EnsureValidTimeout(nameof(CommandTimeout));
+
+                _commandTimeout = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets the number representing the exit status of the command, if applicable,
+        /// otherwise <see langword="null"/>.
+        /// </summary>
+        /// <remarks>
+        /// The value is not <see langword="null"/> when an exit status code has been returned
+        /// from the server. If the command terminated due to a signal, <see cref="ExitSignal"/>
+        /// may be not <see langword="null"/> instead.
+        /// </remarks>
+        /// <seealso cref="ExitSignal"/>
+        public int? ExitStatus
+        {
+            get
+            {
+                return _haveExitStatus ? _exitStatus : null;
+            }
+        }
+
+        /// <summary>
+        /// Gets the name of the signal due to which the command
+        /// terminated violently, if applicable, otherwise <see langword="null"/>.
+        /// </summary>
+        /// <remarks>
+        /// The value (if it exists) is supplied by the server and is usually one of the
+        /// following, as described in https://datatracker.ietf.org/doc/html/rfc4254#section-6.10:
+        /// ABRT, ALRM, FPE, HUP, ILL, INT, KILL, PIPE, QUIT, SEGV, TER, USR1, USR2.
+        /// </remarks>
+        public string? ExitSignal { get; private set; }
+
+        /// <summary>
+        /// Occurs when output is received.
+        /// </summary>
+        public event EventHandler<CommandOutputEventArgs>? OutputReceived;
+
+        /// <summary>
+        /// Occurs when ExtendedOutput is received.
+        /// </summary>
+        public event EventHandler<ExtendedCommandEventArgs>? ExtendedOutputReceived;
+
+        /// <summary>
+        /// Occurs when the command has finished executing and the channel has been closed.
+        /// Returns the exit status code if it was provided by the server, or <see langword="null"/> otherwise.
+        /// </summary>
+        public event EventHandler<CommandExitedEventArgs>? Exited;
+
+        /// <summary>
+        /// Creates and returns the input stream for the command.
+        /// </summary>
+        /// <returns>
+        /// The stream that can be used to transfer data to the command's input stream.
+        /// </returns>
+        /// <remarks>
+        /// Callers should ensure that <see cref="Stream.Dispose()"/> is called on the
+        /// returned instance in order to notify the command that no more data will be sent.
+        /// Failure to do so may result in the command executing indefinitely.
+        /// </remarks>
+        /// <example>
+        /// This example shows how to stream some data to 'cat' and have the server echo it back.
+        /// <code>
+        /// using (SshCommand command = mySshClient.CreateCommand("cat"))
+        /// {
+        ///     Task executeTask = command.ExecuteAsync(CancellationToken.None);
+        ///
+        ///     using (Stream inputStream = command.CreateInputStream())
+        ///     {
+        ///         inputStream.Write("Hello World!"u8);
+        ///     }
+        ///
+        ///     await executeTask;
+        ///
+        ///     Console.WriteLine(command.ExitStatus); // 0
+        ///     Console.WriteLine(command.Result); // "Hello World!"
+        /// }
+        /// </code>
+        /// </example>
+        public Stream CreateInputStream()
+        {
+            if (!_channel.IsOpen)
+            {
+                throw new InvalidOperationException("The input stream can be used only during execution.");
+            }
+
+            if (_inputStream != null)
+            {
+                throw new InvalidOperationException("The input stream already exists.");
+            }
+
+            _inputStream = new ChannelInputStream(_channel);
+            return _inputStream;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SshCommandLite"/> class.
+        /// </summary>
+        /// <param name="session">The session.</param>
+        /// <param name="commandText">The command text.</param>
+        /// <param name="encoding">The encoding to use for the results.</param>
+        /// <exception cref="ArgumentNullException">Either <paramref name="session"/>, <paramref name="commandText"/> is <see langword="null"/>.</exception>
+        internal SshCommandLite(ISession session, string commandText, Encoding encoding)
+        {
+            ArgumentNullException.ThrowIfNull(session);
+            ArgumentNullException.ThrowIfNull(commandText);
+            ArgumentNullException.ThrowIfNull(encoding);
+
+            _session = session;
+            CommandText = commandText;
+            _encoding = encoding;
+            CommandTimeout = Timeout.InfiniteTimeSpan;
+            _session.Disconnected += Session_Disconnected;
+            _session.ErrorOccured += Session_ErrorOccurred;
+            _channel = _session.CreateChannelSession();
+        }
+
+        /// <summary>
+        /// Executes the command asynchronously.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// The <see cref="CancellationToken"/>. When triggered, attempts to terminate the
+        /// remote command by sending a signal.
+        /// </param>
+        /// <returns>A <see cref="Task"/> representing the lifetime of the command.</returns>
+        /// <exception cref="InvalidOperationException">Command is already executing. Thrown synchronously.</exception>
+        /// <exception cref="ObjectDisposedException">Instance has been disposed. Thrown synchronously.</exception>
+        /// <exception cref="OperationCanceledException">The <see cref="Task"/> has been cancelled.</exception>
+        /// <exception cref="SshOperationTimeoutException">The command timed out according to <see cref="CommandTimeout"/>.</exception>
+#pragma warning disable CA1849 // Call async methods when in an async method; PipeStream.DisposeAsync would complete synchronously anyway.
+        public Task ExecuteAsync(CancellationToken cancellationToken = default)
+        {
+            ObjectDisposedException.ThrowIf(_isDisposed, this);
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled(cancellationToken);
+            }
+
+            if (_tcs is not null)
+            {
+                if (!_tcs.Task.IsCompleted)
+                {
+                    throw new InvalidOperationException("Asynchronous operation is already in progress.");
+                }
+
+                UnsubscribeFromChannelEvents(dispose: true);
+
+                _channel = _session.CreateChannelSession();
+            }
+
+            _exitStatus = default;
+            _haveExitStatus = false;
+            ExitSignal = null;
+            _tokenRegistration.Dispose();
+            _tokenRegistration = default;
+            _cts?.Dispose();
+            _cts = null;
+            _cancellationRequested = false;
+
+            _tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _userToken = cancellationToken;
+
+            _channel.DataReceived += Channel_DataReceived;
+            _channel.ExtendedDataReceived += Channel_ExtendedDataReceived;
+            _channel.RequestReceived += Channel_RequestReceived;
+            _channel.Closed += Channel_Closed;
+            _channel.Open();
+
+            _ = _channel.SendExecRequest(CommandText);
+
+            if (CommandTimeout != Timeout.InfiniteTimeSpan)
+            {
+                _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                _cts.CancelAfter(CommandTimeout);
+                cancellationToken = _cts.Token;
+            }
+
+            if (cancellationToken.CanBeCanceled)
+            {
+                _tokenRegistration = cancellationToken.Register(static cmd =>
+                {
+                    try
+                    {
+                        ((SshCommand)cmd!).CancelAsync();
+                    }
+                    catch
+                    {
+                        // Swallow exceptions which would otherwise be unhandled.
+                    }
+                },
+                this);
+            }
+
+            return _tcs.Task;
+        }
+#pragma warning restore CA1849
+
+        /// <summary>
+        /// Cancels a running command by sending a signal to the remote process.
+        /// </summary>
+        /// <param name="forceKill">if true send SIGKILL instead of SIGTERM.</param>
+        /// <param name="millisecondsTimeout">Time to wait for the server to reply.</param>
+        /// <remarks>
+        /// <para>
+        /// This method stops the command running on the server by sending a SIGTERM
+        /// (or SIGKILL, depending on <paramref name="forceKill"/>) signal to the remote
+        /// process. When the server implements signals, it will send a response which
+        /// populates <see cref="ExitSignal"/> with the signal with which the command terminated.
+        /// </para>
+        /// <para>
+        /// When the server does not implement signals, it may send no response. As a fallback,
+        /// this method waits up to <paramref name="millisecondsTimeout"/> for a response
+        /// and then completes the <see cref="SshCommand"/> object anyway if there was none.
+        /// </para>
+        /// <para>
+        /// If the command has already finished (with or without cancellation), this method does
+        /// nothing.
+        /// </para>
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">Command has not been started.</exception>
+        public void CancelAsync(bool forceKill = false, int millisecondsTimeout = 500)
+        {
+            if (_tcs is null)
+            {
+                throw new InvalidOperationException("Command has not been started.");
+            }
+
+            if (_tcs.Task.IsCompleted)
+            {
+                return;
+            }
+
+            _cancellationRequested = true;
+            Interlocked.MemoryBarrier(); // ensure fresh read in SetAsyncComplete (possibly unnecessary)
+
+            try
+            {
+                // Try to send the cancellation signal.
+                if (_channel?.SendSignalRequest(forceKill ? "KILL" : "TERM") is null)
+                {
+                    // Command has completed (in the meantime since the last check).
+                    return;
+                }
+
+                // Having sent the "signal" message, we expect to receive "exit-signal"
+                // and then a close message. But since a server may not implement signals,
+                // we can't guarantee that, so we wait a short time for that to happen and
+                // if it doesn't, just complete the task ourselves to unblock waiters.
+
+                _ = _tcs.Task.Wait(millisecondsTimeout);
+            }
+            catch (AggregateException)
+            {
+                // We expect to be here from the call to Wait if the server implements signals.
+                // But we don't want to propagate the exception on the task from here.
+            }
+            finally
+            {
+                SetAsyncComplete();
+            }
+        }
+
+        private static string? GetSignalName(CommandSignal signal)
+        {
+#if NETCOREAPP
+            return Enum.GetName(signal);
+#else
+
+            // Boxes signal, but Enum.GetName does not have a non-boxing overload prior to .NET Core.
+            return Enum.GetName(typeof(CommandSignal), signal);
+#endif
+        }
+
+        /// <summary>
+        /// Tries to send a POSIX/ANSI signal to the remote process executing the command, such as SIGINT or SIGTERM.
+        /// </summary>
+        /// <param name="signal">The signal to send</param>
+        /// <returns>If the signal was sent.</returns>
+        public bool TrySendSignal(CommandSignal signal)
+        {
+            var signalName = GetSignalName(signal);
+            if (signalName is null)
+            {
+                return false;
+            }
+
+            if (_tcs is null || _tcs.Task.IsCompleted || _channel?.IsOpen != true)
+            {
+                return false;
+            }
+
+            try
+            {
+                // Try to send the cancellation signal.
+                return _channel.SendSignalRequest(signalName);
+            }
+            catch (Exception)
+            {
+                // Exception can be ignored since we are in a Try method
+                // Possible exceptions here: InvalidOperationException, SshConnectionException, SshOperationTimeoutException
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Tries to send a POSIX/ANSI signal to the remote process executing the command, such as SIGINT or SIGTERM.
+        /// </summary>
+        /// <param name="signal">The signal to send</param>
+        /// <exception cref="ArgumentException">Signal was not a valid CommandSignal.</exception>
+        /// <exception cref="SshConnectionException">The client is not connected.</exception>
+        /// <exception cref="SshOperationTimeoutException">The operation timed out.</exception>
+        /// <exception cref="InvalidOperationException">The size of the packet exceeds the maximum size defined by the protocol.</exception>
+        /// <exception cref="InvalidOperationException">Command has not been started.</exception>
+        public void SendSignal(CommandSignal signal)
+        {
+            var signalName = GetSignalName(signal);
+            if (signalName is null)
+            {
+                throw new ArgumentException("Signal was not a valid CommandSignal.");
+            }
+            if (_tcs is null || _tcs.Task.IsCompleted || _channel?.IsOpen != true)
+            {
+                throw new InvalidOperationException("Command has not been started.");
+            }
+
+            _ = _channel.SendSignalRequest(signalName);
+        }
+
+        /// <summary>
+        /// Executes the command specified by <see cref="CommandText"/>.
+        /// </summary>
+        /// <returns><see cref="ExitStatus"/>.</returns>
+        /// <exception cref="SshConnectionException">Client is not connected.</exception>
+        /// <exception cref="SshOperationTimeoutException">Operation has timed out.</exception>
+        public int? Execute()
+        {
+            ExecuteAsync().GetAwaiter().GetResult();
+            return ExitStatus;
+        }
+
+        /// <summary>
+        /// Executes the specified command.
+        /// </summary>
+        /// <param name="commandText">The command text.</param>
+        /// <returns><see cref="ExitStatus"/>.</returns>
+        /// <exception cref="SshConnectionException">Client is not connected.</exception>
+        /// <exception cref="SshOperationTimeoutException">Operation has timed out.</exception>
+        public int? Execute(string commandText)
+        {
+            CommandText = commandText;
+
+            return Execute();
+        }
+
+        private void Session_Disconnected(object? sender, EventArgs e)
+        {
+            _ = _tcs?.TrySetException(new SshConnectionException("An established connection was aborted by the software in your host machine.", DisconnectReason.ConnectionLost));
+
+            SetAsyncComplete(setResult: false);
+        }
+
+        private void Session_ErrorOccurred(object? sender, ExceptionEventArgs e)
+        {
+            _ = _tcs?.TrySetException(e.Exception);
+
+            SetAsyncComplete(setResult: false);
+        }
+
+        private void SetAsyncComplete(bool setResult = true)
+        {
+            Interlocked.MemoryBarrier(); // ensure fresh read of _cancellationRequested (possibly unnecessary)
+
+            if (setResult)
+            {
+                Debug.Assert(_tcs is not null, "Should only be completing the task if we've started one.");
+
+                if (_userToken.IsCancellationRequested)
+                {
+                    _ = _tcs.TrySetCanceled(_userToken);
+                }
+                else if (_cts?.Token.IsCancellationRequested == true)
+                {
+                    _ = _tcs.TrySetException(new SshOperationTimeoutException($"Command '{CommandText}' timed out. ({nameof(CommandTimeout)}: {CommandTimeout})."));
+                }
+                else if (_cancellationRequested)
+                {
+                    _ = _tcs.TrySetCanceled();
+                }
+                else
+                {
+                    _ = _tcs.TrySetResult(null!);
+                }
+            }
+
+            // We don't dispose the channel here to avoid a race condition
+            // where SSH_MSG_CHANNEL_CLOSE arrives before _channel starts
+            // waiting for a response in _channel.SendExecRequest().
+            UnsubscribeFromChannelEvents(dispose: false);
+
+            Exited?.Invoke(this, new(ExitStatus, ExitSignal));
+        }
+
+        private void Channel_Closed(object? sender, ChannelEventArgs e)
+        {
+            SetAsyncComplete();
+        }
+
+        private void Channel_RequestReceived(object? sender, ChannelRequestEventArgs e)
+        {
+            if (e.Info is ExitStatusRequestInfo exitStatusInfo)
+            {
+                _exitStatus = (int)exitStatusInfo.ExitStatus;
+                _haveExitStatus = true;
+
+                Debug.Assert(!exitStatusInfo.WantReply, "exit-status is want_reply := false by definition.");
+            }
+            else if (e.Info is ExitSignalRequestInfo exitSignalInfo)
+            {
+                ExitSignal = exitSignalInfo.SignalName;
+
+                Debug.Assert(!exitSignalInfo.WantReply, "exit-signal is want_reply := false by definition.");
+            }
+            else if (e.Info.WantReply && sender is IChannel { RemoteChannelNumber: uint remoteChannelNumber })
+            {
+                var replyMessage = new ChannelFailureMessage(remoteChannelNumber);
+                _session.SendMessage(replyMessage);
+            }
+        }
+
+        private void Channel_ExtendedDataReceived(object? sender, ChannelExtendedDataEventArgs e)
+        {
+            ExtendedOutputReceived?.Invoke(this, new(e.Data, _encoding, e.DataTypeCode));
+        }
+
+        private void Channel_DataReceived(object? sender, ChannelDataEventArgs e)
+        {
+            OutputReceived?.Invoke(this, new(e.Data, _encoding));
+        }
+
+        /// <summary>
+        /// Unsubscribes the current <see cref="SshCommand"/> from channel events, and optionally,
+        /// disposes <see cref="_channel"/>.
+        /// </summary>
+        private void UnsubscribeFromChannelEvents(bool dispose)
+        {
+            var channel = _channel;
+
+            // unsubscribe from events as we do not want to be signaled should these get fired
+            // during the dispose of the channel
+            channel.DataReceived -= Channel_DataReceived;
+            channel.ExtendedDataReceived -= Channel_ExtendedDataReceived;
+            channel.RequestReceived -= Channel_RequestReceived;
+            channel.Closed -= Channel_Closed;
+
+            if (dispose)
+            {
+                channel.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases unmanaged and - optionally - managed resources.
+        /// </summary>
+        /// <param name="disposing"><see langword="true"/> to release both managed and unmanaged resources; <see langword="false"/> to release only unmanaged resources.</param>
+        private void Dispose(bool disposing)
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                // unsubscribe from session events to ensure other objects that we're going to dispose
+                // are not accessed while disposing
+                _session.Disconnected -= Session_Disconnected;
+                _session.ErrorOccured -= Session_ErrorOccurred;
+
+                // unsubscribe from channel events to ensure other objects that we're going to dispose
+                // are not accessed while disposing
+                UnsubscribeFromChannelEvents(dispose: true);
+
+                _inputStream?.Dispose();
+                _inputStream = null;
+
+                _tokenRegistration.Dispose();
+                _tokenRegistration = default;
+                _cts?.Dispose();
+                _cts = null;
+
+                if (_tcs is { Task.IsCompleted: false } tcs)
+                {
+                    // In case an operation is still running, try to complete it with an ObjectDisposedException.
+                    _ = tcs.TrySetException(new ObjectDisposedException(GetType().FullName));
+                }
+
+                _isDisposed = true;
+            }
+        }
+    }
+}

--- a/src/Renci.SshNet/SshCommandLite.cs
+++ b/src/Renci.SshNet/SshCommandLite.cs
@@ -352,7 +352,7 @@ namespace Renci.SshNet
         /// <summary>
         /// Tries to send a POSIX/ANSI signal to the remote process executing the command, such as SIGINT or SIGTERM.
         /// </summary>
-        /// <param name="signal">The signal to send</param>
+        /// <param name="signal">The signal to send.</param>
         /// <returns>If the signal was sent.</returns>
         public bool TrySendSignal(CommandSignal signal)
         {
@@ -384,7 +384,7 @@ namespace Renci.SshNet
         /// <summary>
         /// Tries to send a POSIX/ANSI signal to the remote process executing the command, such as SIGINT or SIGTERM.
         /// </summary>
-        /// <param name="signal">The signal to send</param>
+        /// <param name="signal">The signal to send.</param>
         /// <exception cref="ArgumentException">Signal was not a valid CommandSignal.</exception>
         /// <exception cref="SshConnectionException">The client is not connected.</exception>
         /// <exception cref="SshOperationTimeoutException">The operation timed out.</exception>
@@ -397,6 +397,7 @@ namespace Renci.SshNet
             {
                 throw new ArgumentException("Signal was not a valid CommandSignal.");
             }
+
             if (_tcs is null || _tcs.Task.IsCompleted || _channel?.IsOpen != true)
             {
                 throw new InvalidOperationException("Command has not been started.");


### PR DESCRIPTION
# Low allocation SshCommand

Fixes #1776 and #1608
(includes #1777)

## Problem

SshCommand currently allocates a lot of data and doesn't allow directly processing it. This is causing memory issues and GC pressure on low memory devices or when issuing many commands at the same time. A low allocation version should be essential in my opinion for a library optimized for parallelism.

### Allocations

Example:
```cs
var c = client.RunCommand("for i in {1..1000} ; do echo aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ; done");
```
Allocated 298.272 bytes while the output might not even be needed. the thing to note here is that this is more than the data in itself, the utf8 data is only 70.000 bytes, somehow it is allocating this at least 4 times.
Allocations i could find:
- Buffer in session (unavoidable i think, but might be an issue with clearing the buffer?)
- Buffer (PipeStream) in SshCommand (avoidable)
- Result string (in utf16 = size *2) (definitely avoidable)
70kB *4 = 280 kB which is around what we get.

Even when clearing the pipebuffer, since a stream is not event driven it will with sudden bursts of data still enlarge the buffers and cause large allocations.

Additionally, small commands that are not even expected to give output will always allocate a minimum of 4kB of which 2kB of pipestream buffer.

Example:
```cs
var createcommands = Enumerable.Range(0, 100).Select(i => client.CreateCommand("echo a")).ToArray();
```
This will allocate 400kB of buffers, of which 200kB might be completely wasted if the output is never used and then still needs to get collected by the GC.

### Event vs Stream

While i respect the stream approach which makes it compatible with a lot of dotnet build in systems currently we are doing:
- Session reads data and buffers it
- Session raises events
- Command captures event
- Command buffers data again in pipestream <= this could be avoided
- Pipestream needs separate thread to read it again asynchronously and process it

This also causes other issues like #1608 where continuity is lost. The events could simply be exposed and never need to be handled.

### Fire and forget

Right now the buffers are always used and filled, if you don't read them they keep growing. For long running fire and forget processes that means you deliberately need to set up 2 threads to spin and read the buffers or they will keep growing indefinitely, leading to more wasted memory (16kB stream copy buffers) and wasted cpu: 
```cs
cmd.OutputStream.CopyToAsync(Stream.Null);
cmd.ExtendedOutputStream.CopyToAsync(Stream.Null);
```
So right now `var c = client.RunCommand("...");` just cannot be used for long running processes.
The minimum for fire and forget is:
```cs
var cmd = client.CreateCommand("..."); //allocates 4kB
cmd.OutputStream.CopyToAsync(Stream.Null); //allocates 8kB + wasted cpu
cmd.ExtendedOutputStream.CopyToAsync(Stream.Null); //allocates 8kB + wasted cpu
```

## Proposal

### Breaking changes

The first method would be exposing the events in SshCommand and only allocating the buffers when used, but this would be a breaking change. Since that is to be avoided i believe this is not a good solution.

### Allocation free SshCommand alternative

This is included in this pull request in the form of "SshCommandLite". It exposes the events through a user friendly eventarg allowing both directly using the bytes as well as the text.

#### Allocations solved

No streams are used and both the 2kB minimum and the ever growing buffer are solved. Output can still be obtained by using the events

`client.CreateCommandLite("...");` only allocates 184 for SshCommandLite and the rest is Session buffer
`client.RunCommandLite("for i in {1..1000} ; do echo aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ; done")` only allocates 5kB in session buffer, nothing elsewhere

#### Event vs Stream

Since events are accessible, this solves continuity issues and improves efficiency due to no extra wasted cycles on buffer copies.

#### Fire and forget

Fire and forget is now actually possible since no output keeps growing while its not captured.
```cs
using var c = client.CreateCommandLite("");
// Optional only log errors for demonstration, normal or unsubscribed output will be ignored
c.ExtendedOutputReceived += (s, e) => {if (e.IsError) { Console.WriteLine(e.Text); } }; 
c.ExecuteAsync().ContinueWith(t=>c.Dispose()); // or await ...
```

I agree this is a rather "large" change you might not be willing to do, but i decided since otherwise the library just isn't usable for me i need to make my own fork either way if it is not accepted. No hard feelings if you discard it. But please do take a look at the problems shown here as they might be bothering other people as well.

Thank you and sorry for the long read.