### PR TITLE
ConnectionInfo.SendTimeout — configurable socket send timeout to prevent indefinite hangs on TCP zero-window stalls

### DIFF
--- a/src/Renci.SshNet/ConnectionInfo.cs
+++ b/src/Renci.SshNet/ConnectionInfo.cs
@@ -51,6 +51,7 @@ namespace Renci.SshNet
 
         private TimeSpan _timeout;
         private TimeSpan _channelCloseTimeout;
+        private TimeSpan _sendTimeout = System.Threading.Timeout.InfiniteTimeSpan;
 
         /// <summary>
         /// Gets supported key exchange algorithms for this connection.
@@ -188,6 +189,25 @@ namespace Renci.SshNet
                 value.EnsureValidTimeout(nameof(ChannelCloseTimeout));
 
                 _channelCloseTimeout = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the socket send timeout. Controls how long a socket send may block before
+        /// throwing a <see cref="System.Net.Sockets.SocketException"/>. The default value is
+        /// <see cref="Timeout.InfiniteTimeSpan"/> (no timeout).
+        /// </summary>
+        public TimeSpan SendTimeout
+        {
+            get
+            {
+                return _sendTimeout;
+            }
+            set
+            {
+                value.EnsureValidTimeout(nameof(SendTimeout));
+
+                _sendTimeout = value;
             }
         }
 

--- a/src/Renci.SshNet/Session.cs
+++ b/src/Renci.SshNet/Session.cs
@@ -602,6 +602,8 @@ namespace Renci.SshNet
                 _socket = _serviceFactory.CreateConnector(ConnectionInfo, _socketFactory)
                                             .Connect(ConnectionInfo);
 
+                _socket.SendTimeout = ConnectionInfo.SendTimeout.AsTimeout();
+
                 var serverIdentification = _serviceFactory.CreateProtocolVersionExchange()
                                                             .Start(ClientVersion, _socket, ConnectionInfo.Timeout);
 
@@ -726,6 +728,8 @@ namespace Renci.SshNet
 
                 _socket = await _serviceFactory.CreateConnector(ConnectionInfo, _socketFactory)
                                             .ConnectAsync(ConnectionInfo, cancellationToken).ConfigureAwait(false);
+
+                _socket.SendTimeout = ConnectionInfo.SendTimeout.AsTimeout();
 
                 var serverIdentification = await _serviceFactory.CreateProtocolVersionExchange()
                                                             .StartAsync(ClientVersion, _socket, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
fixes #1793 