### PR TITLE
Fix SOCKS reply ordering and rejected SOCKS4 responses

### DIFF
--- a/src/Renci.SshNet/Channels/ChannelDirectTcpip.cs
+++ b/src/Renci.SshNet/Channels/ChannelDirectTcpip.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
@@ -24,6 +25,34 @@ namespace Renci.SshNet.Channels
         private Socket _socket;
 
         /// <summary>
+        /// Holds a value indicating whether data received on the channel may be written to
+        /// <see cref="_socket"/>.
+        /// </summary>
+        /// <value>
+        /// <see langword="false"/> until <see cref="Bind()"/> releases the relay; see
+        /// <see cref="StartRelay"/> for why it is held back.
+        /// </value>
+        private bool _relaying;
+
+        /// <summary>
+        /// Holds the data received on the channel before the relay was released, or
+        /// <see langword="null"/> when there is none.
+        /// </summary>
+        private Queue<byte[]> _pendingData;
+
+        /// <summary>
+        /// Holds the shutdown that was requested before the relay was released, or
+        /// <see langword="null"/> when none was.
+        /// </summary>
+        private SocketShutdown? _pendingShutdown;
+
+        /// <summary>
+        /// Holds a value indicating whether <see cref="_socket"/> must be closed as soon as the relay
+        /// is released.
+        /// </summary>
+        private bool _pendingClose;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ChannelDirectTcpip"/> class.
         /// </summary>
         /// <param name="session">The session.</param>
@@ -47,6 +76,18 @@ namespace Renci.SshNet.Channels
             get { return ChannelTypes.DirectTcpip; }
         }
 
+        /// <summary>
+        /// Opens the channel for the specified remote host and port.
+        /// </summary>
+        /// <param name="remoteHost">The name of the remote host to forward to.</param>
+        /// <param name="port">The port of the remote host to forward to.</param>
+        /// <param name="forwardedPort">The forwarded port for which the channel is opened.</param>
+        /// <param name="socket">The socket to receive requests from, and send responses from the remote host to.</param>
+        /// <remarks>
+        /// The channel takes ownership of <paramref name="socket"/> here, but does not yet write to it:
+        /// the caller may still have its own reply to send first. Data received before
+        /// <see cref="Bind()"/> is buffered rather than written. See <see cref="StartRelay"/>.
+        /// </remarks>
         public void Open(string remoteHost, uint port, IForwardedPort forwardedPort, Socket socket)
         {
             if (IsOpen)
@@ -80,13 +121,20 @@ namespace Renci.SshNet.Channels
         /// </summary>
         private void ForwardedPort_Closing(object sender, EventArgs eventArgs)
         {
-            // signal to the client that we will not send anything anymore; this should also interrupt the
-            // blocking receive in Bind if the client sends FIN/ACK in time
-            ShutdownSocket(SocketShutdown.Send);
+            // The port is going away, so this is an abort rather than an orderly close: act on the
+            // socket right away even when the relay has not been released, discarding anything that
+            // is still buffered. There is nobody left to relay it for, and the whole point of this
+            // handler is to interrupt a blocking receive.
+            lock (_socketLock)
+            {
+                // signal to the client that we will not send anything anymore; this should also interrupt the
+                // blocking receive in Bind if the client sends FIN/ACK in time
+                ShutdownSocketCore(SocketShutdown.Send);
 
-            // if the FIN/ACK is not sent in time by the remote client, then interrupt the blocking receive
-            // by closing the socket
-            CloseSocket();
+                // if the FIN/ACK is not sent in time by the remote client, then interrupt the blocking receive
+                // by closing the socket
+                CloseSocketCore();
+            }
         }
 
         /// <summary>
@@ -94,15 +142,25 @@ namespace Renci.SshNet.Channels
         /// </summary>
         public void Bind()
         {
+            // Release the data that arrived while the forwarded port was still writing its own reply
+            // to the client, and only then start pumping in the other direction.
+            StartRelay();
+
             // Cannot bind if channel is not open
             if (!IsOpen)
             {
                 return;
             }
 
+            var socket = _socket;
+            if (socket is null)
+            {
+                return;
+            }
+
             var buffer = new byte[RemotePacketSize];
 
-            SocketAbstraction.ReadContinuous(_socket, buffer, 0, buffer.Length, SendData);
+            SocketAbstraction.ReadContinuous(socket, buffer, 0, buffer.Length, SendData);
 
             // even though the client has disconnected, we still want to properly close the
             // channel
@@ -113,27 +171,115 @@ namespace Renci.SshNet.Channels
         }
 
         /// <summary>
-        /// Closes the socket, hereby interrupting the blocking receive in <see cref="Bind()"/>.
+        /// Starts writing data received on the channel to the socket, first flushing whatever arrived
+        /// while the relay was held back.
         /// </summary>
-        private void CloseSocket()
+        /// <remarks>
+        /// <para>
+        /// A forwarded port writes its own reply to the client between <see cref="Open"/> and
+        /// <see cref="Bind()"/> - for <see cref="ForwardedPortDynamic"/> that is the SOCKS reply, which
+        /// RFC 1928 s6 requires to precede any byte from the target. <see cref="OnData"/> runs on the
+        /// session's message-receive thread, so without this gate the two would write to the same
+        /// socket from two threads with no ordering between them, and a target that speaks first - SSH,
+        /// SMTP, IMAP, POP3, FTP, MySQL, PostgreSQL, Redis - would land its greeting where the reply
+        /// belonged.
+        /// </para>
+        /// <para>
+        /// A shutdown or close requested while the relay was closed is applied here too, after the
+        /// buffered data, so that a target which speaks and then immediately hangs up still gets its
+        /// bytes to the client in the right order.
+        /// </para>
+        /// </remarks>
+        private void StartRelay()
         {
-            if (_socket is null)
-            {
-                return;
-            }
-
             lock (_socketLock)
             {
-                if (_socket is null)
+                if (_relaying)
                 {
                     return;
                 }
 
-                // closing a socket actually disposes the socket, so we can safely dereference
-                // the field to avoid entering the lock again later
-                _socket.Dispose();
-                _socket = null;
+                _relaying = true;
+
+                var pending = _pendingData;
+                _pendingData = null;
+
+                if (pending is not null)
+                {
+                    while (pending.Count > 0)
+                    {
+                        var data = pending.Dequeue();
+                        SendToSocket(data, 0, data.Length);
+                    }
+                }
+
+                if (_pendingShutdown is SocketShutdown pendingShutdown)
+                {
+                    _pendingShutdown = null;
+                    ShutdownSocketCore(pendingShutdown);
+                }
+
+                if (_pendingClose)
+                {
+                    _pendingClose = false;
+                    CloseSocketCore();
+                }
             }
+        }
+
+        /// <summary>
+        /// Writes data to the socket, if there still is one and it is connected.
+        /// </summary>
+        /// <param name="data">An array of <see cref="byte"/> containing the data to write.</param>
+        /// <param name="offset">The zero-based offset in <paramref name="data"/> at which to begin taking data from.</param>
+        /// <param name="count">The number of bytes of <paramref name="data"/> to write.</param>
+        /// <remarks>
+        /// The caller must hold <see cref="_socketLock"/>.
+        /// </remarks>
+        private void SendToSocket(byte[] data, int offset, int count)
+        {
+            var socket = _socket;
+
+            if (socket.IsConnected())
+            {
+                SocketAbstraction.Send(socket, data, offset, count);
+            }
+        }
+
+        /// <summary>
+        /// Closes the socket, hereby interrupting the blocking receive in <see cref="Bind()"/>.
+        /// </summary>
+        private void CloseSocket()
+        {
+            lock (_socketLock)
+            {
+                if (!_relaying)
+                {
+                    // Disposing the socket now would strand both the reply the forwarded port is about
+                    // to write and anything OnData has buffered. StartRelay applies this afterwards.
+                    _pendingClose = true;
+                    return;
+                }
+
+                CloseSocketCore();
+            }
+        }
+
+        /// <summary>
+        /// Disposes the socket.
+        /// </summary>
+        /// <remarks>
+        /// The caller must hold <see cref="_socketLock"/>.
+        /// </remarks>
+        private void CloseSocketCore()
+        {
+            // closing a socket actually disposes the socket, so we can safely dereference
+            // the field to avoid entering the lock again later
+            _socket?.Dispose();
+            _socket = null;
+
+            // there is no longer anywhere to write buffered data to
+            _pendingData = null;
         }
 
         /// <summary>
@@ -142,26 +288,46 @@ namespace Renci.SshNet.Channels
         /// <param name="how">One of the <see cref="SocketShutdown"/> values that specifies the operation that will no longer be allowed.</param>
         private void ShutdownSocket(SocketShutdown how)
         {
-            if (_socket is null)
+            lock (_socketLock)
+            {
+                if (!_relaying)
+                {
+                    // Shutting the send side down now would break the reply the forwarded port is
+                    // about to write, and would discard whatever OnData has buffered. StartRelay
+                    // applies this after the buffer has been drained.
+                    _pendingShutdown = _pendingShutdown is null || _pendingShutdown == how
+                        ? how
+                        : SocketShutdown.Both;
+                    return;
+                }
+
+                ShutdownSocketCore(how);
+            }
+        }
+
+        /// <summary>
+        /// Shuts down the socket, without regard for the relay.
+        /// </summary>
+        /// <param name="how">One of the <see cref="SocketShutdown"/> values that specifies the operation that will no longer be allowed.</param>
+        /// <remarks>
+        /// The caller must hold <see cref="_socketLock"/>.
+        /// </remarks>
+        private void ShutdownSocketCore(SocketShutdown how)
+        {
+            var socket = _socket;
+
+            if (!socket.IsConnected())
             {
                 return;
             }
 
-            lock (_socketLock)
+            try
             {
-                if (!_socket.IsConnected())
-                {
-                    return;
-                }
-
-                try
-                {
-                    _socket.Shutdown(how);
-                }
-                catch (SocketException ex)
-                {
-                    _logger.LogInformation(ex, "Failure shutting down socket");
-                }
+                socket.Shutdown(how);
+            }
+            catch (SocketException ex)
+            {
+                _logger.LogInformation(ex, "Failure shutting down socket");
             }
         }
 
@@ -198,15 +364,28 @@ namespace Renci.SshNet.Channels
         {
             base.OnData(data);
 
-            if (_socket != null)
+            lock (_socketLock)
             {
-                lock (_socketLock)
+                if (_socket is null)
                 {
-                    if (_socket.IsConnected())
-                    {
-                        SocketAbstraction.Send(_socket, data.Array, data.Offset, data.Count);
-                    }
+                    return;
                 }
+
+                if (!_relaying)
+                {
+                    // We are on the session's message-receive thread and the forwarded port has not
+                    // finished writing its own reply to the client yet. Hold on to the data instead of
+                    // racing that thread for the socket; StartRelay writes it out in order. The array
+                    // belongs to the message being processed, so it has to be copied.
+                    var buffered = new byte[data.Count];
+                    Buffer.BlockCopy(data.Array, data.Offset, buffered, 0, data.Count);
+
+                    _pendingData ??= new Queue<byte[]>();
+                    _pendingData.Enqueue(buffered);
+                    return;
+                }
+
+                SendToSocket(data.Array, data.Offset, data.Count);
             }
         }
 
@@ -288,17 +467,9 @@ namespace Renci.SshNet.Channels
 
             if (disposing)
             {
-                if (_socket != null)
+                lock (_socketLock)
                 {
-                    lock (_socketLock)
-                    {
-                        var socket = _socket;
-                        if (socket != null)
-                        {
-                            _socket = null;
-                            socket.Dispose();
-                        }
-                    }
+                    CloseSocketCore();
                 }
 
                 var channelOpen = _channelOpen;

--- a/src/Renci.SshNet/ForwardedPortDynamic.cs
+++ b/src/Renci.SshNet/ForwardedPortDynamic.cs
@@ -504,19 +504,13 @@ namespace Renci.SshNet
 
             channel.Open(host, port, this, socket);
 
-            SocketAbstraction.SendByte(socket, 0x00);
+            var channelOpen = channel.IsOpen;
 
-            if (channel.IsOpen)
-            {
-                SocketAbstraction.SendByte(socket, 0x5a);
-                SocketAbstraction.Send(socket, portBuffer, 0, portBuffer.Length);
-                SocketAbstraction.Send(socket, ipBuffer, 0, ipBuffer.Length);
-                return true;
-            }
+            var socksReply = CreateSocks4Reply(channelOpen, portBuffer, ipBuffer);
 
-            // signal that request was rejected or failed
-            SocketAbstraction.SendByte(socket, 0x5b);
-            return false;
+            SocketAbstraction.Send(socket, socksReply, 0, socksReply.Length);
+
+            return channelOpen;
         }
 
         private bool HandleSocks5(Socket socket, IChannelDirectTcpip channel, TimeSpan timeout)
@@ -669,6 +663,52 @@ namespace Renci.SshNet
                 default:
                     throw new ProxyException(string.Format(CultureInfo.InvariantCulture, "SOCKS5: Address type '{0}' is not supported.", addressType));
             }
+        }
+
+        /// <summary>
+        /// Creates the reply to a SOCKS4 request.
+        /// </summary>
+        /// <param name="channelOpen"><see langword="true"/> if the channel was opened; otherwise, <see langword="false"/>.</param>
+        /// <param name="portBuffer">The destination port from the request.</param>
+        /// <param name="ipBuffer">The destination address from the request.</param>
+        /// <returns>
+        /// An array of <see cref="byte"/> containing the reply.
+        /// </returns>
+        /// <remarks>
+        /// The reply is eight bytes whether or not the request was granted. The destination port and
+        /// address are defined to be ignored by the client, but they are not optional: a client that
+        /// reads the reply as the fixed-width record it is - which includes the SOCKS4 client in this
+        /// library - would block waiting for the remaining six bytes of a rejection.
+        /// </remarks>
+        private static byte[] CreateSocks4Reply(bool channelOpen, byte[] portBuffer, byte[] ipBuffer)
+        {
+            var socksReply = new byte[// Reply version; fixed: 0x00
+                                      1 +
+
+                                      // Reply code
+                                      1 +
+
+                                      // Destination port; ignored by the client
+                                      2 +
+
+                                      // Destination IPv4 address; ignored by the client
+                                      4];
+
+            socksReply[0] = 0x00;
+
+            if (channelOpen)
+            {
+                socksReply[1] = 0x5a; // request granted
+            }
+            else
+            {
+                socksReply[1] = 0x5b; // request rejected or failed
+            }
+
+            Buffer.BlockCopy(portBuffer, 0, socksReply, 2, portBuffer.Length);
+            Buffer.BlockCopy(ipBuffer, 0, socksReply, 4, ipBuffer.Length);
+
+            return socksReply;
         }
 
         private static byte[] CreateSocks5Reply(bool channelOpen)

--- a/test/Renci.SshNet.Tests/Classes/Channels/ChannelDirectTcpipTest_ReplyOrdering.cs
+++ b/test/Renci.SshNet.Tests/Classes/Channels/ChannelDirectTcpipTest_ReplyOrdering.cs
@@ -1,0 +1,357 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Moq;
+
+using Renci.SshNet.Channels;
+using Renci.SshNet.Messages;
+using Renci.SshNet.Messages.Connection;
+using Renci.SshNet.Tests.Common;
+
+namespace Renci.SshNet.Tests.Classes.Channels
+{
+    /// <summary>
+    /// A forwarded port owns the client socket between <see cref="ChannelDirectTcpip.Open"/> and
+    /// <see cref="ChannelDirectTcpip.Bind"/> so that it can write its own reply first —
+    /// <see cref="ForwardedPortDynamic"/> writes the SOCKS reply there, and RFC 1928 §6 requires that
+    /// reply to precede any byte from the target.
+    ///
+    /// <see cref="ChannelDirectTcpip.OnData"/> runs on the session's message-receive thread, so if it
+    /// wrote to the socket during that window the two threads would race and a target that speaks
+    /// first — SSH, SMTP, IMAP, POP3, FTP, MySQL, PostgreSQL, Redis — could land its greeting where
+    /// the reply belonged. These tests pin the ordering, and the disposal of the data and of the
+    /// socket itself when the target speaks and then immediately hangs up.
+    /// </summary>
+    [TestClass]
+    public class ChannelDirectTcpipTest_ReplyOrdering : TestBase
+    {
+        private const string Reply = "<REPLY>";
+        private const string TargetGreeting = "SSH-2.0-OpenSSH_10.2p1\r\n";
+
+        private Mock<ISession> _sessionMock;
+        private Mock<IForwardedPort> _forwardedPortMock;
+        private Mock<IConnectionInfo> _connectionInfoMock;
+        private uint _localChannelNumber;
+        private uint _remoteChannelNumber;
+        private uint _remoteWindowSize;
+        private uint _remotePacketSize;
+
+        /// <summary>
+        /// The socket the channel owns and writes to, i.e. the one the forwarded port accepted.
+        /// </summary>
+        private Socket _serverSide;
+
+        /// <summary>
+        /// The socket the SOCKS client would be holding.
+        /// </summary>
+        private Socket _clientSide;
+
+        private Socket _listener;
+
+        protected override void OnInit()
+        {
+            base.OnInit();
+
+            var random = new Random();
+            _localChannelNumber = (uint)random.Next(0, int.MaxValue);
+            _remoteChannelNumber = (uint)random.Next(0, int.MaxValue);
+            _remoteWindowSize = 0x100000;
+            _remotePacketSize = 0x8000;
+
+            _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _forwardedPortMock = new Mock<IForwardedPort>(MockBehavior.Strict);
+            _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
+
+            _ = _sessionMock.Setup(p => p.SessionLoggerFactory)
+                            .Returns(NullLoggerFactory.Instance);
+            _ = _sessionMock.Setup(p => p.IsConnected)
+                            .Returns(true);
+            _ = _sessionMock.Setup(p => p.ConnectionInfo)
+                            .Returns(_connectionInfoMock.Object);
+            _ = _connectionInfoMock.Setup(p => p.ChannelCloseTimeout)
+                                   .Returns(TimeSpan.FromSeconds(10));
+            _ = _sessionMock.Setup(p => p.WaitOnHandle(It.IsAny<EventWaitHandle>()))
+                            .Callback<WaitHandle>(handle => handle.WaitOne());
+            _ = _sessionMock.Setup(p => p.TryWait(It.IsAny<EventWaitHandle>(), It.IsAny<TimeSpan>()))
+                            .Returns(WaitResult.Success);
+            _ = _sessionMock.Setup(p => p.TrySendMessage(It.IsAny<Message>()))
+                            .Returns(true);
+
+            // Confirm the channel open as soon as it is requested, the way a server would. Any other
+            // message the channel sends (a window adjust, say) is simply accepted.
+            _ = _sessionMock.Setup(p => p.SendMessage(It.IsAny<Message>()))
+                            .Callback<Message>(message =>
+                                {
+                                    if (message is ChannelOpenMessage open)
+                                    {
+                                        _sessionMock.Raise(p => p.ChannelOpenConfirmationReceived += null,
+                                                           new MessageEventArgs<ChannelOpenConfirmationMessage>(
+                                                               new ChannelOpenConfirmationMessage(open.LocalChannelNumber,
+                                                                                                  _remoteWindowSize,
+                                                                                                  _remotePacketSize,
+                                                                                                  _remoteChannelNumber)));
+                                    }
+                                });
+
+            _listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            _listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            _listener.Listen(1);
+
+            _clientSide = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+            _clientSide.Connect(_listener.LocalEndPoint);
+            _serverSide = _listener.Accept();
+            _serverSide.NoDelay = true;
+        }
+
+        protected override void OnCleanup()
+        {
+            _clientSide?.Dispose();
+            _serverSide?.Dispose();
+            _listener?.Dispose();
+
+            base.OnCleanup();
+        }
+
+        /// <summary>
+        /// The defect itself: data that arrives while the port is still composing its reply must not
+        /// be written to the client ahead of that reply.
+        /// </summary>
+        [TestMethod]
+        public void TargetDataArrivingBeforeBindIsWrittenAfterThePortsOwnReply()
+        {
+            using (var channel = CreateOpenChannel())
+            {
+                RaiseData(TargetGreeting);
+
+                // Nothing may reach the client yet: the port has not written its reply.
+                Assert.AreEqual(0, BytesWaitingForClient(), "the target's greeting was written to the client before the port's reply");
+
+                // The forwarded port writes its reply, then hands the socket over.
+                _ = _serverSide.Send(Encoding.ASCII.GetBytes(Reply));
+
+                var bind = RunBind(channel);
+
+                Assert.AreEqual(Reply + TargetGreeting, ReadFromClient(Reply.Length + TargetGreeting.Length));
+
+                FinishBind(bind);
+            }
+        }
+
+        /// <summary>
+        /// Everything buffered has to come out, once, in the order it arrived.
+        /// </summary>
+        [TestMethod]
+        public void EveryChunkBufferedBeforeBindIsDeliveredOnceAndInOrder()
+        {
+            using (var channel = CreateOpenChannel())
+            {
+                var expected = new StringBuilder(Reply);
+
+                for (var i = 0; i < 25; i++)
+                {
+                    var chunk = "chunk-" + i.ToString("D2") + ";";
+                    RaiseData(chunk);
+                    _ = expected.Append(chunk);
+                }
+
+                Assert.AreEqual(0, BytesWaitingForClient());
+
+                _ = _serverSide.Send(Encoding.ASCII.GetBytes(Reply));
+
+                var bind = RunBind(channel);
+
+                Assert.AreEqual(expected.ToString(), ReadFromClient(expected.Length));
+
+                FinishBind(bind);
+            }
+        }
+
+        /// <summary>
+        /// A target that speaks and hangs up at once — sshd refusing a connection, say — must still
+        /// get its bytes to the client, after the reply, before the socket is shut down.
+        /// </summary>
+        [TestMethod]
+        public void EofArrivingBeforeBindDoesNotDiscardBufferedDataOrPreEmptTheReply()
+        {
+            using (var channel = CreateOpenChannel())
+            {
+                RaiseData(TargetGreeting);
+                _sessionMock.Raise(p => p.ChannelEofReceived += null,
+                                   new MessageEventArgs<ChannelEofMessage>(new ChannelEofMessage(_localChannelNumber)));
+
+                // The reply must still be writable: the send side may not have been shut down yet.
+                _ = _serverSide.Send(Encoding.ASCII.GetBytes(Reply));
+
+                var bind = RunBind(channel);
+
+                Assert.AreEqual(Reply + TargetGreeting, ReadFromClient(Reply.Length + TargetGreeting.Length));
+
+                // and only then the end of the stream
+                Assert.AreEqual(0, _clientSide.Receive(new byte[16], 0, 16, SocketFlags.None));
+
+                FinishBind(bind);
+            }
+        }
+
+        /// <summary>
+        /// Same again, but with the whole channel closed before the port got its reply out. The socket
+        /// may not be disposed from under the reply.
+        /// </summary>
+        [TestMethod]
+        public void ChannelClosedBeforeBindDoesNotDiscardBufferedDataOrPreEmptTheReply()
+        {
+            using (var channel = CreateOpenChannel())
+            {
+                RaiseData(TargetGreeting);
+                _sessionMock.Raise(p => p.ChannelEofReceived += null,
+                                   new MessageEventArgs<ChannelEofMessage>(new ChannelEofMessage(_localChannelNumber)));
+                _sessionMock.Raise(p => p.ChannelCloseReceived += null,
+                                   new MessageEventArgs<ChannelCloseMessage>(new ChannelCloseMessage(_localChannelNumber)));
+
+                Assert.IsFalse(channel.IsOpen, "the channel should have been closed");
+
+                _ = _serverSide.Send(Encoding.ASCII.GetBytes(Reply));
+
+                channel.Bind();
+
+                Assert.AreEqual(Reply + TargetGreeting, ReadFromClient(Reply.Length + TargetGreeting.Length));
+                Assert.AreEqual(0, _clientSide.Receive(new byte[16], 0, 16, SocketFlags.None));
+            }
+        }
+
+        /// <summary>
+        /// Once the relay is running, data goes straight to the socket — no buffering, no delay until
+        /// some later event.
+        /// </summary>
+        [TestMethod]
+        public void DataArrivingAfterBindIsWrittenStraightToTheClient()
+        {
+            using (var channel = CreateOpenChannel())
+            {
+                _ = _serverSide.Send(Encoding.ASCII.GetBytes(Reply));
+
+                var bind = RunBind(channel);
+
+                Assert.AreEqual(Reply, ReadFromClient(Reply.Length));
+
+                RaiseData(TargetGreeting);
+
+                Assert.AreEqual(TargetGreeting, ReadFromClient(TargetGreeting.Length));
+
+                FinishBind(bind);
+            }
+        }
+
+        /// <summary>
+        /// The port going away is an abort, not an orderly close: it must still take the socket down
+        /// immediately, which is what unblocks a forwarded port that is stopping.
+        /// </summary>
+        [TestMethod]
+        public void ForwardedPortClosingBeforeBindStillTakesTheSocketDown()
+        {
+            using (var channel = CreateOpenChannel())
+            {
+                RaiseData(TargetGreeting);
+
+                _forwardedPortMock.Raise(p => p.Closing += null, EventArgs.Empty);
+
+                // FIN, not the buffered greeting
+                Assert.AreEqual(0, _clientSide.Receive(new byte[64], 0, 64, SocketFlags.None));
+
+                // and Bind must not block on a socket that is gone
+                channel.Bind();
+            }
+        }
+
+        private ChannelDirectTcpip CreateOpenChannel()
+        {
+            var channel = new ChannelDirectTcpip(_sessionMock.Object,
+                                                 _localChannelNumber,
+                                                 localWindowSize: 0x100000,
+                                                 localPacketSize: 0x8000);
+            channel.Open("target.example.com", 22, _forwardedPortMock.Object, _serverSide);
+            Assert.IsTrue(channel.IsOpen);
+            return channel;
+        }
+
+        private void RaiseData(string text)
+        {
+            // The array belongs to the message and is reused by the session, so hand over a distinct
+            // one each time — a channel that kept a reference rather than a copy must not pass.
+            var payload = Encoding.ASCII.GetBytes(text);
+            _sessionMock.Raise(p => p.ChannelDataReceived += null,
+                               new MessageEventArgs<ChannelDataMessage>(new ChannelDataMessage(_localChannelNumber, payload)));
+            Array.Clear(payload, 0, payload.Length);
+        }
+
+        /// <summary>
+        /// Bind blocks receiving from the client, so it runs on its own thread.
+        /// </summary>
+        private static Task RunBind(ChannelDirectTcpip channel)
+        {
+            var started = new ManualResetEventSlim(false);
+            var task = Task.Factory.StartNew(() =>
+                {
+                    started.Set();
+                    channel.Bind();
+                }, TaskCreationOptions.LongRunning);
+            _ = started.Wait(TimeSpan.FromSeconds(5));
+            return task;
+        }
+
+        private void FinishBind(Task bind)
+        {
+            _clientSide.Shutdown(SocketShutdown.Send);
+            Assert.IsTrue(bind.Wait(TimeSpan.FromSeconds(10)), "Bind did not return after the client shut down its send side");
+        }
+
+        /// <summary>
+        /// Returns how many bytes are readable by the client, after giving a wrongly-ordered write
+        /// long enough to show up. Loopback delivery is immediate, so this does not race the fault it
+        /// is looking for; it only gives it time.
+        /// </summary>
+        private int BytesWaitingForClient()
+        {
+            var deadline = DateTime.UtcNow.AddMilliseconds(250);
+            while (DateTime.UtcNow < deadline)
+            {
+                if (_clientSide.Available > 0)
+                {
+                    return _clientSide.Available;
+                }
+
+                Thread.Sleep(10);
+            }
+
+            return _clientSide.Available;
+        }
+
+        private string ReadFromClient(int count)
+        {
+            var buffer = new byte[count];
+            var read = 0;
+
+            _clientSide.ReceiveTimeout = 10000;
+
+            while (read < count)
+            {
+                var bytes = _clientSide.Receive(buffer, read, count - read, SocketFlags.None);
+                if (bytes == 0)
+                {
+                    break;
+                }
+
+                read += bytes;
+            }
+
+            return Encoding.ASCII.GetString(buffer, 0, read);
+        }
+    }
+}

--- a/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Started_Socks4Reply.cs
+++ b/test/Renci.SshNet.Tests/Classes/ForwardedPortDynamicTest_Started_Socks4Reply.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Moq;
+
+using Renci.SshNet.Channels;
+using Renci.SshNet.Common;
+using Renci.SshNet.Tests.Common;
+
+namespace Renci.SshNet.Tests.Classes
+{
+    /// <summary>
+    /// A SOCKS4 reply is a fixed-width eight byte record - version, code, destination port,
+    /// destination address - whether or not the request was granted. The last six fields are defined
+    /// as ignored by the client, but reading them is not optional: a client that reads the record as
+    /// a record, which SSH.NET's own <see cref="Renci.SshNet.Connection.Socks4Connector"/> does on the
+    /// granted path, blocks waiting for bytes that never come if a rejection is short.
+    /// </summary>
+    [TestClass]
+    public class ForwardedPortDynamicTest_Started_Socks4Reply
+    {
+        private const string UserName = "socks-user";
+
+        private Mock<ISession> _sessionMock;
+        private Mock<IChannelDirectTcpip> _channelMock;
+        private Mock<IConnectionInfo> _connectionInfoMock;
+        private ForwardedPortDynamic _forwardedPort;
+        private Socket _client;
+        private IPEndPoint _remoteEndpoint;
+        private IList<ExceptionEventArgs> _exceptionRegister;
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            if (_forwardedPort is not null && _forwardedPort.IsStarted)
+            {
+                _forwardedPort.Stop();
+            }
+
+            _client?.Dispose();
+            _client = null;
+            _forwardedPort?.Dispose();
+            _forwardedPort = null;
+        }
+
+        /// <summary>
+        /// The case that was short: the channel could not be opened, so the request is rejected.
+        /// </summary>
+        [TestMethod]
+        public void RejectedRequestShouldBeAnsweredWithAFullEightByteReply()
+        {
+            Arrange(channelOpen: false);
+
+            var reply = RequestConnect();
+
+            Assert.AreEqual(8, reply.Length, "a SOCKS4 reply is eight bytes, granted or not");
+            Assert.AreEqual(0x00, reply[0], "reply version");
+            Assert.AreEqual(0x5b, reply[1], "request rejected or failed");
+            AssertEchoesTheRequest(reply);
+        }
+
+        /// <summary>
+        /// And the granted case still is what it was.
+        /// </summary>
+        [TestMethod]
+        public void GrantedRequestShouldBeAnsweredWithAFullEightByteReply()
+        {
+            Arrange(channelOpen: true);
+
+            var reply = RequestConnect();
+
+            Assert.AreEqual(8, reply.Length);
+            Assert.AreEqual(0x00, reply[0], "reply version");
+            Assert.AreEqual(0x5a, reply[1], "request granted");
+            AssertEchoesTheRequest(reply);
+        }
+
+        private void AssertEchoesTheRequest(byte[] reply)
+        {
+            var address = _remoteEndpoint.Address.GetAddressBytes();
+
+            Assert.AreEqual((byte)(_remoteEndpoint.Port >> 8), reply[2], "destination port, high byte");
+            Assert.AreEqual((byte)(_remoteEndpoint.Port & 0xFF), reply[3], "destination port, low byte");
+            CollectionAssert.AreEqual(address, new[] { reply[4], reply[5], reply[6], reply[7] }, "destination address");
+        }
+
+        private void Arrange(bool channelOpen)
+        {
+            _exceptionRegister = new List<ExceptionEventArgs>();
+            _remoteEndpoint = new IPEndPoint(IPAddress.Parse("193.168.1.5"), 8122);
+
+            _sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            _channelMock = new Mock<IChannelDirectTcpip>(MockBehavior.Strict);
+            _connectionInfoMock = new Mock<IConnectionInfo>(MockBehavior.Strict);
+
+            _ = _sessionMock.Setup(p => p.SessionLoggerFactory).Returns(NullLoggerFactory.Instance);
+            _ = _sessionMock.Setup(p => p.IsConnected).Returns(true);
+            _ = _sessionMock.Setup(p => p.ConnectionInfo).Returns(_connectionInfoMock.Object);
+            _ = _sessionMock.Setup(p => p.CreateChannelDirectTcpip()).Returns(_channelMock.Object);
+            _ = _connectionInfoMock.Setup(p => p.Timeout).Returns(TimeSpan.FromSeconds(5));
+            _ = _channelMock.Setup(p => p.Open(_remoteEndpoint.Address.ToString(),
+                                               (uint)_remoteEndpoint.Port,
+                                               It.IsAny<IForwardedPort>(),
+                                               It.IsAny<Socket>()));
+            _ = _channelMock.Setup(p => p.IsOpen).Returns(channelOpen);
+            _ = _channelMock.Setup(p => p.Bind());
+            _ = _channelMock.Setup(p => p.Dispose());
+
+            // Bind to an ephemeral port rather than a fixed one, so that the test does not collide
+            // with anything else that happens to be listening.
+            _forwardedPort = new ForwardedPortDynamic("127.0.0.1", 0);
+            _forwardedPort.Exception += (sender, args) => _exceptionRegister.Add(args);
+            _forwardedPort.Session = _sessionMock.Object;
+            _forwardedPort.Start();
+
+            _client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp)
+            {
+                ReceiveTimeout = 10000
+            };
+            _client.Connect(new IPEndPoint(IPAddress.Loopback, (int)_forwardedPort.BoundPort));
+        }
+
+        /// <summary>
+        /// Sends a SOCKS4 CONNECT and reads back exactly what the protocol says the reply is, without
+        /// giving up early. A reply that is short shows up here as a receive timeout, which is what a
+        /// real client would see too.
+        /// </summary>
+        private byte[] RequestConnect()
+        {
+            var user = Encoding.ASCII.GetBytes(UserName);
+            var address = _remoteEndpoint.Address.GetAddressBytes();
+            var request = new byte[8 + user.Length + 1];
+
+            request[0] = 0x04; // SOCKS version
+            request[1] = 0x01; // CONNECT
+            request[2] = (byte)(_remoteEndpoint.Port >> 8);
+            request[3] = (byte)(_remoteEndpoint.Port & 0xFF);
+            Buffer.BlockCopy(address, 0, request, 4, address.Length);
+            Buffer.BlockCopy(user, 0, request, 8, user.Length);
+            request[request.Length - 1] = 0x00;
+
+            _ = _client.Send(request, 0, request.Length, SocketFlags.None);
+
+            var reply = new byte[8];
+            var received = 0;
+
+            try
+            {
+                while (received < reply.Length)
+                {
+                    var bytes = _client.Receive(reply, received, reply.Length - received, SocketFlags.None);
+                    if (bytes == 0)
+                    {
+                        break;
+                    }
+
+                    received += bytes;
+                }
+            }
+            catch (SocketException ex) when (ex.SocketErrorCode == SocketError.TimedOut)
+            {
+                Assert.Fail(string.Format(CultureInfo.InvariantCulture,
+                                          "timed out after {0} of {1} reply bytes: {2}",
+                                          received,
+                                          reply.Length,
+                                          BitConverter.ToString(reply, 0, received)));
+            }
+
+            Assert.AreEqual(0, _exceptionRegister.Count, _exceptionRegister.AsString());
+
+            var actual = new byte[received];
+            Buffer.BlockCopy(reply, 0, actual, 0, received);
+            return actual;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR fixes two protocol issues in `ForwardedPortDynamic`:

1. Data from the target server could be sent to the SOCKS client before the SOCKS CONNECT reply.
2. A rejected SOCKS4 request received only 2 bytes instead of the required 8-byte reply.

The fixes are split into separate commits.

## 1. Prevent target data from preceding the SOCKS reply

### Problem

The current SOCKS5 flow is:

```csharp
channel.Open(host, port, this, socket);
var socksReply = CreateSocks5Reply(channel.IsOpen);
SocketAbstraction.Send(socket, socksReply, 0, socksReply.Length);
```

`channel.Open()` assigns the client socket to `ChannelDirectTcpip` and waits for the SSH channel to open.

After it returns, target data may arrive on the SSH session’s receive thread. `ChannelDirectTcpip.OnData()` immediately writes that data to the same client socket.

This creates a race:

```text
Thread 1: channel.Open() returns
Thread 2: target data is written to the client
Thread 1: SOCKS reply is written to the client
```

For protocols where the server speaks first, the client can therefore receive target data where it expects the SOCKS reply.

Examples include SSH, SMTP, IMAP, POP3, FTP, MySQL, PostgreSQL, and Redis.

An SSH connection through the proxy failed with:

```text
ProxyException: SOCKS5: Version 5 is expected.
```

The first byte received was from the SSH banner rather than the SOCKS5 reply.

### Fix

`ChannelDirectTcpip` now keeps relaying disabled until `Bind()` calls `StartRelay()`.

While relaying is disabled:

* Incoming target data is copied and queued.
* Target EOF, socket shutdown, and socket close operations are deferred.
* The SOCKS reply can be written before any target activity reaches the client.

When `StartRelay()` is called, queued operations are processed in order and subsequent data is relayed directly.

`ForwardedPort_Closing` is not deferred because it is the abort path and must still interrupt a blocking receive.

No public API changes are required. Both forwarded-port implementations already call `Bind()` after writing their protocol reply.

### Verification

Tested against a real SSH server:

| Concurrency | Before: valid reply | Before: target data first | After: valid reply |
| ----------: | ------------------: | ------------------------: | -----------------: |
|           1 |                   4 |                         8 |                 12 |
|           2 |                  19 |                         5 |                 24 |
|           8 |                  49 |                        47 |                 96 |
|          16 |                 119 |                        73 |                192 |

The issue reproduced even at concurrency 1, so it is not limited to stress conditions.

A complete SSH handshake using SSH.NET’s own `Socks5Connector` succeeded in all 90 post-fix test runs.

`ForwardedPortLocal` was also tested to ensure the buffering change did not alter its behavior. All 60 forwarded connections delivered their payloads byte-for-byte.

## 2. Return a complete SOCKS4 rejection reply

### Problem

A SOCKS4 reply is always 8 bytes, whether the request is accepted or rejected.

The rejection path currently sends only:

```text
00 5B
```

A client reading the fixed-width SOCKS4 reply waits indefinitely for the remaining 6 bytes instead of receiving the rejection.

### Fix

Both accepted and rejected requests now use `CreateSocks4Reply()` and send the complete reply in one write.

Example rejection reply:

```text
00-5B-00-01-7F-00-00-01
```

## Tests

Added two test classes containing eight tests:

* `ChannelDirectTcpipTest_ReplyOrdering`

  * Target data is buffered until `Bind()`.
  * Buffered chunks are delivered once and in order.
  * EOF and channel closure do not discard buffered data or precede the SOCKS reply.
  * Data received after `Bind()` is relayed immediately.
  * `ForwardedPort_Closing` still closes the socket immediately.

* `ForwardedPortDynamicTest_Started_Socks4Reply`

  * Accepted and rejected SOCKS4 requests both return valid 8-byte replies.

The new and affected tests pass on `net462`, `net8.0`, and `net9.0`.

The full repository test run still encounters an unrelated, pre-existing `ObjectDisposedException` in:

```text
SessionTest_ConnectingBase.SetupData
  -> AsyncSocketListener.ReadCallback
```

The same failure occurs on the unchanged `develop` branch.
