### PR TITLE
Generate ten synchronous SftpClient methods from their async versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,5 +23,6 @@
     <!-- Should stay on LTS .NET releases. -->
     <PackageVersion Include="System.Formats.Asn1" Version="10.0.9" />
     <PackageVersion Include="Testcontainers" Version="4.13.0" />
+    <PackageVersion Include="Zomp.SyncMethodGenerator" Version="2.0.42" />
   </ItemGroup>
 </Project>

--- a/src/Renci.SshNet/Renci.SshNet.csproj
+++ b/src/Renci.SshNet/Renci.SshNet.csproj
@@ -47,6 +47,7 @@
     <PackageReference Include="PolySharp" PrivateAssets="all">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Zomp.SyncMethodGenerator" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">

--- a/src/Renci.SshNet/SftpClient.cs
+++ b/src/Renci.SshNet/SftpClient.cs
@@ -23,7 +23,7 @@ namespace Renci.SshNet
     /// <summary>
     /// Implementation of the SSH File Transfer Protocol (SFTP) over SSH.
     /// </summary>
-    public class SftpClient : BaseClient, ISftpClient
+    public partial class SftpClient : BaseClient, ISftpClient
     {
         private static readonly Encoding Utf8NoBOM = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
 
@@ -284,41 +284,8 @@ namespace Renci.SshNet
 
         #endregion Constructors
 
-        /// <summary>
-        /// Changes remote directory to path.
-        /// </summary>
-        /// <param name="path">New directory path.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/>.</exception>
-        /// <exception cref="SshConnectionException">Client is not connected.</exception>
-        /// <exception cref="SftpPermissionDeniedException">Permission to change directory denied by remote host. <para>-or-</para> A SSH command was denied by the server.</exception>
-        /// <exception cref="SftpPathNotFoundException"><paramref name="path"/> was not found on the remote host.</exception>
-        /// <exception cref="SshException">A SSH error where <see cref="Exception.Message"/> is the message from the remote host.</exception>
-        /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
-        public void ChangeDirectory(string path)
-        {
-            CheckDisposed();
-            ArgumentNullException.ThrowIfNull(path);
-
-            if (_sftpSession is null)
-            {
-                throw new SshConnectionException("Client not connected.");
-            }
-
-            _sftpSession.ChangeDirectory(path);
-        }
-
-        /// <summary>
-        /// Asynchronously requests to change the current working directory to the specified path.
-        /// </summary>
-        /// <param name="path">The new working directory.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <returns>A <see cref="Task"/> that tracks the asynchronous change working directory request.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/>.</exception>
-        /// <exception cref="SshConnectionException">Client is not connected.</exception>
-        /// <exception cref="SftpPermissionDeniedException">Permission to change directory denied by remote host. <para>-or-</para> A SSH command was denied by the server.</exception>
-        /// <exception cref="SftpPathNotFoundException"><paramref name="path"/> was not found on the remote host.</exception>
-        /// <exception cref="SshException">A SSH error where <see cref="Exception.Message"/> is the message from the remote host.</exception>
-        /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
+        /// <inheritdoc />
+        [Zomp.SyncMethodGenerator.CreateSyncVersion]
         public Task ChangeDirectoryAsync(string path, CancellationToken cancellationToken = default)
         {
             CheckDisposed();
@@ -351,41 +318,8 @@ namespace Renci.SshNet
             file.SetPermissions(mode);
         }
 
-        /// <summary>
-        /// Creates remote directory specified by path.
-        /// </summary>
-        /// <param name="path">Directory path to create.</param>
-        /// <exception cref="ArgumentException"><paramref name="path"/> is <see langword="null"/> or contains only whitespace characters.</exception>
-        /// <exception cref="SshConnectionException">Client is not connected.</exception>
-        /// <exception cref="SftpPermissionDeniedException">Permission to create the directory was denied by the remote host. <para>-or-</para> A SSH command was denied by the server.</exception>
-        /// <exception cref="SshException">A SSH error where <see cref="Exception.Message"/> is the message from the remote host.</exception>
-        /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
-        public void CreateDirectory(string path)
-        {
-            CheckDisposed();
-            ArgumentException.ThrowIfNullOrWhiteSpace(path);
-
-            if (_sftpSession is null)
-            {
-                throw new SshConnectionException("Client not connected.");
-            }
-
-            var fullPath = _sftpSession.GetCanonicalPath(path);
-
-            _sftpSession.RequestMkDir(fullPath);
-        }
-
-        /// <summary>
-        /// Asynchronously requests to create a remote directory specified by path.
-        /// </summary>
-        /// <param name="path">Directory path to create.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to observe.</param>
-        /// <returns>A <see cref="Task"/> that represents the asynchronous create directory operation.</returns>
-        /// <exception cref="ArgumentException"><paramref name="path"/> is <see langword="null"/> or contains only whitespace characters.</exception>
-        /// <exception cref="SshConnectionException">Client is not connected.</exception>
-        /// <exception cref="SftpPermissionDeniedException">Permission to create the directory was denied by the remote host. <para>-or-</para> A SSH command was denied by the server.</exception>
-        /// <exception cref="SshException">A SSH error where <see cref="Exception.Message"/> is the message from the remote host.</exception>
-        /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
+        /// <inheritdoc />
+        [Zomp.SyncMethodGenerator.CreateSyncVersion]
         public async Task CreateDirectoryAsync(string path, CancellationToken cancellationToken = default)
         {
             CheckDisposed();
@@ -401,32 +335,8 @@ namespace Renci.SshNet
             await _sftpSession.RequestMkDirAsync(fullPath, cancellationToken).ConfigureAwait(false);
         }
 
-        /// <summary>
-        /// Deletes remote directory specified by path.
-        /// </summary>
-        /// <param name="path">Directory to be deleted path.</param>
-        /// <exception cref="ArgumentException"><paramref name="path"/> is <see langword="null"/> or contains only whitespace characters.</exception>
-        /// <exception cref="SshConnectionException">Client is not connected.</exception>
-        /// <exception cref="SftpPathNotFoundException"><paramref name="path"/> was not found on the remote host.</exception>
-        /// <exception cref="SftpPermissionDeniedException">Permission to delete the directory was denied by the remote host. <para>-or-</para> A SSH command was denied by the server.</exception>
-        /// <exception cref="SshException">A SSH error where <see cref="Exception.Message"/> is the message from the remote host.</exception>
-        /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
-        public void DeleteDirectory(string path)
-        {
-            CheckDisposed();
-            ArgumentException.ThrowIfNullOrWhiteSpace(path);
-
-            if (_sftpSession is null)
-            {
-                throw new SshConnectionException("Client not connected.");
-            }
-
-            var fullPath = _sftpSession.GetCanonicalPath(path);
-
-            _sftpSession.RequestRmDir(fullPath);
-        }
-
         /// <inheritdoc />
+        [Zomp.SyncMethodGenerator.CreateSyncVersion]
         public async Task DeleteDirectoryAsync(string path, CancellationToken cancellationToken = default)
         {
             CheckDisposed();
@@ -444,32 +354,8 @@ namespace Renci.SshNet
             await _sftpSession.RequestRmDirAsync(fullPath, cancellationToken).ConfigureAwait(false);
         }
 
-        /// <summary>
-        /// Deletes remote file specified by path.
-        /// </summary>
-        /// <param name="path">File to be deleted path.</param>
-        /// <exception cref="ArgumentException"><paramref name="path"/> is <see langword="null"/> or contains only whitespace characters.</exception>
-        /// <exception cref="SshConnectionException">Client is not connected.</exception>
-        /// <exception cref="SftpPathNotFoundException"><paramref name="path"/> was not found on the remote host.</exception>
-        /// <exception cref="SftpPermissionDeniedException">Permission to delete the file was denied by the remote host. <para>-or-</para> A SSH command was denied by the server.</exception>
-        /// <exception cref="SshException">A SSH error where <see cref="Exception.Message"/> is the message from the remote host.</exception>
-        /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
-        public void DeleteFile(string path)
-        {
-            CheckDisposed();
-            ArgumentException.ThrowIfNullOrWhiteSpace(path);
-
-            if (_sftpSession is null)
-            {
-                throw new SshConnectionException("Client not connected.");
-            }
-
-            var fullPath = _sftpSession.GetCanonicalPath(path);
-
-            _sftpSession.RequestRemove(fullPath);
-        }
-
         /// <inheritdoc />
+        [Zomp.SyncMethodGenerator.CreateSyncVersion]
         public async Task DeleteFileAsync(string path, CancellationToken cancellationToken)
         {
             CheckDisposed();
@@ -725,47 +611,8 @@ namespace Renci.SshNet
             return ar.EndInvoke();
         }
 
-        /// <summary>
-        /// Gets reference to remote file or directory.
-        /// </summary>
-        /// <param name="path">The path.</param>
-        /// <returns>
-        /// A reference to <see cref="ISftpFile"/> file object.
-        /// </returns>
-        /// <exception cref="SshConnectionException">Client is not connected.</exception>
-        /// <exception cref="SftpPathNotFoundException"><paramref name="path"/> was not found on the remote host.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="path" /> is <see langword="null"/>.</exception>
-        /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
-        public ISftpFile Get(string path)
-        {
-            CheckDisposed();
-            ArgumentNullException.ThrowIfNull(path);
-
-            if (_sftpSession is null)
-            {
-                throw new SshConnectionException("Client not connected.");
-            }
-
-            var fullPath = _sftpSession.GetCanonicalPath(path);
-
-            var attributes = _sftpSession.RequestLStat(fullPath);
-
-            return new SftpFile(_sftpSession, fullPath, attributes);
-        }
-
-        /// <summary>
-        /// Gets reference to remote file or directory.
-        /// </summary>
-        /// <param name="path">The path.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to observe.</param>
-        /// <returns>
-        /// A <see cref="Task{ISftpFile}"/> that represents the get operation.
-        /// The task result contains the reference to <see cref="ISftpFile"/> file object.
-        /// </returns>
-        /// <exception cref="SshConnectionException">Client is not connected.</exception>
-        /// <exception cref="SftpPathNotFoundException"><paramref name="path"/> was not found on the remote host.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="path" /> is <see langword="null"/>.</exception>
-        /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
+        /// <inheritdoc />
+        [Zomp.SyncMethodGenerator.CreateSyncVersion]
         public async Task<ISftpFile> GetAsync(string path, CancellationToken cancellationToken)
         {
             CheckDisposed();
@@ -785,74 +632,8 @@ namespace Renci.SshNet
             return new SftpFile(_sftpSession, fullPath, attributes);
         }
 
-        /// <summary>
-        /// Checks whether file or directory exists.
-        /// </summary>
-        /// <param name="path">The path.</param>
-        /// <returns>
-        /// <see langword="true"/> if directory or file exists; otherwise <see langword="false"/>.
-        /// </returns>
-        /// <exception cref="ArgumentException"><paramref name="path"/> is <see langword="null"/> or contains only whitespace characters.</exception>
-        /// <exception cref="SshConnectionException">Client is not connected.</exception>
-        /// <exception cref="SftpPermissionDeniedException">Permission to perform the operation was denied by the remote host. <para>-or-</para> A SSH command was denied by the server.</exception>
-        /// <exception cref="SshException">A SSH error where <see cref="Exception.Message"/> is the message from the remote host.</exception>
-        /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
-        public bool Exists(string path)
-        {
-            CheckDisposed();
-            ArgumentException.ThrowIfNullOrWhiteSpace(path);
-
-            if (_sftpSession is null)
-            {
-                throw new SshConnectionException("Client not connected.");
-            }
-
-            var fullPath = _sftpSession.GetCanonicalPath(path);
-
-            /*
-             * Using SSH_FXP_REALPATH is not an alternative as the SFTP specification has not always
-             * been clear on how the server should respond when the specified path is not present on
-             * the server:
-             *
-             * SSH 1 to 4:
-             * No mention of how the server should respond if the path is not present on the server.
-             *
-             * SSH 5:
-             * The server SHOULD fail the request if the path is not present on the server.
-             *
-             * SSH 6:
-             * Draft 06: The server SHOULD fail the request if the path is not present on the server.
-             * Draft 07 to 13: The server MUST NOT fail the request if the path does not exist.
-             *
-             * Note that SSH 6 (draft 06 and forward) allows for more control options, but we
-             * currently only support up to v3.
-             */
-
-            try
-            {
-                _ = _sftpSession.RequestLStat(fullPath);
-                return true;
-            }
-            catch (SftpPathNotFoundException)
-            {
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Checks whether file or directory exists.
-        /// </summary>
-        /// <param name="path">The path.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to observe.</param>
-        /// <returns>
-        /// A <see cref="Task{T}"/> that represents the exists operation.
-        /// The task result contains <see langword="true"/> if directory or file exists; otherwise <see langword="false"/>.
-        /// </returns>
-        /// <exception cref="ArgumentException"><paramref name="path"/> is <see langword="null"/> or contains only whitespace characters.</exception>
-        /// <exception cref="SshConnectionException">Client is not connected.</exception>
-        /// <exception cref="SftpPermissionDeniedException">Permission to perform the operation was denied by the remote host. <para>-or-</para> A SSH command was denied by the server.</exception>
-        /// <exception cref="SshException">A SSH error where <see cref="Exception.Message"/> is the message from the remote host.</exception>
-        /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
+        /// <inheritdoc />
+        [Zomp.SyncMethodGenerator.CreateSyncVersion]
         public async Task<bool> ExistsAsync(string path, CancellationToken cancellationToken = default)
         {
             CheckDisposed();
@@ -1335,43 +1116,8 @@ namespace Renci.SshNet
             ar.EndInvoke();
         }
 
-        /// <summary>
-        /// Gets status using statvfs@openssh.com request.
-        /// </summary>
-        /// <param name="path">The path.</param>
-        /// <returns>
-        /// A <see cref="SftpFileSystemInformation"/> instance that contains file status information.
-        /// </returns>
-        /// <exception cref="SshConnectionException">Client is not connected.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="path" /> is <see langword="null"/>.</exception>
-        /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
-        public SftpFileSystemInformation GetStatus(string path)
-        {
-            CheckDisposed();
-            ArgumentNullException.ThrowIfNull(path);
-
-            if (_sftpSession is null)
-            {
-                throw new SshConnectionException("Client not connected.");
-            }
-
-            var fullPath = _sftpSession.GetCanonicalPath(path);
-
-            return _sftpSession.RequestStatVfs(fullPath);
-        }
-
-        /// <summary>
-        /// Asynchronously gets status using statvfs@openssh.com request.
-        /// </summary>
-        /// <param name="path">The path.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to observe.</param>
-        /// <returns>
-        /// A <see cref="Task{SftpFileSystemInformation}"/> that represents the status operation.
-        /// The task result contains the <see cref="SftpFileSystemInformation"/> instance that contains file status information.
-        /// </returns>
-        /// <exception cref="SshConnectionException">Client is not connected.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="path" /> is <see langword="null"/>.</exception>
-        /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
+        /// <inheritdoc />
+        [Zomp.SyncMethodGenerator.CreateSyncVersion]
         public async Task<SftpFileSystemInformation> GetStatusAsync(string path, CancellationToken cancellationToken)
         {
             CheckDisposed();
@@ -1572,21 +1318,8 @@ namespace Renci.SshNet
             return new StreamWriter(Open(path, FileMode.Create, FileAccess.Write), encoding);
         }
 
-        /// <summary>
-        /// Deletes the specified file or directory.
-        /// </summary>
-        /// <param name="path">The name of the file or directory to be deleted. Wildcard characters are not supported.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/>.</exception>
-        /// <exception cref="SshConnectionException">Client is not connected.</exception>
-        /// <exception cref="SftpPathNotFoundException"><paramref name="path"/> was not found on the remote host.</exception>
-        /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
-        public void Delete(string path)
-        {
-            var file = Get(path);
-            file.Delete();
-        }
-
         /// <inheritdoc />
+        [Zomp.SyncMethodGenerator.CreateSyncVersion]
         public async Task DeleteAsync(string path, CancellationToken cancellationToken = default)
         {
             var file = await GetAsync(path, cancellationToken).ConfigureAwait(false);
@@ -1677,39 +1410,8 @@ namespace Renci.SshNet
             return Open(path, mode, FileAccess.ReadWrite);
         }
 
-        /// <summary>
-        /// Opens a <see cref="SftpFileStream"/> on the specified path, with the specified mode and access.
-        /// </summary>
-        /// <param name="path">The file to open.</param>
-        /// <param name="mode">A <see cref="FileMode"/> value that specifies whether a file is created if one does not exist, and determines whether the contents of existing files are retained or overwritten.</param>
-        /// <param name="access">A <see cref="FileAccess"/> value that specifies the operations that can be performed on the file.</param>
-        /// <returns>
-        /// An unshared <see cref="SftpFileStream"/> that provides access to the specified file, with the specified mode and access.
-        /// </returns>
-        /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/>.</exception>
-        /// <exception cref="SshConnectionException">Client is not connected.</exception>
-        /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
-        public SftpFileStream Open(string path, FileMode mode, FileAccess access)
-        {
-            CheckDisposed();
-
-            return SftpFileStream.Open(_sftpSession, path, mode, access, (int)_bufferSize);
-        }
-
-        /// <summary>
-        /// Asynchronously opens a <see cref="SftpFileStream"/> on the specified path, with the specified mode and access.
-        /// </summary>
-        /// <param name="path">The file to open.</param>
-        /// <param name="mode">A <see cref="FileMode"/> value that specifies whether a file is created if one does not exist, and determines whether the contents of existing files are retained or overwritten.</param>
-        /// <param name="access">A <see cref="FileAccess"/> value that specifies the operations that can be performed on the file.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to observe.</param>
-        /// <returns>
-        /// A <see cref="Task{SftpFileStream}"/> that represents the asynchronous open operation.
-        /// The task result contains the <see cref="SftpFileStream"/> that provides access to the specified file, with the specified mode and access.
-        /// </returns>
-        /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/>.</exception>
-        /// <exception cref="SshConnectionException">Client is not connected.</exception>
-        /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
+        /// <inheritdoc />
+        [Zomp.SyncMethodGenerator.CreateSyncVersion]
         public Task<SftpFileStream> OpenAsync(string path, FileMode mode, FileAccess access, CancellationToken cancellationToken)
         {
             CheckDisposed();
@@ -2023,44 +1725,8 @@ namespace Renci.SshNet
             }
         }
 
-        /// <summary>
-        /// Gets the <see cref="SftpFileAttributes"/> of the file on the path.
-        /// </summary>
-        /// <param name="path">The path to the file.</param>
-        /// <returns>
-        /// The <see cref="SftpFileAttributes"/> of the file on the path.
-        /// </returns>
-        /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/>.</exception>
-        /// <exception cref="SshConnectionException">Client is not connected.</exception>
-        /// <exception cref="SftpPathNotFoundException"><paramref name="path"/> was not found on the remote host.</exception>
-        /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
-        public SftpFileAttributes GetAttributes(string path)
-        {
-            CheckDisposed();
-
-            if (_sftpSession is null)
-            {
-                throw new SshConnectionException("Client not connected.");
-            }
-
-            var fullPath = _sftpSession.GetCanonicalPath(path);
-
-            return _sftpSession.RequestLStat(fullPath);
-        }
-
-        /// <summary>
-        /// Gets the <see cref="SftpFileAttributes"/> of the file on the path.
-        /// </summary>
-        /// <param name="path">The path to the file.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to observe.</param>
-        /// <returns>
-        /// A <see cref="Task{SftpFileAttributes}"/> that represents the attribute retrieval operation.
-        /// The task result contains the <see cref="SftpFileAttributes"/> of the file on the path.
-        /// </returns>
-        /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/>.</exception>
-        /// <exception cref="SshConnectionException">Client is not connected.</exception>
-        /// <exception cref="SftpPathNotFoundException"><paramref name="path"/> was not found on the remote host.</exception>
-        /// <exception cref="ObjectDisposedException">The method was called after the client was disposed.</exception>
+        /// <inheritdoc />
+        [Zomp.SyncMethodGenerator.CreateSyncVersion]
         public async Task<SftpFileAttributes> GetAttributesAsync(string path, CancellationToken cancellationToken)
         {
             CheckDisposed();


### PR DESCRIPTION
## What this is

Ten of the synchronous methods on `SftpClient` are mechanical translations of the asynchronous ones beside them - the same argument checks, the same session calls with `Async` dropped, the same order. Each is maintained by hand next to its twin, so every fix has to be made twice.

This generates the synchronous version from the asynchronous source at compile time, into the same partial class. The public API is unchanged.

`DeleteFile` is representative:

```cs
public async Task DeleteFileAsync(string path, CancellationToken cancellationToken)
{
    CheckDisposed();
    ArgumentException.ThrowIfNullOrWhiteSpace(path);

    if (_sftpSession is null)
    {
        throw new SshConnectionException("Client not connected.");
    }

    cancellationToken.ThrowIfCancellationRequested();

    var fullPath = await _sftpSession.GetCanonicalPathAsync(path, cancellationToken).ConfigureAwait(false);
    await _sftpSession.RequestRemoveAsync(fullPath, cancellationToken).ConfigureAwait(false);
}
```

`await` is unwrapped, `Task` becomes `void`, the token parameter and the statements which only exist to observe it are dropped, `GetCanonicalPathAsync` resolves to `GetCanonicalPath`, and what comes out is exactly the `DeleteFile` which is in the file today.

## Verification

I compared each generated method against the hand-written one it replaces, reducing the fully qualified names the generator emits. **All ten are identical** - not equivalent, identical. The methods are `ChangeDirectory`, `CreateDirectory`, `DeleteDirectory`, `DeleteFile`, `Get`, `Exists`, `GetStatus`, `Delete`, `Open(string, FileMode, FileAccess)` and `GetAttributes`.

- `dotnet build Renci.SshNet.slnx -c Release` - clean, no new warnings, across all five target frameworks
- `Renci.SshNet.Tests` on net10.0 - 2312 passed, 0 failed, 12 skipped
- Integration tests not run here; they need Docker, which I do not have set up for this repository

To read what is generated:

```
dotnet build src/Renci.SshNet/Renci.SshNet.csproj -p:EmitCompilerGeneratedFiles=true
```

## Documentation

The converted async methods now carry `<inheritdoc />` where they previously repeated what `ISftpClient` already declares. That is the pattern `DeleteFileAsync` and `DeleteDirectoryAsync` already use, and the generated synchronous methods inherit the same documentation from the interface. Published documentation is unchanged - worth stating plainly, since the docs site is built from these.

## Deliberately left alone

- **`RenameFile`** - the synchronous version routes through an `isPosix` overload which the async version has no equivalent of, so the two are not twins.
- **`DownloadFile`, `UploadFile`, `ListDirectory`** - these genuinely differ between the two versions rather than being translations.

`SftpSession` has another 16 pairs in the same shape. I have not touched them; if this lands well, that is the obvious follow-up.

## About the dependency

[Zomp.SyncMethodGenerator](https://github.com/zompinc/sync-method-generator) is a Roslyn source generator, referenced with `PrivateAssets="all"`, so it adds nothing to the shipped package or the runtime graph. [SharpCompress adopted it](https://github.com/adamhathcock/sharpcompress/pull/1381) earlier this week for the same reason.

Disclosure: I maintain the generator. Two fixes went into it while preparing this PR - crefs in generated documentation not resolving, which would otherwise have been a build failure here, and argument list spacing. I am proposing this because the duplication in this file is exactly the case the tool handles, but if you would rather not take a build-time dependency, no hard feelings and I will close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)