### PR TITLE
Add ConnectionHandler for customizing connection establishment

### DIFF
--- a/docfx/examples.md
+++ b/docfx/examples.md
@@ -126,6 +126,54 @@ using (var client = new SshClient("sftp.foo.com", "user", "password"))
 }
 ```
 
+### Customize the underlying socket connection
+
+Implement `ConnectionHandler` (or `DelegatingConnectionHandler`, if you only want to customize
+part of the default behavior) to configure the underlying socket beyond what `ConnectionInfo`
+exposes directly - for example, tuning the socket's buffer sizes on a high-latency connection:
+
+```cs
+public class BufferSizeConnectionHandler : DelegatingConnectionHandler
+{
+    private readonly int _bufferSize;
+
+    public BufferSizeConnectionHandler(ConnectionHandler inner, int bufferSize) : base(inner)
+    {
+        _bufferSize = bufferSize;
+    }
+
+    public override Socket Connect(ConnectionInfo connectionInfo)
+    {
+        var socket = base.Connect(connectionInfo);
+        socket.SendBufferSize = socket.ReceiveBufferSize = _bufferSize;
+        return socket;
+    }
+
+    public override async Task<Socket> ConnectAsync(ConnectionInfo connectionInfo, CancellationToken cancellationToken)
+    {
+        var socket = await base.ConnectAsync(connectionInfo, cancellationToken).ConfigureAwait(false);
+        socket.SendBufferSize = socket.ReceiveBufferSize = _bufferSize;
+        return socket;
+    }
+}
+```
+
+```cs
+var connectionInfo = new ConnectionInfo("sftp.foo.com", "guest", new PasswordAuthenticationMethod("guest", "pwd"))
+{
+    // DefaultConnectionHandler.Instance retains this library's built-in connection behavior,
+    // including proxy support, alongside your own customization.
+    ConnectionHandler = new BufferSizeConnectionHandler(DefaultConnectionHandler.Instance, 1024 * 1024)
+};
+
+using (var client = new SftpClient(connectionInfo))
+{
+    client.Connect();
+}
+```
+
+Multiple handlers can be composed by nesting them, similar to `DelegatingHandler` for `HttpClient`.
+
 ### Stream data to a command
 
 ```cs

--- a/src/Renci.SshNet/Connection/ConnectionHandler.cs
+++ b/src/Renci.SshNet/Connection/ConnectionHandler.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Renci.SshNet.Connection
+{
+    /// <summary>
+    /// Represents a way to establish the underlying transport connection for an SSH session.
+    /// </summary>
+    /// <remarks>
+    /// Implement this class to customize how the underlying <see cref="Socket"/> for a connection is
+    /// established, for example to configure socket options that <see cref="ConnectionInfo"/> does not
+    /// expose directly. Assign an instance to <see cref="ConnectionInfo.ConnectionHandler"/> to use it.
+    /// Multiple handlers can be composed by nesting <see cref="DelegatingConnectionHandler"/>
+    /// implementations, similar to <c>DelegatingHandler</c> for <c>HttpClient</c>.
+    /// </remarks>
+    public abstract class ConnectionHandler : IDisposable
+    {
+        /// <summary>
+        /// Establishes a connection and returns the connected <see cref="Socket"/>.
+        /// </summary>
+        /// <param name="connectionInfo">The connection information.</param>
+        /// <returns>
+        /// A <see cref="Socket"/> connected as specified by <paramref name="connectionInfo"/>.
+        /// </returns>
+        public abstract Socket Connect(ConnectionInfo connectionInfo);
+
+        /// <summary>
+        /// Asynchronously establishes a connection and returns the connected <see cref="Socket"/>.
+        /// </summary>
+        /// <param name="connectionInfo">The connection information.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>
+        /// A <see cref="Socket"/> connected as specified by <paramref name="connectionInfo"/>.
+        /// </returns>
+        public abstract Task<Socket> ConnectAsync(ConnectionInfo connectionInfo, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases unmanaged and - optionally - managed resources.
+        /// </summary>
+        /// <param name="disposing"><see langword="true"/> to release both managed and unmanaged resources; <see langword="false"/> to release only unmanaged resources.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+        }
+    }
+}

--- a/src/Renci.SshNet/Connection/DefaultConnectionHandler.cs
+++ b/src/Renci.SshNet/Connection/DefaultConnectionHandler.cs
@@ -5,18 +5,20 @@ using System.Threading.Tasks;
 namespace Renci.SshNet.Connection
 {
     /// <summary>
-    /// The <see cref="ConnectionHandler"/> used when no custom <see cref="ConnectionInfo.ConnectionHandler"/>
-    /// is configured.
+    /// A <see cref="ConnectionHandler"/> that reproduces this library's built-in connection
+    /// establishment behavior, including proxy support.
     /// </summary>
     /// <remarks>
     /// Use <see cref="Instance"/> as the innermost handler when composing a custom
-    /// <see cref="ConnectionHandler"/> chain, to retain this library's built-in connection
-    /// establishment behavior (including proxy support) alongside your own customizations.
+    /// <see cref="ConnectionHandler"/> chain, to retain the built-in behavior alongside your
+    /// own customizations. When <see cref="ConnectionInfo.ConnectionHandler"/> is left unset,
+    /// this type is not used - the built-in behavior runs as it always has, without going
+    /// through this class.
     /// </remarks>
     public sealed class DefaultConnectionHandler : ConnectionHandler
     {
-        private static readonly ServiceFactory ServiceFactory = new();
-        private static readonly SocketFactory SocketFactory = new();
+        private static readonly ServiceFactory DefaultServiceFactory = new();
+        private static readonly SocketFactory DefaultSocketFactory = new();
 
         /// <summary>
         /// Gets the singleton instance of <see cref="DefaultConnectionHandler"/>.
@@ -30,13 +32,13 @@ namespace Renci.SshNet.Connection
         /// <inheritdoc/>
         public override Socket Connect(ConnectionInfo connectionInfo)
         {
-            return ServiceFactory.CreateConnector(connectionInfo, SocketFactory).Connect(connectionInfo);
+            return DefaultServiceFactory.CreateConnector(connectionInfo, DefaultSocketFactory).Connect(connectionInfo);
         }
 
         /// <inheritdoc/>
         public override Task<Socket> ConnectAsync(ConnectionInfo connectionInfo, CancellationToken cancellationToken)
         {
-            return ServiceFactory.CreateConnector(connectionInfo, SocketFactory).ConnectAsync(connectionInfo, cancellationToken);
+            return DefaultServiceFactory.CreateConnector(connectionInfo, DefaultSocketFactory).ConnectAsync(connectionInfo, cancellationToken);
         }
     }
 }

--- a/src/Renci.SshNet/Connection/DefaultConnectionHandler.cs
+++ b/src/Renci.SshNet/Connection/DefaultConnectionHandler.cs
@@ -1,0 +1,42 @@
+﻿using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Renci.SshNet.Connection
+{
+    /// <summary>
+    /// The <see cref="ConnectionHandler"/> used when no custom <see cref="ConnectionInfo.ConnectionHandler"/>
+    /// is configured.
+    /// </summary>
+    /// <remarks>
+    /// Use <see cref="Instance"/> as the innermost handler when composing a custom
+    /// <see cref="ConnectionHandler"/> chain, to retain this library's built-in connection
+    /// establishment behavior (including proxy support) alongside your own customizations.
+    /// </remarks>
+    public sealed class DefaultConnectionHandler : ConnectionHandler
+    {
+        private static readonly ServiceFactory ServiceFactory = new();
+        private static readonly SocketFactory SocketFactory = new();
+
+        /// <summary>
+        /// Gets the singleton instance of <see cref="DefaultConnectionHandler"/>.
+        /// </summary>
+        public static DefaultConnectionHandler Instance { get; } = new DefaultConnectionHandler();
+
+        private DefaultConnectionHandler()
+        {
+        }
+
+        /// <inheritdoc/>
+        public override Socket Connect(ConnectionInfo connectionInfo)
+        {
+            return ServiceFactory.CreateConnector(connectionInfo, SocketFactory).Connect(connectionInfo);
+        }
+
+        /// <inheritdoc/>
+        public override Task<Socket> ConnectAsync(ConnectionInfo connectionInfo, CancellationToken cancellationToken)
+        {
+            return ServiceFactory.CreateConnector(connectionInfo, SocketFactory).ConnectAsync(connectionInfo, cancellationToken);
+        }
+    }
+}

--- a/src/Renci.SshNet/Connection/DelegatingConnectionHandler.cs
+++ b/src/Renci.SshNet/Connection/DelegatingConnectionHandler.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Renci.SshNet.Connection
+{
+    /// <summary>
+    /// A base type for a <see cref="ConnectionHandler"/> that wraps and delegates to another
+    /// <see cref="ConnectionHandler"/>.
+    /// </summary>
+    /// <remarks>
+    /// Override only the members you want to customize; the rest forward to
+    /// <see cref="InnerHandler"/> by default. This mirrors <c>DelegatingHandler</c> for <c>HttpClient</c>.
+    /// </remarks>
+    public abstract class DelegatingConnectionHandler : ConnectionHandler
+    {
+        /// <summary>
+        /// Gets the inner handler which this instance delegates to by default.
+        /// </summary>
+        protected ConnectionHandler InnerHandler { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DelegatingConnectionHandler"/> class.
+        /// </summary>
+        /// <param name="innerHandler">The inner handler which this instance delegates to by default.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="innerHandler"/> is <see langword="null"/>.</exception>
+        protected DelegatingConnectionHandler(ConnectionHandler innerHandler)
+        {
+            ArgumentNullException.ThrowIfNull(innerHandler);
+
+            InnerHandler = innerHandler;
+        }
+
+        /// <inheritdoc/>
+        public override Socket Connect(ConnectionInfo connectionInfo)
+        {
+            return InnerHandler.Connect(connectionInfo);
+        }
+
+        /// <inheritdoc/>
+        public override Task<Socket> ConnectAsync(ConnectionInfo connectionInfo, CancellationToken cancellationToken)
+        {
+            return InnerHandler.ConnectAsync(connectionInfo, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                InnerHandler.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Renci.SshNet/ConnectionInfo.cs
+++ b/src/Renci.SshNet/ConnectionInfo.cs
@@ -12,6 +12,7 @@ using Org.BouncyCastle.Crypto.Agreement;
 
 using Renci.SshNet.Common;
 using Renci.SshNet.Compression;
+using Renci.SshNet.Connection;
 using Renci.SshNet.Messages.Authentication;
 using Renci.SshNet.Messages.Connection;
 using Renci.SshNet.Security;
@@ -216,6 +217,15 @@ namespace Renci.SshNet
         /// value is 10.
         /// </value>
         public int MaxSessions { get; set; }
+
+        /// <summary>
+        /// Gets or sets the handler used to establish the underlying transport connection.
+        /// </summary>
+        /// <value>
+        /// The connection handler, or <see langword="null"/> to use this library's built-in
+        /// connection establishment behavior. The default value is <see langword="null"/>.
+        /// </value>
+        public ConnectionHandler? ConnectionHandler { get; set; }
 
         /// <summary>
         /// Occurs when authentication banner is sent by the server.

--- a/src/Renci.SshNet/Session.cs
+++ b/src/Renci.SshNet/Session.cs
@@ -599,8 +599,9 @@ namespace Renci.SshNet
                 // Build list of available messages while connecting
                 _sshMessageFactory = new SshMessageFactory();
 
-                _socket = _serviceFactory.CreateConnector(ConnectionInfo, _socketFactory)
-                                            .Connect(ConnectionInfo);
+                _socket = ConnectionInfo.ConnectionHandler is { } connectionHandler
+                                            ? connectionHandler.Connect(ConnectionInfo)
+                                            : _serviceFactory.CreateConnector(ConnectionInfo, _socketFactory).Connect(ConnectionInfo);
 
                 var serverIdentification = _serviceFactory.CreateProtocolVersionExchange()
                                                             .Start(ClientVersion, _socket, ConnectionInfo.Timeout);
@@ -724,8 +725,9 @@ namespace Renci.SshNet
                 // Build list of available messages while connecting
                 _sshMessageFactory = new SshMessageFactory();
 
-                _socket = await _serviceFactory.CreateConnector(ConnectionInfo, _socketFactory)
-                                            .ConnectAsync(ConnectionInfo, cancellationToken).ConfigureAwait(false);
+                _socket = ConnectionInfo.ConnectionHandler is { } connectionHandler
+                                            ? await connectionHandler.ConnectAsync(ConnectionInfo, cancellationToken).ConfigureAwait(false)
+                                            : await _serviceFactory.CreateConnector(ConnectionInfo, _socketFactory).ConnectAsync(ConnectionInfo, cancellationToken).ConfigureAwait(false);
 
                 var serverIdentification = await _serviceFactory.CreateProtocolVersionExchange()
                                                             .StartAsync(ClientVersion, _socket, cancellationToken).ConfigureAwait(false);

--- a/test/Renci.SshNet.Tests/Classes/Connection/DefaultConnectionHandlerTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Connection/DefaultConnectionHandlerTest.cs
@@ -1,0 +1,55 @@
+﻿using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Renci.SshNet.Connection;
+using Renci.SshNet.Tests.Common;
+
+namespace Renci.SshNet.Tests.Classes.Connection
+{
+    [TestClass]
+    public class DefaultConnectionHandlerTest
+    {
+        [TestMethod]
+        public void InstanceShouldReturnTheSameObjectEachTime()
+        {
+            Assert.AreSame(DefaultConnectionHandler.Instance, DefaultConnectionHandler.Instance);
+        }
+
+        [TestMethod]
+        public void ConnectShouldEstablishAConnection()
+        {
+            var connectionInfo = new ConnectionInfo(
+                IPAddress.Loopback.ToString(),
+                1029,
+                "user",
+                new NoneAuthenticationMethod("user"));
+
+            using var server = new AsyncSocketListener(new IPEndPoint(IPAddress.Loopback, connectionInfo.Port));
+            server.Start();
+
+            using var socket = DefaultConnectionHandler.Instance.Connect(connectionInfo);
+
+            Assert.IsTrue(socket.Connected);
+        }
+
+        [TestMethod]
+        public async Task ConnectAsyncShouldEstablishAConnection()
+        {
+            var connectionInfo = new ConnectionInfo(
+                IPAddress.Loopback.ToString(),
+                1030,
+                "user",
+                new NoneAuthenticationMethod("user"));
+
+            using var server = new AsyncSocketListener(new IPEndPoint(IPAddress.Loopback, connectionInfo.Port));
+            server.Start();
+
+            using var socket = await DefaultConnectionHandler.Instance.ConnectAsync(connectionInfo, CancellationToken.None);
+
+            Assert.IsTrue(socket.Connected);
+        }
+    }
+}

--- a/test/Renci.SshNet.Tests/Classes/Connection/DelegatingConnectionHandlerTest.cs
+++ b/test/Renci.SshNet.Tests/Classes/Connection/DelegatingConnectionHandlerTest.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Renci.SshNet.Connection;
+
+namespace Renci.SshNet.Tests.Classes.Connection
+{
+    [TestClass]
+    public class DelegatingConnectionHandlerTest
+    {
+        private FakeConnectionHandler _innerHandler;
+        private TestableDelegatingConnectionHandler _handler;
+        private ConnectionInfo _connectionInfo;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _innerHandler = new FakeConnectionHandler();
+            _handler = new TestableDelegatingConnectionHandler(_innerHandler);
+            _connectionInfo = new ConnectionInfo("host", "user", new NoneAuthenticationMethod("user"));
+        }
+
+        [TestCleanup]
+        public void TearDown()
+        {
+            _innerHandler.SocketToReturn.Dispose();
+        }
+
+        [TestMethod]
+        public void ConstructorShouldThrowArgumentNullExceptionWhenInnerHandlerIsNull()
+        {
+            _ = Assert.ThrowsExactly<ArgumentNullException>(() => _ = new TestableDelegatingConnectionHandler(innerHandler: null));
+        }
+
+        [TestMethod]
+        public void ConnectShouldDelegateToInnerHandler()
+        {
+            var actual = _handler.Connect(_connectionInfo);
+
+            Assert.AreSame(_innerHandler.SocketToReturn, actual);
+            Assert.AreEqual(1, _innerHandler.ConnectCallCount);
+        }
+
+        [TestMethod]
+        public async Task ConnectAsyncShouldDelegateToInnerHandler()
+        {
+            var actual = await _handler.ConnectAsync(_connectionInfo, CancellationToken.None);
+
+            Assert.AreSame(_innerHandler.SocketToReturn, actual);
+            Assert.AreEqual(1, _innerHandler.ConnectAsyncCallCount);
+        }
+
+        [TestMethod]
+        public void DisposeShouldDisposeInnerHandler()
+        {
+            _handler.Dispose();
+
+            Assert.AreEqual(1, _innerHandler.DisposeCallCount);
+        }
+
+        private sealed class TestableDelegatingConnectionHandler : DelegatingConnectionHandler
+        {
+            public TestableDelegatingConnectionHandler(ConnectionHandler innerHandler)
+                : base(innerHandler)
+            {
+            }
+        }
+
+        private sealed class FakeConnectionHandler : ConnectionHandler
+        {
+            public Socket SocketToReturn { get; } = new Socket(SocketType.Stream, ProtocolType.Tcp);
+
+            public int ConnectCallCount { get; private set; }
+
+            public int ConnectAsyncCallCount { get; private set; }
+
+            public int DisposeCallCount { get; private set; }
+
+            public override Socket Connect(ConnectionInfo connectionInfo)
+            {
+                ConnectCallCount++;
+                return SocketToReturn;
+            }
+
+            public override Task<Socket> ConnectAsync(ConnectionInfo connectionInfo, CancellationToken cancellationToken)
+            {
+                ConnectAsyncCallCount++;
+                return Task.FromResult(SocketToReturn);
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    DisposeCallCount++;
+                }
+
+                base.Dispose(disposing);
+            }
+        }
+    }
+}

--- a/test/Renci.SshNet.Tests/Classes/SessionTest_ConnectingBase.cs
+++ b/test/Renci.SshNet.Tests/Classes/SessionTest_ConnectingBase.cs
@@ -203,12 +203,18 @@ namespace Renci.SshNet.Tests.Classes
             _clientAuthenticationMock = new Mock<IClientAuthentication>(MockBehavior.Strict);
         }
 
-        private void SetupMocks()
+        protected virtual void SetupConnectorMocks()
         {
             _ = ServiceFactoryMock.Setup(p => p.CreateConnector(ConnectionInfo, SocketFactoryMock.Object))
                                   .Returns(ConnectorMock.Object);
             _ = ConnectorMock.Setup(p => p.Connect(ConnectionInfo))
                              .Returns(ClientSocket);
+        }
+
+        private void SetupMocks()
+        {
+            SetupConnectorMocks();
+
             _ = ServiceFactoryMock.Setup(p => p.CreateProtocolVersionExchange())
                                   .Returns(_protocolVersionExchangeMock.Object);
             _ = _protocolVersionExchangeMock.Setup(p => p.Start(Session.ClientVersion, ClientSocket, ConnectionInfo.Timeout))

--- a/test/Renci.SshNet.Tests/Classes/SessionTest_Connecting_WithCustomConnectionHandler.cs
+++ b/test/Renci.SshNet.Tests/Classes/SessionTest_Connecting_WithCustomConnectionHandler.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Moq;
+
+using Renci.SshNet.Connection;
+
+namespace Renci.SshNet.Tests.Classes
+{
+    [TestClass]
+    public class SessionTest_Connecting_WithCustomConnectionHandler : SessionTest_ConnectingBase
+    {
+        internal Mock<ConnectionHandler> ConnectionHandlerMock { get; private set; }
+
+        protected override void SetupData()
+        {
+            base.SetupData();
+
+            ConnectionHandlerMock = new Mock<ConnectionHandler>(MockBehavior.Strict);
+            ConnectionInfo.ConnectionHandler = ConnectionHandlerMock.Object;
+        }
+
+        protected override void SetupConnectorMocks()
+        {
+            _ = ConnectionHandlerMock.Setup(p => p.Connect(ConnectionInfo))
+                                      .Returns(ClientSocket);
+        }
+
+        [TestMethod]
+        public void ConnectShouldUseTheConfiguredConnectionHandlerInsteadOfTheDefault()
+        {
+            Session.Connect();
+
+            ConnectionHandlerMock.Verify(p => p.Connect(ConnectionInfo), Times.Once);
+            ServiceFactoryMock.Verify(p => p.CreateConnector(It.IsAny<IConnectionInfo>(), It.IsAny<ISocketFactory>()), Times.Never);
+        }
+    }
+}


### PR DESCRIPTION
## What this does

Adds a public, composable `ConnectionHandler` abstraction for customizing how the underlying socket connection is established — mirroring `System.Net.Http.DelegatingHandler`/`HttpClient`, as discussed in #1821.

- `ConnectionHandler` — abstract base (`Connect`/`ConnectAsync`/`Dispose`)
- `DelegatingConnectionHandler` — wraps an inner handler, forwards by default; override only what you need
- `DefaultConnectionHandler` — public singleton reproducing this library's built-in connect behavior (including proxy support), usable as the innermost handler in a custom chain
- `ConnectionInfo.ConnectionHandler` — new opt-in property, default `null`

`Session`'s own default path is unchanged — it still goes through the existing connector machinery directly, and is only bypassed when a caller explicitly sets `ConnectionInfo.ConnectionHandler`.

## Testing

New tests for the handler delegation logic, `DefaultConnectionHandler`, and that `Session` uses a custom handler when one is set. Full existing suite passes, no regressions.

## Docs

Added an example to `docfx/examples.md` showing how to compose a custom handler on top of `DefaultConnectionHandler`.

cc @Rob-Hague @drieseng @WojciechNagorski