### PR TITLE
Reset server MAC after TransformFinalBlock on .NET FW

### DIFF
--- a/src/Renci.SshNet/Session.cs
+++ b/src/Renci.SshNet/Session.cs
@@ -1327,6 +1327,11 @@ namespace Renci.SshNet
                 {
                     throw new SshConnectionException("MAC error", DisconnectReason.MacError);
                 }
+#if NETFRAMEWORK
+                // Ensure MAC is reset so that it can be reused for the next packet
+                // It is only required for certain older .NET Framework builds, e.g., mscorlib.dll version 4.8.4110.0
+                _serverMac.Initialize();
+#endif
             }
 
             var numberOfBytesToDecrypt = 4 + packetLength - blockSize;
@@ -1374,6 +1379,11 @@ namespace Renci.SshNet
                 {
                     throw new SshConnectionException("MAC error", DisconnectReason.MacError);
                 }
+#if NETFRAMEWORK
+                // Ensure MAC is reset so that it can be reused for the next packet
+                // It is only required for certain older .NET Framework builds, e.g., mscorlib.dll version 4.8.4110.0
+                _serverMac.Initialize();
+#endif
             }
 
             var paddingLength = _receiveBuffer.ActiveReadOnlySpan[packetLengthFieldLength];


### PR DESCRIPTION
Call `_serverMac.Initialize()` after `TransformFinalBlock` when running on .NET Framework. This ensures the MAC is properly reset, addressing differences in cryptographic API behavior across different versions of mscorlib.dll.

Close https://github.com/sshnet/SSH.NET/issues/1829