### PR TITLE
Add net11.0 target / drop net8.0 and net9.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,16 +148,7 @@ jobs:
           -f net48 `
           --logger "console;verbosity=normal" `
           --logger GitHubActions `
-          -p:CollectCoverage=true `
-          -p:CoverletOutputFormat=cobertura `
-          -p:CoverletOutput=..\..\coverlet\windows_integration_test_net_4_8_coverage.xml `
           test\Renci.SshNet.IntegrationTests\
-
-    - name: Archive Coverlet Results
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: Coverlet Results Windows .NET Framework
-        path: coverlet
 
   Windows-Integration-Tests-Net:
     name: Windows Integration Tests .NET

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ on:
 permissions:
   contents: read
 
+env:
+  DOTNET_TARGET_FRAMEWORK: net11.0
+
 jobs:
   Linux:
     runs-on: ubuntu-24.04
@@ -27,15 +30,15 @@ jobs:
       uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
 
     - name: Build Unit Tests .NET
-      run: dotnet build -f net10.0 test/Renci.SshNet.Tests/
+      run: dotnet build -f $DOTNET_TARGET_FRAMEWORK test/Renci.SshNet.Tests/
 
     - name: Build IntegrationTests .NET
-      run: dotnet build -f net10.0 test/Renci.SshNet.IntegrationTests/
+      run: dotnet build -f $DOTNET_TARGET_FRAMEWORK test/Renci.SshNet.IntegrationTests/
 
     - name: Run Unit Tests .NET
       run: |
         dotnet test \
-          -f net10.0 \
+          -f $DOTNET_TARGET_FRAMEWORK \
           --no-build \
           --logger "console;verbosity=normal" \
           --logger GitHubActions \
@@ -47,7 +50,7 @@ jobs:
     - name: Run Integration Tests .NET
       run: |
         dotnet test \
-          -f net10.0 \
+          -f $DOTNET_TARGET_FRAMEWORK \
           --no-build \
           --logger "console;verbosity=normal" \
           --logger GitHubActions \
@@ -92,7 +95,7 @@ jobs:
     - name: Run Unit Tests .NET
       run: |
         dotnet test `
-          -f net10.0 `
+          -f $DOTNET_TARGET_FRAMEWORK `
           --no-build `
           --logger "console;verbosity=normal" `
           --logger GitHubActions `
@@ -185,7 +188,7 @@ jobs:
     - name: Run Integration Tests .NET
       run:
         dotnet test `
-          -f net10.0 `
+          -f $env:DOTNET_TARGET_FRAMEWORK `
           --logger "console;verbosity=normal" `
           --logger GitHubActions `
           -p:CollectCoverage=true `

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -34,7 +34,7 @@
   <!--
         Disable nullable warnings on old frameworks because of missing annotations.
   -->
-  <PropertyGroup Condition=" !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')) ">
+  <PropertyGroup Condition=" !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0')) ">
     <NoWarn>$(NoWarn);CS8602;CS8604;CS8777</NoWarn>
   </PropertyGroup>
 

--- a/docfx/docfx.json
+++ b/docfx/docfx.json
@@ -13,7 +13,7 @@
       "outputFormat": "apiPage",
       "output": "api",
       "properties": {
-          "TargetFramework": "net8.0"
+          "TargetFramework": "net10.0"
       }
     }
   ],

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.201",
+    "version": "11.0.0-rc.1.26425.128",
     "rollForward": "latestMinor"
   }
 }

--- a/src/Renci.SshNet/Channels/ChannelForwardedTcpip.cs
+++ b/src/Renci.SshNet/Channels/ChannelForwardedTcpip.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Net;
 using System.Net.Sockets;
-#if NET9_0_OR_GREATER
+#if NET
 using System.Threading;
 #endif
 

--- a/src/Renci.SshNet/Common/Lock.cs
+++ b/src/Renci.SshNet/Common/Lock.cs
@@ -1,4 +1,4 @@
-#if !NET9_0_OR_GREATER
+#if !NET
 using System.Threading;
 
 namespace Renci.SshNet.Common

--- a/src/Renci.SshNet/Common/SshDataStream.cs
+++ b/src/Renci.SshNet/Common/SshDataStream.cs
@@ -66,7 +66,7 @@ namespace Renci.SshNet.Common
         // to write directly into the underlying buffer without the need for any intermediate
         // arrays (rented or otherwise).
 
-#if NET9_0_OR_GREATER
+#if NET
         /// <inheritdoc/>
         public override void Write(ReadOnlySpan<byte> buffer)
         {
@@ -75,13 +75,13 @@ namespace Renci.SshNet.Common
 #endif
 
         private delegate void WriteAction<in TArg>(Span<byte> span, TArg arg)
-#if NET9_0_OR_GREATER
+#if NET
             where TArg : allows ref struct
 #endif
             ;
 
         private void Write<TArg>(TArg arg, int numBytesToWrite, WriteAction<TArg> writeAction)
-#if NET9_0_OR_GREATER
+#if NET
             where TArg : allows ref struct
 #endif
         {

--- a/src/Renci.SshNet/Connection/HttpConnector.cs
+++ b/src/Renci.SshNet/Connection/HttpConnector.cs
@@ -38,14 +38,11 @@ namespace Renci.SshNet.Connection
         private const string HttpHeaderPattern = @"(?<fieldName>[^\[\]()<>@,;:\""/?={} \t]+):(?<fieldValue>.+)?";
 
 #if NET
-        private static readonly Regex HttpResponseRegex = GetHttpResponseRegex();
-        private static readonly Regex HttpHeaderRegex = GetHttpHeaderRegex();
-
         [GeneratedRegex(HttpResponsePattern)]
-        private static partial Regex GetHttpResponseRegex();
+        private static partial Regex HttpResponseRegex { get; }
 
         [GeneratedRegex(HttpHeaderPattern)]
-        private static partial Regex GetHttpHeaderRegex();
+        private static partial Regex HttpHeaderRegex { get; }
 #else
         private static readonly Regex HttpResponseRegex = new Regex(HttpResponsePattern, RegexOptions.Compiled);
         private static readonly Regex HttpHeaderRegex = new Regex(HttpHeaderPattern, RegexOptions.Compiled);

--- a/src/Renci.SshNet/Connection/ProtocolVersionExchange.cs
+++ b/src/Renci.SshNet/Connection/ProtocolVersionExchange.cs
@@ -29,10 +29,8 @@ namespace Renci.SshNet.Connection
         private const int MaximumBannerLineLength = 8192;
 
 #if NET
-        private static readonly Regex ServerVersionRegex = GetServerVersionRegex();
-
         [GeneratedRegex(ServerVersionPattern, RegexOptions.ExplicitCapture)]
-        private static partial Regex GetServerVersionRegex();
+        private static partial Regex ServerVersionRegex { get; }
 #else
         private static readonly Regex ServerVersionRegex = new Regex(ServerVersionPattern, RegexOptions.Compiled | RegexOptions.ExplicitCapture);
 #endif

--- a/src/Renci.SshNet/Netconf/NetConfSession.cs
+++ b/src/Renci.SshNet/Netconf/NetConfSession.cs
@@ -24,14 +24,11 @@ namespace Renci.SshNet.NetConf
         private int _messageId;
 
 #if NET
-        private static readonly Regex LengthRegex = GetLengthRegex();
-        private static readonly Regex ReplyRegex = GetReplyRegex();
-
         [GeneratedRegex(LengthPattern)]
-        private static partial Regex GetLengthRegex();
+        private static partial Regex LengthRegex { get; }
 
         [GeneratedRegex(ReplyPattern)]
-        private static partial Regex GetReplyRegex();
+        private static partial Regex ReplyRegex { get; }
 #else
         private static readonly Regex LengthRegex = new Regex(LengthPattern, RegexOptions.Compiled);
         private static readonly Regex ReplyRegex = new Regex(ReplyPattern, RegexOptions.Compiled);

--- a/src/Renci.SshNet/OrderedDictionary.net.cs
+++ b/src/Renci.SshNet/OrderedDictionary.net.cs
@@ -1,4 +1,4 @@
-﻿#if NET9_0_OR_GREATER
+﻿#if NET
 #nullable enable
 #pragma warning disable SA1649 // File name should match first type name
 
@@ -209,15 +209,7 @@ namespace Renci.SshNet
 
         public bool TryAdd(TKey key, TValue value, out int index)
         {
-#if NET10_0_OR_GREATER
             return _impl.TryAdd(key, value, out index);
-#else
-            var success = _impl.TryAdd(key, value);
-
-            index = _impl.IndexOf(key);
-
-            return success;
-#endif
         }
 
         public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
@@ -227,18 +219,7 @@ namespace Renci.SshNet
 
         public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value, out int index)
         {
-#if NET10_0_OR_GREATER
             return _impl.TryGetValue(key, out value, out index);
-#else
-            if (_impl.TryGetValue(key, out value))
-            {
-                index = _impl.IndexOf(key);
-                return true;
-            }
-
-            index = -1;
-            return false;
-#endif
         }
     }
 }

--- a/src/Renci.SshNet/OrderedDictionary.netstandard.cs
+++ b/src/Renci.SshNet/OrderedDictionary.netstandard.cs
@@ -1,4 +1,4 @@
-﻿#if !NET9_0_OR_GREATER
+﻿#if !NET
 #nullable enable
 #pragma warning disable SA1649 // File name should match first type name
 

--- a/src/Renci.SshNet/PrivateKeyFile.cs
+++ b/src/Renci.SshNet/PrivateKeyFile.cs
@@ -115,18 +115,14 @@ namespace Renci.SshNet
         private const string CertificatePattern = @"(?<type>[-\w]+@openssh\.com)\s(?<data>[a-zA-Z0-9\/+=]*)(\s+(?<comment>.*))?";
 
 #if NET
-        private static readonly Regex PrivateKeyRegex = GetPrivateKeyRegex();
-        private static readonly Regex PuTTYPrivateKeyRegex = GetPrivateKeyPuTTYRegex();
-        private static readonly Regex CertificateRegex = GetCertificateRegex();
-
         [GeneratedRegex(PrivateKeyPattern, RegexOptions.Multiline | RegexOptions.ExplicitCapture)]
-        private static partial Regex GetPrivateKeyRegex();
+        private static partial Regex PrivateKeyRegex { get; }
 
         [GeneratedRegex(PuTTYPrivateKeyPattern, RegexOptions.Multiline | RegexOptions.ExplicitCapture)]
-        private static partial Regex GetPrivateKeyPuTTYRegex();
+        private static partial Regex PuTTYPrivateKeyRegex { get; }
 
         [GeneratedRegex(CertificatePattern, RegexOptions.ExplicitCapture)]
-        private static partial Regex GetCertificateRegex();
+        private static partial Regex CertificateRegex { get; }
 #else
         private static readonly Regex PrivateKeyRegex = new Regex(PrivateKeyPattern, RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.ExplicitCapture);
         private static readonly Regex PuTTYPrivateKeyRegex = new Regex(PuTTYPrivateKeyPattern, RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.ExplicitCapture);

--- a/src/Renci.SshNet/Renci.SshNet.csproj
+++ b/src/Renci.SshNet/Renci.SshNet.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>Renci.SshNet</AssemblyName>
     <Product>SSH.NET</Product>
     <AssemblyTitle>SSH.NET</AssemblyTitle>
-    <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Renci.SshNet/Renci.SshNet.csproj
+++ b/src/Renci.SshNet/Renci.SshNet.csproj
@@ -42,11 +42,14 @@
 
   <ItemGroup>
     <PackageReference Include="BouncyCastle.Cryptography" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" />
     <PackageReference Include="PolySharp" PrivateAssets="all">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition=" !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net11.0')) ">
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">

--- a/src/Renci.SshNet/Renci.SshNet.csproj
+++ b/src/Renci.SshNet/Renci.SshNet.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>Renci.SshNet</AssemblyName>
     <Product>SSH.NET</Product>
     <AssemblyTitle>SSH.NET</AssemblyTitle>
-    <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;net10.0;net11.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -36,7 +36,7 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')) ">
+  <PropertyGroup Condition=" $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0')) ">
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 

--- a/src/Renci.SshNet/ScpClient.cs
+++ b/src/Renci.SshNet/ScpClient.cs
@@ -68,18 +68,14 @@ namespace Renci.SshNet
         private const string TimestampPattern = @"T(?<mtime>\d+) 0 (?<atime>\d+) 0";
 
 #if NET
-        private static readonly Regex FileInfoRegex = GetFileInfoRegex();
-        private static readonly Regex DirectoryInfoRegex = GetDirectoryInfoRegex();
-        private static readonly Regex TimestampRegex = GetTimestampRegex();
-
         [GeneratedRegex(FileInfoPattern)]
-        private static partial Regex GetFileInfoRegex();
+        private static partial Regex FileInfoRegex { get; }
 
         [GeneratedRegex(DirectoryInfoPattern)]
-        private static partial Regex GetDirectoryInfoRegex();
+        private static partial Regex DirectoryInfoRegex { get; }
 
         [GeneratedRegex(TimestampPattern)]
-        private static partial Regex GetTimestampRegex();
+        private static partial Regex TimestampRegex { get; }
 #else
         private static readonly Regex FileInfoRegex = new Regex(FileInfoPattern, RegexOptions.Compiled);
         private static readonly Regex DirectoryInfoRegex = new Regex(DirectoryInfoPattern, RegexOptions.Compiled);

--- a/src/Renci.SshNet/SshMessageFactory.cs
+++ b/src/Renci.SshNet/SshMessageFactory.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 
-#if NET9_0_OR_GREATER
+#if NET
 using System.Threading;
 #endif
 

--- a/test/Renci.SshNet.AotCompatibilityTestApp/Renci.SshNet.AotCompatibilityTestApp.csproj
+++ b/test/Renci.SshNet.AotCompatibilityTestApp/Renci.SshNet.AotCompatibilityTestApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
     <PublishAot>true</PublishAot>
     <SelfContained>true</SelfContained>
     <TrimmerSingleWarn>false</TrimmerSingleWarn>

--- a/test/Renci.SshNet.Benchmarks/Renci.SshNet.Benchmarks.csproj
+++ b/test/Renci.SshNet.Benchmarks/Renci.SshNet.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/test/Renci.SshNet.IntegrationBenchmarks/Renci.SshNet.IntegrationBenchmarks.csproj
+++ b/test/Renci.SshNet.IntegrationBenchmarks/Renci.SshNet.IntegrationBenchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/test/Renci.SshNet.IntegrationTests/Renci.SshNet.IntegrationTests.csproj
+++ b/test/Renci.SshNet.IntegrationTests/Renci.SshNet.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsTestProject>true</IsTestProject>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>

--- a/test/Renci.SshNet.IntegrationTests/Renci.SshNet.IntegrationTests.csproj
+++ b/test/Renci.SshNet.IntegrationTests/Renci.SshNet.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
+    <TargetFrameworks>net48;net10.0;net11.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsTestProject>true</IsTestProject>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>

--- a/test/Renci.SshNet.Tests/Common/PacketDump.cs
+++ b/test/Renci.SshNet.Tests/Common/PacketDump.cs
@@ -70,7 +70,7 @@ namespace Renci.SshNet.Tests.Common
 
             if (length < data.Length)
             {
-                _ = hex.Append(new string(' ', (data.Length - length) * 3));
+                _ = hex.Append(' ', (data.Length - length) * 3);
             }
 
             return hex.ToString();

--- a/test/Renci.SshNet.Tests/Renci.SshNet.Tests.csproj
+++ b/test/Renci.SshNet.Tests/Renci.SshNet.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
+    <TargetFrameworks>net462;net10.0;net11.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Renci.SshNet.Tests/Renci.SshNet.Tests.csproj
+++ b/test/Renci.SshNet.Tests/Renci.SshNet.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This adds a net11.0 target and drops net8.0 and net9.0 as they will be EOL when .NET 11 releases.

Notes:
 - Coverlet doesn't work with .NET Framework. It seems like Coverlet would need to add a net11.0 target first, see also https://github.com/coverlet-coverage/coverlet/issues/1818 .I removed it for now. Not sure if this is worth dealing with?
 - Removed Microsoft.Extensions.Logging.Abstractions from net11.0 because it is part of the runtime now (see https://learn.microsoft.com/en-us/dotnet/core/compatibility/extensions/11/extensions-in-shared-framework )
 - TODO: use stable SDK in global.json

I could split dropping net8.0 and net9.0 into a separate PR if you want.